### PR TITLE
Fixed label background flickering when tapped on mobile webkit-based browsers.

### DIFF
--- a/components/01-atoms/label/label.scss
+++ b/components/01-atoms/label/label.scss
@@ -10,6 +10,7 @@
 
   display: block;
   margin-bottom: ct-spacing();
+  -webkit-tap-highlight-color: transparent;
 
   @include ct-typography('label-regular');
 


### PR DESCRIPTION
The problem:


https://github.com/civictheme/uikit/assets/378794/975e7f9e-2b49-4886-ac92-e9c795647502



