### PR TITLE
Fixed background not applying to navigation of type 'dropdown'.

### DIFF
--- a/components/03-organisms/navigation/navigation.scss
+++ b/components/03-organisms/navigation/navigation.scss
@@ -501,7 +501,7 @@
           }
 
           .ct-menu__sub-menu__wrapper--level-1 {
-            @include ct-component-property($root, dropdown-sub-menu, background-color);
+            @include ct-component-property($root, $theme, dropdown-sub-menu, background-color);
           }
         }
       }


### PR DESCRIPTION
## Checklist before requesting a review

- [ ] I have formatted the subject to include the issue number
  as `[#123] Verb in past tense with a period at the end.`
- [x] I have provided information in the `Changed` section about WHY something was
  done if this was a bespoke implementation.
- [x] I have performed a self-review of my code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have run new and existing relevant tests locally with my changes,
  and they have passed.
- [ ] I have provided screenshots, where applicable.

## Changed

1. Fixed background not applying to navigation of type 'dropdown'.

## Screenshots

<img width="800" alt="Window_and_Organisms___Header_-_Header_⋅_Storybook" src="https://github.com/civictheme/uikit/assets/378794/3e3e48cb-31f4-44a5-85c0-246c352a242e">

