### PR TITLE
[#78] Fixed Single and Group filter announcing changes to content and a "down" key trigger for collapsible.

### DIFF
--- a/components/00-base/collapsible/collapsible.js
+++ b/components/00-base/collapsible/collapsible.js
@@ -255,7 +255,7 @@ CivicThemeCollapsible.prototype.collapse = function (animate, evt) {
   }
 
   if (evt && evt.target) {
-    if (evt.detail.keydown && !evt.detail.closeGroup) {
+    if (evt.detail && evt.detail.keydown && !evt.detail.closeGroup) {
       if (evt.target.closest('[data-collapsible="true"]') !== t.el) {
         return;
       }

--- a/components/01-atoms/button/button.js
+++ b/components/01-atoms/button/button.js
@@ -53,7 +53,7 @@ CivicThemeButton.prototype.clickEvent = function (e) {
  * Keydown event handler.
  */
 CivicThemeButton.prototype.keydownEvent = function (e) {
-  if (e.key === 'Tab' || e.key.indexOf('Arrow') === 0) {
+  if (e.key && (e.key === 'Tab' || e.key.indexOf('Arrow') === 0)) {
     this.keyboardFocused = true;
   }
 };

--- a/components/01-atoms/popover/popover.twig
+++ b/components/01-atoms/popover/popover.twig
@@ -28,7 +28,7 @@
       url: trigger.url is defined ? trigger.url : null,
       is_new_window: trigger.is_new_window,
       modifier_class: 'ct-popover__link',
-      attributes: 'data-collapsible-trigger',
+      attributes: 'data-collapsible-trigger tabindex="0"',
     } only %}
 
     <div class="ct-popover__content" data-collapsible-panel>

--- a/components/02-molecules/group-filter/group-filter.js
+++ b/components/02-molecules/group-filter/group-filter.js
@@ -3,6 +3,16 @@
  * Group Filter component.
  */
 function CivicThemeGroupFilterComponent(el) {
+  if (this.el) {
+    return;
+  }
+
+  this.el = el;
+
+  this.el.addEventListener('ct.group-filter.update', () => {
+    this.update(true);
+  });
+
   // Function to trigger custom event
   const triggerFilterUpdateEvent = function () {
     el.dispatchEvent(new CustomEvent('ct.group-filter.update'));
@@ -11,7 +21,7 @@ function CivicThemeGroupFilterComponent(el) {
   // Function to bind event listeners
   const bindEventListeners = function () {
     // Add event listener for filter change
-    el.querySelectorAll('input').forEach((input) => {
+    el.querySelectorAll('input, textarea, select, [type="checkbox"], [type="radio"]').forEach((input) => {
       input.addEventListener('change', triggerFilterUpdateEvent);
     });
   };
@@ -24,10 +34,11 @@ function CivicThemeGroupFilterComponent(el) {
  * Update the instance.
  */
 CivicThemeGroupFilterComponent.prototype.update = function () {
-  // TODO
+  const t = this;
+  t.el.setAttribute('aria-live', 'polite');
 };
 
 // Find group Filter components and initialize
-document.querySelectorAll('[data-component-name="ct-group-filter"]').forEach((el) => {
+document.querySelectorAll('[data-ct-group-filter-filters]').forEach((el) => {
   new CivicThemeGroupFilterComponent(el);
 });

--- a/components/02-molecules/group-filter/group-filter.js
+++ b/components/02-molecules/group-filter/group-filter.js
@@ -9,36 +9,25 @@ function CivicThemeGroupFilterComponent(el) {
 
   this.el = el;
 
-  this.el.addEventListener('ct.group-filter.update', () => {
-    this.update(true);
-  });
+  this.el.addEventListener('ct.group-filter.update', this.update.bind(this));
 
-  // Function to trigger custom event
-  const triggerFilterUpdateEvent = function () {
-    el.dispatchEvent(new CustomEvent('ct.group-filter.update'));
-  };
-
-  // Function to bind event listeners
-  const bindEventListeners = function () {
-    // Add event listener for filter change
+  if (!el.hasEventListener) {
+    el.hasEventListener = true;
     el.querySelectorAll('input, textarea, select, [type="checkbox"], [type="radio"]').forEach((input) => {
-      input.addEventListener('change', triggerFilterUpdateEvent);
+      input.addEventListener('change', () => {
+        el.dispatchEvent(new CustomEvent('ct.group-filter.update', { detail: { parent: input.parentElement } }));
+      });
     });
-  };
-
-  // Bind event listeners
-  bindEventListeners();
+  }
 }
 
 /**
  * Update the instance.
  */
-CivicThemeGroupFilterComponent.prototype.update = function () {
-  const t = this;
-  t.el.setAttribute('aria-live', 'polite');
+CivicThemeGroupFilterComponent.prototype.update = function (el) {
+  el.detail.parent.setAttribute('aria-live', 'polite');
 };
 
-// Find group Filter components and initialize
 document.querySelectorAll('[data-ct-group-filter-filters]').forEach((el) => {
   new CivicThemeGroupFilterComponent(el);
 });

--- a/components/02-molecules/group-filter/group-filter.js
+++ b/components/02-molecules/group-filter/group-filter.js
@@ -1,0 +1,33 @@
+/**
+ * @file
+ * Group Filter component.
+ */
+function CivicThemeGroupFilterComponent(el) {
+  // Function to trigger custom event
+  const triggerFilterUpdateEvent = function () {
+    el.dispatchEvent(new CustomEvent('ct.group-filter.update'));
+  };
+
+  // Function to bind event listeners
+  const bindEventListeners = function () {
+    // Add event listener for filter change
+    el.querySelectorAll('input').forEach((input) => {
+      input.addEventListener('change', triggerFilterUpdateEvent);
+    });
+  };
+
+  // Bind event listeners
+  bindEventListeners();
+}
+
+/**
+ * Update the instance.
+ */
+CivicThemeGroupFilterComponent.prototype.update = function () {
+  // TODO
+};
+
+// Find group Filter components and initialize
+document.querySelectorAll('[data-component-name="ct-group-filter"]').forEach((el) => {
+  new CivicThemeGroupFilterComponent(el);
+});

--- a/components/02-molecules/group-filter/group-filter.stories.js
+++ b/components/02-molecules/group-filter/group-filter.stories.js
@@ -7,6 +7,7 @@ import {
 } from '../../00-base/base.utils';
 
 import CivicThemeGroupFilter from './group-filter.twig';
+import './group-filter';
 
 export default {
   title: 'Molecules/Group Filter',

--- a/components/02-molecules/single-filter/single-filter.js
+++ b/components/02-molecules/single-filter/single-filter.js
@@ -1,0 +1,33 @@
+/**
+ * @file
+ * Single Filter component.
+ */
+function CivicThemeSingleFilterComponent(el) {
+  // Function to trigger custom event
+  const triggerFilterUpdateEvent = function () {
+    el.dispatchEvent(new CustomEvent('ct.single-filter.update'));
+  };
+
+  // Function to bind event listeners
+  const bindEventListeners = function () {
+    // Add event listener for filter change
+    el.querySelectorAll('input').forEach((input) => {
+      input.addEventListener('change', triggerFilterUpdateEvent);
+    });
+  };
+
+  // Bind event listeners
+  bindEventListeners();
+}
+
+/**
+ * Update the instance.
+ */
+CivicThemeSingleFilterComponent.prototype.update = function () {
+  // TODO
+};
+
+// Find Single Filter components and initialize
+document.querySelectorAll('[data-component-name="ct-single-filter"]').forEach((el) => {
+  new CivicThemeSingleFilterComponent(el);
+});

--- a/components/02-molecules/single-filter/single-filter.js
+++ b/components/02-molecules/single-filter/single-filter.js
@@ -9,36 +9,25 @@ function CivicThemeSingleFilterComponent(el) {
 
   this.el = el;
 
-  this.el.addEventListener('ct.single-filter.update', () => {
-    this.update(true);
-  });
+  this.el.addEventListener('ct.single-filter.update', this.update.bind(this));
 
-  // Function to trigger custom event
-  const triggerFilterUpdateEvent = function () {
-    el.dispatchEvent(new CustomEvent('ct.single-filter.update'));
-  };
-
-  // Function to bind event listeners
-  const bindEventListeners = function () {
-    // Add event listener for filter change
+  if (!el.hasEventListener) {
+    el.hasEventListener = true;
     el.querySelectorAll('input, textarea, select, [type="checkbox"], [type="radio"]').forEach((input) => {
-      input.addEventListener('change', triggerFilterUpdateEvent);
+      input.addEventListener('change', () => {
+        el.dispatchEvent(new CustomEvent('ct.single-filter.update', { detail: { parent: input.parentElement } }));
+      });
     });
-  };
-
-  // Bind event listeners
-  bindEventListeners();
+  }
 }
 
 /**
  * Update the instance.
  */
-CivicThemeSingleFilterComponent.prototype.update = function () {
-  const t = this;
-  t.el.setAttribute('aria-live', 'polite');
+CivicThemeSingleFilterComponent.prototype.update = function (el) {
+  el.detail.parent.setAttribute('aria-live', 'polite');
 };
 
-// Find Single Filter components and initialize
-document.querySelectorAll('[data-ct-single-filter-filters]').forEach((el) => {
+document.querySelectorAll('.ct-single-filter__list').forEach((el) => {
   new CivicThemeSingleFilterComponent(el);
 });

--- a/components/02-molecules/single-filter/single-filter.js
+++ b/components/02-molecules/single-filter/single-filter.js
@@ -3,6 +3,16 @@
  * Single Filter component.
  */
 function CivicThemeSingleFilterComponent(el) {
+  if (this.el) {
+    return;
+  }
+
+  this.el = el;
+
+  this.el.addEventListener('ct.single-filter.update', () => {
+    this.update(true);
+  });
+
   // Function to trigger custom event
   const triggerFilterUpdateEvent = function () {
     el.dispatchEvent(new CustomEvent('ct.single-filter.update'));
@@ -11,7 +21,7 @@ function CivicThemeSingleFilterComponent(el) {
   // Function to bind event listeners
   const bindEventListeners = function () {
     // Add event listener for filter change
-    el.querySelectorAll('input').forEach((input) => {
+    el.querySelectorAll('input, textarea, select, [type="checkbox"], [type="radio"]').forEach((input) => {
       input.addEventListener('change', triggerFilterUpdateEvent);
     });
   };
@@ -24,10 +34,11 @@ function CivicThemeSingleFilterComponent(el) {
  * Update the instance.
  */
 CivicThemeSingleFilterComponent.prototype.update = function () {
-  // TODO
+  const t = this;
+  t.el.setAttribute('aria-live', 'polite');
 };
 
 // Find Single Filter components and initialize
-document.querySelectorAll('[data-component-name="ct-single-filter"]').forEach((el) => {
+document.querySelectorAll('[data-ct-single-filter-filters]').forEach((el) => {
   new CivicThemeSingleFilterComponent(el);
 });

--- a/components/02-molecules/single-filter/single-filter.stories.js
+++ b/components/02-molecules/single-filter/single-filter.stories.js
@@ -3,6 +3,7 @@ import {
 } from '@storybook/addon-knobs';
 
 import CivicThemeSingleFilter from './single-filter.twig';
+import './single-filter';
 import {
   getSlots, randomName, randomString,
 } from '../../00-base/base.utils';


### PR DESCRIPTION
Closes https://github.com/civictheme/uikit/issues/78 

## Checklist before requesting a review

- [x] I have formatted the subject to include the issue number
  as `[#123] Verb in past tense with a period at the end.`
- [x] I have provided information in the `Changed` section about WHY something was
  done if this was a bespoke implementation.
- [ ] I have performed a self-review of my code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have run new and existing relevant tests locally with my changes,
  and they have passed.
- [ ] I have provided screenshots, where applicable.

## Changed

1. [x] Fixed: The filters and options are read by a screenreader left to right, top to bottom (e.g. first row left to right and then second row left to right).
2. [x] Fixed: The focus is visible on each select box in drop down when navigating using a mouse or keyboard.
3. [x] Fixed: The user can tab to each interactive element and interact with the filter using keyboard or mouse.
4. [x] Fixed: If the contents underneath the filter change when an option is selected, the change should be announced using aria-live=”polite” - FAIL.

## Screenshots
