### PR TITLE
[#172] Fixed Icon colour on Navigation card.

### DIFF
--- a/components/00-base/_variables.components.scss
+++ b/components/00-base/_variables.components.scss
@@ -561,7 +561,9 @@ $ct-navigation-card-image-width-mobile: auto !default;
 $ct-navigation-card-image-height-desktop: ct-particle(32) !default;
 $ct-navigation-card-image-width-desktop: ct-particle(36) !default;
 $ct-navigation-card-light-background-color: ct-color-light('background-light') !default;
+$ct-navigation-card-light-icon-color: $ct-link-light-color !default;
 $ct-navigation-card-dark-background-color: ct-color-dark('background') !default;
+$ct-navigation-card-dark-icon-color: $ct-link-dark-color !default;
 
 //
 // Cards/Promo card.

--- a/components/02-molecules/navigation-card/navigation-card.scss
+++ b/components/02-molecules/navigation-card/navigation-card.scss
@@ -45,6 +45,7 @@
 
   #{$root}__icon {
     margin-bottom: ct-spacing(2);
+    color: inherit;
   }
 
   #{$root}__icon__image {
@@ -68,5 +69,6 @@
 
   @include ct-component-theme($root) using($root, $theme) {
     @include ct-component-property($root, $theme, background-color);
+    @include ct-component-property($root, $theme, icon, color);
   }
 }

--- a/components/02-molecules/navigation-card/navigation-card.stories.js
+++ b/components/02-molecules/navigation-card/navigation-card.stories.js
@@ -22,15 +22,15 @@ export const NavigationCard = (props = {}) => {
     ),
     title: knobText('Title', 'Navigation card heading which runs across two or three lines', props.navigation_card_title, props.knobTab),
     summary: knobText('Summary', 'Bring to the table win-win survival strategies to ensure proactive domination. At the end of the day, going forward, a new normal that has evolved from generation X is on the runway heading towards a streamlined cloud solution. User generated content in real-time will have multiple touchpoints for offshoring.', props.summary, props.knobTab),
-    link: {
+    link: knobBoolean('With link', true, props.with_link, props.knobTab) ? {
       url: knobText('Link URL', randomUrl(), props.link_url, props.knobTab),
       is_external: knobBoolean('Link is external', false, props.link_is_external, props.knobTab),
       is_new_window: knobBoolean('Open in a new window', false, props.link_is_new_window, props.knobTab),
-    },
+    } : null,
     image: knobBoolean('With image', true, props.with_image, props.knobTab) ? {
       url: generateImage(),
       alt: 'Image alt text',
-    } : false,
+    } : null,
     image_as_icon: knobBoolean('Image as icon', false, props.image_as_icon, props.knobTab),
     modifier_class: `story-wrapper-size--medium ${knobText('Additional class', '', props.modifier_class, props.knobTab)}`,
     attributes: knobText('Additional attributes', '', props.attributes, props.knobTab),


### PR DESCRIPTION
Closes #172 

**With link**
<img width="595" alt="Molecules___Navigation_Card_-_Navigation_Card_⋅_Storybook" src="https://github.com/civictheme/uikit/assets/378794/524fef5b-8d49-43bd-9510-0ac96e113da7">

**Without link - colour remains**
<img width="612" alt="Cursor_and_Molecules___Navigation_Card_-_Navigation_Card_⋅_Storybook" src="https://github.com/civictheme/uikit/assets/378794/4b38b9d4-8991-4722-954b-5a0d415164da">
