### PR TITLE
Fixed browser-provided icon colour on `Input`.

### DIFF
--- a/components/01-atoms/input/input.scss
+++ b/components/01-atoms/input/input.scss
@@ -46,6 +46,11 @@
       @include ct-component-property($root, $theme, border-color);
       @include ct-component-property($root, $theme, background-color);
 
+      @if $theme == 'dark' {
+        // Note that this will also affects the calendar color scheme.
+        color-scheme: dark;
+      }
+
       &::placeholder {
         @include ct-component-property($root, $theme, color);
       }

--- a/components/02-molecules/field/field.utils.js
+++ b/components/02-molecules/field/field.utils.js
@@ -18,8 +18,9 @@ export const randomFields = (count, theme, rand, defaultInputType) => {
     fields.push(Field(new KnobValues({
       theme,
       type: inputType,
+      description: null,
       message: null,
-      orientation: randomArrayItem(['horizontal', 'vertical']),
+      orientation: 'vertical',
     })));
   }
 


### PR DESCRIPTION
<img width="227" alt="Atoms___Form_Controls___Input_-_Input_⋅_Storybook" src="https://github.com/civictheme/uikit/assets/378794/a378efc8-ded9-4733-a2ae-d12588bb8cc2">
