### PR TITLE
Fixed sidebar gap on `Layout` using masonry with JS fallback.

### DIFF
--- a/components/00-base/layout/layout.js
+++ b/components/00-base/layout/layout.js
@@ -40,8 +40,9 @@ function CivicThemeLayout(el) {
  * Position element in relation to it's above element.
  */
 CivicThemeLayout.prototype.masonryPositionElement = function (el, aboveEl, gap) {
-  const aboveLastChild = aboveEl.children[aboveEl.children.length - 1];
-  const aboveBottom = aboveLastChild.getBoundingClientRect().bottom;
+  const aboveChildIdx = aboveEl.children.length - 1;
+  const aboveChild = (aboveChildIdx >= 0) ? aboveEl.children[aboveChildIdx] : null;
+  const aboveBottom = aboveChild ? aboveChild.getBoundingClientRect().bottom : aboveEl.getBoundingClientRect().top;
   const currentTop = el.getBoundingClientRect().top;
   el.style.marginTop = `${aboveBottom + gap - currentTop}px`;
 };

--- a/components/00-base/layout/layout.js
+++ b/components/00-base/layout/layout.js
@@ -1,0 +1,75 @@
+/**
+ * @file
+ * Layout component.
+ */
+function CivicThemeLayout(el) {
+  this.el = el;
+  this.grid = el.querySelector('.ct-layout__inner');
+  const gridStyle = getComputedStyle(this.grid);
+
+  if (gridStyle.gridTemplateRows === 'masonry' || this.grid.hasAttribute('data-masonry')) {
+    return;
+  }
+
+  this.grid.setAttribute('data-masonry', true);
+
+  this.stl = this.grid.querySelector('.ct-layout__sidebar_top_left');
+  this.str = this.grid.querySelector('.ct-layout__sidebar_top_right');
+  this.sbl = this.grid.querySelector('.ct-layout__sidebar_bottom_left');
+  this.sbr = this.grid.querySelector('.ct-layout__sidebar_bottom_right');
+
+  // Only enable masonry if all 4 elements are present.
+  if (this.stl && this.str && this.sbl && this.sbr) {
+    // Prepare redraw variables.
+    this.gap = parseFloat(gridStyle.gridRowGap);
+    this.items = Array.from(this.grid.children);
+    this.height = 0;
+
+    // Listen for redraw events.
+    this.resizeObserver = new ResizeObserver(() => {
+      requestAnimationFrame(() => {
+        this.masonryRedraw();
+      });
+    });
+    this.resizeObserver.observe(this.grid);
+    this.masonryRedraw();
+  }
+}
+
+/**
+ * Position element in relation to it's above element.
+ */
+CivicThemeLayout.prototype.masonryPositionElement = function (el, aboveEl, gap) {
+  const aboveLastChild = aboveEl.children[aboveEl.children.length - 1];
+  const aboveBottom = aboveLastChild.getBoundingClientRect().bottom;
+  const currentTop = el.getBoundingClientRect().top;
+  el.style.marginTop = `${aboveBottom + gap - currentTop}px`;
+};
+
+/**
+ * Reposition grid elements.
+ */
+CivicThemeLayout.prototype.masonryRedraw = function () {
+  // Ignore redraw if grid items total height hasn't changed since last redraw.
+  const newHeight = this.items.reduce((t, el) => t + el.getBoundingClientRect().height, 0);
+
+  if (newHeight !== this.height) {
+    this.height = newHeight;
+
+    // Clear existing positioning.
+    this.sbl.style.removeProperty('margin-top');
+    this.sbr.style.removeProperty('margin-top');
+
+    // Set new position (if masonry css has been applied).
+    if (getComputedStyle(this.grid).getPropertyValue('--js-masonry-enabled')) {
+      this.masonryPositionElement(this.sbl, this.stl, this.gap);
+      this.masonryPositionElement(this.sbr, this.str, this.gap);
+    }
+  }
+};
+
+// Initialize CivicThemeLayout on every element.
+document.querySelectorAll('.ct-layout').forEach((layout) => {
+  // eslint-disable-next-line no-new
+  new CivicThemeLayout(layout);
+});

--- a/components/00-base/layout/layout.scss
+++ b/components/00-base/layout/layout.scss
@@ -27,12 +27,11 @@
     display: grid;
     grid-template-columns: repeat($ct-layout-columns, 1fr);
     gap: $ct-layout-row-gap $ct-layout-column-gap;
+    grid-template-rows: auto 1fr;
+    grid-template-rows: masonry;
 
     @include ct-breakpoint($ct-layout-breakpoint) {
       --js-masonry-enabled: 1;
-
-      grid-template-rows: auto 1fr;
-      grid-template-rows: masonry;
 
       #{$root}--no-top-left#{$root}--no-bottom-left & {
         gap: $ct-layout-row-gap-right-only $ct-layout-column-gap-right-only;

--- a/components/00-base/layout/layout.scss
+++ b/components/00-base/layout/layout.scss
@@ -29,6 +29,11 @@
     gap: $ct-layout-row-gap $ct-layout-column-gap;
 
     @include ct-breakpoint($ct-layout-breakpoint) {
+      --js-masonry-enabled: 1;
+
+      grid-template-rows: auto 1fr;
+      grid-template-rows: masonry;
+
       #{$root}--no-top-left#{$root}--no-bottom-left & {
         gap: $ct-layout-row-gap-right-only $ct-layout-column-gap-right-only;
       }

--- a/components/00-base/layout/layout.stories.js
+++ b/components/00-base/layout/layout.stories.js
@@ -1,3 +1,4 @@
+import './layout';
 import CivicThemeLayout from './layout.twig';
 import { knobBoolean, knobRadios, knobText, placeholder, randomInt, shouldRender, slotKnobs } from '../storybook/storybook.utils';
 


### PR DESCRIPTION
## Checklist before requesting a review

- [ ] I have formatted the subject to include the issue number
  as `[#123] Verb in past tense with a period at the end.`
- [x] I have provided information in the `Changed` section about WHY something was
  done if this was a bespoke implementation.
- [x] I have performed a self-review of my code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have run new and existing relevant tests locally with my changes,
  and they have passed.
- [x] I have provided screenshots, where applicable.

## Changed

1.  Fixed sidebar gap on layout using masonry with JS fallback.
2.  The JS is not a general masonry polyfill, it has been written explicitly to support our use case of both sidebars with top and bottom regions showing - this is to reduce the amount of processing and code required.
3.  The JS fallback has a number of checks in place to avoid needing to redraw anything unnecessarily:
    1.  The fallback is initialized only once on the layout grid.
    2.  The grid must not have enabled masonry (native support must not be working).
    3.  The height of the grid must change before a redraw occurs.


## Screenshots

https://github.com/civictheme/uikit/assets/12739575/87bd3d16-76fb-4893-9b15-949449301298
