### PR TITLE
Fixed column gaps to be larger when only a single sidebar is present.

### DIFF
--- a/components/00-base/layout/layout.scss
+++ b/components/00-base/layout/layout.scss
@@ -44,7 +44,7 @@
     --sbl: 4;
     --sbr: 5;
 
-    #{$root}--no-top-left > #{$root}__inner > & {
+    #{$root}--no-top-left > & {
       --stl: 0;
       --str: 1;
       --m: 2;
@@ -52,7 +52,7 @@
       --sbr: 4;
     }
 
-    #{$root}--no-top-right > #{$root}__inner > & {
+    #{$root}--no-top-right > & {
       --stl: 1;
       --str: 0;
       --m: 2;
@@ -60,7 +60,7 @@
       --sbr: 4;
     }
 
-    #{$root}--no-bottom-left > #{$root}__inner > & {
+    #{$root}--no-bottom-left > & {
       --stl: 1;
       --str: 2;
       --m: 3;
@@ -68,7 +68,7 @@
       --sbr: 4;
     }
 
-    #{$root}--no-bottom-right > #{$root}__inner > & {
+    #{$root}--no-bottom-right > & {
       --stl: 1;
       --str: 2;
       --m: 3;
@@ -76,7 +76,7 @@
       --sbr: 0;
     }
 
-    #{$root}--no-top-left#{$root}--no-top-right > #{$root}__inner > & {
+    #{$root}--no-top-left#{$root}--no-top-right > & {
       --stl: 0;
       --str: 0;
       --m: 1;
@@ -84,7 +84,7 @@
       --sbr: 3;
     }
 
-    #{$root}--no-top-left#{$root}--no-bottom-left > #{$root}__inner > & {
+    #{$root}--no-top-left#{$root}--no-bottom-left > & {
       --stl: 0;
       --str: 1;
       --m: 2;
@@ -92,7 +92,7 @@
       --sbr: 3;
     }
 
-    #{$root}--no-top-left#{$root}--no-bottom-right > #{$root}__inner > & {
+    #{$root}--no-top-left#{$root}--no-bottom-right > & {
       --stl: 0;
       --str: 1;
       --m: 2;
@@ -100,7 +100,7 @@
       --sbr: 0;
     }
 
-    #{$root}--no-top-right#{$root}--no-bottom-left > #{$root}__inner > & {
+    #{$root}--no-top-right#{$root}--no-bottom-left > & {
       --stl: 1;
       --str: 0;
       --m: 2;
@@ -108,7 +108,7 @@
       --sbr: 3;
     }
 
-    #{$root}--no-top-right#{$root}--no-bottom-right > #{$root}__inner > & {
+    #{$root}--no-top-right#{$root}--no-bottom-right > & {
       --stl: 1;
       --str: 0;
       --m: 2;
@@ -116,7 +116,7 @@
       --sbr: 0;
     }
 
-    #{$root}--no-bottom-left#{$root}--no-bottom-right > #{$root}__inner > & {
+    #{$root}--no-bottom-left#{$root}--no-bottom-right > & {
       --stl: 1;
       --str: 2;
       --m: 3;
@@ -124,7 +124,7 @@
       --sbr: 0;
     }
 
-    #{$root}--no-top-left#{$root}--no-top-right#{$root}--no-bottom-left > #{$root}__inner > & {
+    #{$root}--no-top-left#{$root}--no-top-right#{$root}--no-bottom-left > & {
       --stl: 0;
       --str: 0;
       --m: 1;
@@ -132,7 +132,7 @@
       --sbr: 2;
     }
 
-    #{$root}--no-top-left#{$root}--no-top-right#{$root}--no-bottom-right > #{$root}__inner > & {
+    #{$root}--no-top-left#{$root}--no-top-right#{$root}--no-bottom-right > & {
       --stl: 0;
       --str: 0;
       --m: 1;
@@ -140,7 +140,7 @@
       --sbr: 0;
     }
 
-    #{$root}--no-top-left#{$root}--no-bottom-left#{$root}--no-bottom-right > #{$root}__inner > & {
+    #{$root}--no-top-left#{$root}--no-bottom-left#{$root}--no-bottom-right > & {
       --stl: 0;
       --str: 1;
       --m: 2;
@@ -148,7 +148,7 @@
       --sbr: 0;
     }
 
-    #{$root}--no-top-right#{$root}--no-bottom-left#{$root}--no-bottom-right > #{$root}__inner > & {
+    #{$root}--no-top-right#{$root}--no-bottom-left#{$root}--no-bottom-right > & {
       --stl: 1;
       --str: 0;
       --m: 2;
@@ -156,7 +156,7 @@
       --sbr: 0;
     }
 
-    #{$root}--no-top-left#{$root}--no-top-right#{$root}--no-bottom-left#{$root}--no-bottom-right > #{$root}__inner > & {
+    #{$root}--no-top-left#{$root}--no-top-right#{$root}--no-bottom-left#{$root}--no-bottom-right > & {
       --stl: 0;
       --str: 0;
       --m: 1;

--- a/components/00-base/layout/layout.scss
+++ b/components/00-base/layout/layout.scss
@@ -26,7 +26,17 @@
   &__inner {
     display: grid;
     grid-template-columns: repeat($ct-layout-columns, 1fr);
-    grid-gap: $ct-layout-row-gap $ct-layout-column-gap;
+    gap: $ct-layout-row-gap $ct-layout-column-gap;
+
+    @include ct-breakpoint($ct-layout-breakpoint) {
+      #{$root}--no-top-left#{$root}--no-bottom-left & {
+        gap: $ct-layout-row-gap-right-only $ct-layout-column-gap-right-only;
+      }
+
+      #{$root}--no-top-right#{$root}--no-bottom-right & {
+        gap: $ct-layout-row-gap-left-only $ct-layout-column-gap-left-only;
+      }
+    }
 
     --stl: 1;
     --str: 2;


### PR DESCRIPTION
## Checklist before requesting a review

- [ ] I have formatted the subject to include the issue number
  as `[#123] Verb in past tense with a period at the end.`
- [x] I have provided information in the `Changed` section about WHY something was
  done if this was a bespoke implementation.
- [x] I have performed a self-review of my code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have run new and existing relevant tests locally with my changes,
  and they have passed.
- [x] I have provided screenshots, where applicable.

## Changed

- Fixed column gaps to be larger when only a single sidebar is present.
- Updated `grid-gap` to `gap` as [docs](https://developer.mozilla.org/en-US/docs/Web/CSS/gap) say `grid-gap` is a legacy alias.
- Fixed grid ordering not applying due to double .ct-layout__inner.

## Screenshots

https://github.com/civictheme/uikit/assets/12739575/da00c35f-f29b-4def-9904-12fdbca9c373
