### PR TITLE
BC: Fixed navigation menu when 'Dropdown type is set to 'None'.

### DIFF
--- a/components/00-base/_variables.components.scss
+++ b/components/00-base/_variables.components.scss
@@ -965,6 +965,18 @@ $ct-navigation-drawer-top-offset: ct-spacing(2) !default;
 $ct-navigation-drawer-column-gutter: ct-spacing(4) !default;
 
 // Colors.
+$ct-navigation-light-menu-border-color: ct-color-light('interaction-background') !default;
+$ct-navigation-light-menu-color: ct-color-light('interaction-background') !default;
+$ct-navigation-light-menu-hover-color: ct-color-light('interaction-hover-background') !default;
+$ct-navigation-light-menu-active-color: ct-color-light('interaction-hover-background') !default;
+$ct-navigation-light-menu-item-background-color: transparent !default;
+$ct-navigation-light-menu-item-border-color: transparent !default;
+$ct-navigation-light-menu-item-hover-background-color: transparent !default;
+$ct-navigation-light-menu-item-hover-border-color: ct-color-light('interaction-hover-background') !default;
+$ct-navigation-light-menu-item-active-background-color: transparent !default;
+$ct-navigation-light-menu-item-active-border-color: ct-color-light('highlight') !default;
+$ct-navigation-light-menu-item-active-trail-background-color: ct-color-light('interaction-background') !default;
+$ct-navigation-light-menu-item-active-trail-color: ct-color-light('background') !default;
 $ct-navigation-light-drawer-border-color: ct-color-light('interaction-background') !default;
 $ct-navigation-light-drawer-color: ct-color-light('interaction-background') !default;
 $ct-navigation-light-drawer-hover-color: ct-color-light('interaction-hover-background') !default;
@@ -987,6 +999,18 @@ $ct-navigation-light-drawer-sub-menu-item-hover-background-color: ct-color-light
 $ct-navigation-light-drawer-sub-menu-item-hover-color: ct-color-light('interaction-hover-text') !default;
 $ct-navigation-light-drawer-sub-menu-item-active-background-color: ct-color-light('body') !default;
 $ct-navigation-light-drawer-sub-menu-item-active-color: ct-color-light('background') !default;
+$ct-navigation-dark-menu-border-color: ct-color-dark('interaction-background') !default;
+$ct-navigation-dark-menu-color: ct-color-dark('interaction-background') !default;
+$ct-navigation-dark-menu-hover-color: ct-color-dark('interaction-hover-background') !default;
+$ct-navigation-dark-menu-active-color: ct-color-dark('interaction-hover-background') !default;
+$ct-navigation-dark-menu-item-background-color: transparent !default;
+$ct-navigation-dark-menu-item-border-color: transparent !default;
+$ct-navigation-dark-menu-item-hover-background-color: transparent !default;
+$ct-navigation-dark-menu-item-hover-border-color: ct-color-dark('interaction-hover-background') !default;
+$ct-navigation-dark-menu-item-active-background-color: transparent !default;
+$ct-navigation-dark-menu-item-active-border-color: ct-color-dark('highlight') !default;
+$ct-navigation-dark-menu-item-active-trail-background-color: ct-color-dark('interaction-background') !default;
+$ct-navigation-dark-menu-item-active-trail-color: ct-color-dark('background') !default;
 $ct-navigation-dark-drawer-border-color: ct-color-dark('interaction-background') !default;
 $ct-navigation-dark-drawer-color: ct-color-dark('interaction-background') !default;
 $ct-navigation-dark-drawer-hover-color: ct-color-dark('interaction-hover-background') !default;

--- a/components/03-organisms/navigation/navigation.scss
+++ b/components/03-organisms/navigation/navigation.scss
@@ -18,6 +18,14 @@
 
   &#{$root}--none {
     #{$root}__items {
+      display: none;
+      align-items: center;
+      height: 100%;
+
+      @include ct-breakpoint($ct-navigation-breakpoint) {
+        display: flex;
+      }
+
       #{$root}__menu {
         &.ct-menu,
         .ct-menu {
@@ -28,17 +36,70 @@
           margin: 0;
         }
 
-        .ct-menu__sub-menu {
-          margin-top: ct-spacing(2);
+        // First-level items to be displayed inline.
+        &.ct-menu--level-0 {
+          display: flex;
         }
 
         .ct-menu__item {
-          margin-bottom: ct-spacing(2);
-          margin-left: ct-spacing(2);
-        }
+          // Links - level 0.
+          &--level-0 {
+            border-bottom: solid ct-particle(0.5);
 
-        &.ct-menu > .ct-menu__item {
-          margin-left: 0;
+            > .ct-link {
+              display: block;
+              padding: ct-spacing(2);
+              text-align: center;
+
+              &::after {
+                right: ct-spacing();
+                margin-top: -1 * ct-particle(0.25);
+                top: ct-spacing(2);
+              }
+            }
+          }
+        }
+      }
+    }
+
+    @include ct-component-theme($root) using($root, $theme) {
+      #{$root}__items {
+        .ct-menu__item {
+          // Links - level 0.
+          &--level-0 {
+            border-bottom-color: ct-component-var($root, $theme, menu-item, border-color);
+
+            &:hover {
+              @include ct-component-property($root, $theme, menu-item, hover, background-color);
+
+              border-bottom-color: ct-component-var($root, $theme, menu-item, hover, border-color);
+            }
+
+            &:active {
+              @include ct-component-property($root, $theme, menu-item, active, background-color);
+
+              border-bottom-color: ct-component-var($root, $theme, menu-item, active, border-color);
+            }
+
+            &.ct-menu__item--active-trail {
+              border-bottom-color: ct-component-var($root, $theme, menu, border-color);
+            }
+
+            > .ct-link {
+              @include ct-component-property($root, $theme, menu-item, background-color);
+              @include ct-component-property($root, $theme, menu, color);
+
+              &:hover {
+                @include ct-component-property($root, $theme, menu-item, hover, background-color);
+                @include ct-component-property($root, $theme, menu, hover, color);
+              }
+
+              &:active {
+                @include ct-component-property($root, $theme, menu-item, active, background-color);
+                @include ct-component-property($root, $theme, menu, active, color);
+              }
+            }
+          }
         }
       }
     }

--- a/components/03-organisms/navigation/navigation.twig
+++ b/components/03-organisms/navigation/navigation.twig
@@ -46,6 +46,13 @@
         {% endif %}
       {% endif %}
     {% endfor %}
+  {% else %}
+    {% for key in items|keys %}
+      {% if items[key].below %}
+          {% set items_without_below = items[key]|merge({ 'below': null }) %}
+          {% set items = items|merge({(key): items_without_below}) %}
+      {% endif %}
+    {% endfor %}
   {% endif %}
 
   <div class="ct-navigation {{ modifier_class }}" {% if attributes is not empty %}{{ attributes|raw }}{% endif %}>


### PR DESCRIPTION
https://www.drupal.org/project/civictheme/issues/3422805

## Checklist before requesting a review

- [x] I have formatted the subject to include the issue number
  as `[#123] Verb in past tense with a period at the end.`
- [x] I have provided information in the `Changed` section about WHY something was
  done if this was a bespoke implementation.
- [x] I have performed a self-review of my code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have run new and existing relevant tests locally with my changes,
  and they have passed.
- [x] I have provided screenshots, where applicable.

## Changed

1. Updated navigation to remove child items when dropdown is set to none.
2. Added missing styles for navigation when when dropdown is set to none.

## Screenshots
Before: 
<img width="1062" alt="Screenshot 2024-03-06 at 11 53 12 AM" src="https://github.com/civictheme/uikit/assets/83997348/1afd0f81-7f35-4be9-a33d-9acc0a0d14a2">

After: 
![Screenshot 2024-03-06 at 11 54 43 AM](https://github.com/civictheme/uikit/assets/83997348/541c625e-2dcf-45d4-802c-a0a9c95ec645)

