### PR TITLE
[#201] Fixed Left stripe missing for child active items for both themes for side navigation component.

### DIFF
--- a/components/00-base/_variables.components.scss
+++ b/components/00-base/_variables.components.scss
@@ -1219,7 +1219,7 @@ $ct-side-navigation-light-link-child-hover-stripe-background-color: ct-color-lig
 $ct-side-navigation-light-link-child-active-background-color: ct-color-light('background') !default;
 $ct-side-navigation-light-link-child-active-border-color: $ct-side-navigation-light-link-child-border-color !default;
 $ct-side-navigation-light-link-child-active-color: $ct-side-navigation-light-link-child-color !default;
-$ct-side-navigation-light-link-child-active-stripe-background-color: $ct-side-navigation-light-link-child-stripe-background-color !default;
+$ct-side-navigation-light-link-child-active-stripe-background-color: $ct-side-navigation-light-link-child-hover-stripe-background-color !default;
 $ct-side-navigation-dark-title-color: ct-color-dark('heading') !default;
 $ct-side-navigation-dark-link-expanded-icon-color: ct-color-dark('heading') !default;
 $ct-side-navigation-dark-link-parent-background-color: ct-color-dark('background-light') !default;
@@ -1245,7 +1245,7 @@ $ct-side-navigation-dark-link-child-hover-stripe-background-color: ct-color-dark
 $ct-side-navigation-dark-link-child-active-background-color: ct-color-dark('background') !default;
 $ct-side-navigation-dark-link-child-active-border-color: $ct-side-navigation-dark-link-child-border-color !default;
 $ct-side-navigation-dark-link-child-active-color: $ct-side-navigation-dark-link-child-color !default;
-$ct-side-navigation-dark-link-child-active-stripe-background-color: $ct-side-navigation-dark-link-child-stripe-background-color !default;
+$ct-side-navigation-dark-link-child-active-stripe-background-color: $ct-side-navigation-dark-link-child-hover-stripe-background-color !default;
 
 //
 // Mobile navigation.


### PR DESCRIPTION
Closes https://github.com/civictheme/uikit/issues/201#issuecomment-2166229011

## Checklist before requesting a review

- [x] I have formatted the subject to include the issue number
  as `[#123] Verb in past tense with a period at the end.`
- [x] I have provided information in the `Changed` section about WHY something was
  done if this was a bespoke implementation.
- [ ] I have performed a self-review of my code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have run new and existing relevant tests locally with my changes,
  and they have passed.
- [x] I have provided screenshots, where applicable.

## Changed

1. Fixed Left stripe missing for child active items for both themes for side navigation component.

## Screenshots
![Screenshot 2024-06-14 at 7 09 43 AM](https://github.com/civictheme/uikit/assets/83997348/ed81b794-34cf-43cf-8599-e120fe50cc21)
![Screenshot 2024-06-14 at 7 10 18 AM](https://github.com/civictheme/uikit/assets/83997348/748de722-e5e4-4f59-baf7-d81435b29442)
