### PR TITLE
[#156] Updated Campaign to use square image within a container of equal widths.

### DIFF
--- a/components/00-base/_variables.components.scss
+++ b/components/00-base/_variables.components.scss
@@ -533,7 +533,6 @@ $ct-campaign-image-border-radius: $ct-border-radius !default;
 $ct-campaign-image-shadow-offset-x: ct-particle(2) !default;
 $ct-campaign-image-shadow-offset-y: ct-particle(2) !default;
 $ct-campaign-mobile-height: ct-particle(30) !default;
-$ct-campaign-desktop-height: ct-particle(65) !default;
 $ct-campaign-light-background-color: ct-color-light('background-light') !default;
 $ct-campaign-light-image-shadow-color: ct-color-light('background') !default;
 $ct-campaign-dark-background-color: ct-color-dark('background') !default;

--- a/components/00-base/mixins/_image.scss
+++ b/components/00-base/mixins/_image.scss
@@ -21,6 +21,23 @@
 }
 
 //
+// Fit image into a square container.
+//
+@mixin ct-image-container-square() {
+  @include ct-image-fit();
+
+  position: relative;
+  width: 100%;
+  padding-top: 100%;
+
+  img {
+    position: absolute;
+    top: 0;
+    left: 0;
+  }
+}
+
+//
 // Drop shadow for image.
 //
 @mixin ct-image-shadow($color, $up: true, $offset-x: ct-particle(2), $offset-y: ct-particle(2)) {

--- a/components/03-organisms/campaign/campaign.scss
+++ b/components/03-organisms/campaign/campaign.scss
@@ -14,18 +14,6 @@
     }
   }
 
-  #{$root}__inner-wrapper {
-    flex-grow: 1;
-    display: flex;
-    align-items: center;
-    margin-bottom: ct-spacing(3);
-
-    @include ct-breakpoint(m) {
-      margin-left: ct-spacing(12);
-      margin-bottom: ct-spacing(4);
-    }
-  }
-
   &#{$root}--image-right {
     #{$root}__wrapper {
       @include ct-breakpoint(m) {
@@ -34,24 +22,40 @@
     }
   }
 
-  #{$root}__image {
-    width: 100%;
-    overflow: hidden;
-    flex-shrink: 0;
-    height: $ct-campaign-mobile-height;
+  #{$root}__image-wrapper {
+    flex: 1;
     margin-bottom: ct-spacing(3);
-    border-radius: $ct-campaign-image-border-radius;
-
-    @include ct-elevation(1);
 
     @include ct-breakpoint(m) {
-      height: $ct-campaign-desktop-height;
-      width: $ct-campaign-desktop-height * 1.08;
-      margin-left: ct-spacing(12);
+      margin-left: ct-spacing(6);
+      margin-right: ct-spacing(6);
       margin-bottom: ct-spacing(2);
     }
+  }
 
+  #{$root}__image {
     @include ct-image-fit();
+
+    height: $ct-campaign-mobile-height;
+
+    img {
+      border-radius: $ct-campaign-image-border-radius;
+    }
+
+    @include ct-breakpoint(m) {
+      @include ct-image-container-square();
+    }
+  }
+
+  #{$root}__inner-wrapper {
+    flex: 1;
+    margin-bottom: ct-spacing(3);
+
+    @include ct-breakpoint(m) {
+      margin-left: ct-spacing(6);
+      margin-right: ct-spacing(6);
+      margin-bottom: ct-spacing(4);
+    }
   }
 
   #{$root}__tags {

--- a/components/03-organisms/campaign/campaign.stories.js
+++ b/components/03-organisms/campaign/campaign.stories.js
@@ -70,7 +70,7 @@ export const Campaign = (props = {}) => {
         Bottom: 'bottom',
         Both: 'both',
       },
-      'none',
+      'both',
       props.vertical_spacing,
       props.knobTab,
     ),

--- a/components/03-organisms/campaign/campaign.twig
+++ b/components/03-organisms/campaign/campaign.twig
@@ -38,12 +38,14 @@
         <div class="ct-campaign__wrapper">
           {% block image %}
             {% if image is not empty %}
-              <div class="ct-campaign__image">
-                {% include '@atoms/image/image.twig' with {
-                  theme: theme,
-                  url: image.url,
-                  alt: image.alt,
-                } only %}
+              <div class="ct-campaign__image-wrapper">
+                <div class="ct-campaign__image">
+                  {% include '@atoms/image/image.twig' with {
+                    theme: theme,
+                    url: image.url,
+                    alt: image.alt,
+                  } only %}
+                </div>
               </div>
             {% endif %}
           {% endblock %}


### PR DESCRIPTION
Closes #156 

<img width="185" alt="organisms-campaign--campaign-4" src="https://github.com/civictheme/uikit/assets/378794/199f200b-959a-4642-b3f2-36877b1f01f1">

---

<img width="325" alt="organisms-campaign--campaign-3" src="https://github.com/civictheme/uikit/assets/378794/eccc17ad-6cdc-4061-87ae-4ced9db206da">

---

<img width="502" alt="organisms-campaign--campaign-2" src="https://github.com/civictheme/uikit/assets/378794/5e9af169-e4e0-4acc-8e6a-7d1072c97a90">

---

<img width="737" alt="organisms-campaign--campaign" src="https://github.com/civictheme/uikit/assets/378794/54d471ed-337f-4219-9f1b-9f5eecc0324a">

