### PR TITLE
[96] Regression fix for footer for Fixed navigation menu when 'Dropdown type is set to 'None'.

### DIFF
--- a/components/03-organisms/footer/footer.scss
+++ b/components/03-organisms/footer/footer.scss
@@ -77,6 +77,14 @@
     @include ct-breakpoint-upto(m) {
       margin-bottom: ct-spacing(3);
     }
+
+    &.ct-navigation--none {
+      .ct-navigation__items {
+        .ct-navigation__menu.ct-menu--level-0 {
+          display: block;
+        }
+      }
+    }
   }
 
   [data-collapsible='true'] {


### PR DESCRIPTION
Regression fix: https://github.com/civictheme/uikit/pull/94

## Checklist before requesting a review

- [ ] I have formatted the subject to include the issue number
  as `[#123] Verb in past tense with a period at the end.`
- [ ] I have provided information in the `Changed` section about WHY something was
  done if this was a bespoke implementation.
- [ ] I have performed a self-review of my code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have run new and existing relevant tests locally with my changes,
  and they have passed.
- [ ] I have provided screenshots, where applicable.

## Changed

1.

## Screenshots
<img width="1279" alt="Screenshot 2024-03-15 at 9 57 30 AM" src="https://github.com/civictheme/uikit/assets/83997348/7d98668d-4696-453a-a1f4-ada07bd1516d">
<img width="1185" alt="Screenshot 2024-03-15 at 9 58 07 AM" src="https://github.com/civictheme/uikit/assets/83997348/8143d502-fd8f-4b8c-8928-619d18315948">
