### PR TITLE
[#277] Added fixed width utility class to size labels consistently.

### DIFF
--- a/components/00-base/_variables.components.scss
+++ b/components/00-base/_variables.components.scss
@@ -748,6 +748,7 @@ $ct-callout-dark-stripe-background-color: ct-color-dark('highlight') !default;
 //
 $ct-field-horizontal-label-min-width: auto !default;
 $ct-field-horizontal-label-max-width: 25% !default;
+$ct-field-horizontal-label-fixed-widths: 15, 25 !default;
 
 //
 // Figure.

--- a/components/02-molecules/field/field.scss
+++ b/components/02-molecules/field/field.scss
@@ -38,6 +38,12 @@
       min-width: $ct-field-horizontal-label-min-width;
       max-width: $ct-field-horizontal-label-max-width;
       margin-top: $_control-vertical-padding - $_control-border-width;
+
+      @each $width in $ct-field-horizontal-label-fixed-widths {
+        .ct-field-horizontal-label-fixed-width-#{$width} & {
+          width: ct-spacing($width);
+        }
+      }
     }
 
     &#{$root}--radio,

--- a/components/02-molecules/field/field.stories.js
+++ b/components/02-molecules/field/field.stories.js
@@ -1,5 +1,6 @@
-import { generateItems, knobBoolean, knobNumber, knobRadios, knobText, KnobValues, randomId, randomLink, randomName, randomSentence, shouldRender } from '../../00-base/storybook/storybook.utils';
+import { generateItems, knobBoolean, knobNumber, knobRadios, knobText, KnobValues, randomId, randomInt, randomLink, randomName, randomSentence, randomText, shouldRender } from '../../00-base/storybook/storybook.utils';
 import CivicThemeField from './field.twig';
+import CivicThemeFieldset from '../../01-atoms/fieldset/fieldset.twig';
 import { Select } from '../../01-atoms/select/select.stories';
 import { Textfield } from '../../01-atoms/textfield/textfield.stories';
 import { Textarea } from '../../01-atoms/textarea/textarea.stories';
@@ -160,4 +161,56 @@ export const Field = (parentKnobs = {}) => {
   const combinedKnobs = { ...controlKnobs, ...knobs };
 
   return shouldRender(parentKnobs) ? CivicThemeField(combinedKnobs) : combinedKnobs;
+};
+
+export const FieldExamples = (parentKnobs = {}) => {
+  const inputTypes = [
+    'textfield',
+    'textarea',
+    'select',
+    'radio',
+    'checkbox',
+  ];
+
+  const knobs = {
+    theme: knobRadios(
+      'Theme',
+      {
+        Light: 'light',
+        Dark: 'dark',
+      },
+      'light',
+      parentKnobs.theme,
+      parentKnobs.knobTab,
+    ),
+    modifier_class: knobText('Additional class', '', parentKnobs.modifier_class, parentKnobs.knobTab),
+    attributes: knobText('Additional attributes', '', parentKnobs.attributes, parentKnobs.knobTab),
+  };
+
+  const fieldsets = [
+    CivicThemeFieldset({
+      theme: knobs.theme,
+      fields: inputTypes.map((type) => Field(new KnobValues({
+        theme: knobs.theme,
+        type,
+        label: randomText(randomInt(1, 6)),
+        description: null,
+        message: null,
+        orientation: 'vertical',
+      }))).join(''),
+    }),
+    CivicThemeFieldset({
+      theme: knobs.theme,
+      fields: inputTypes.map((type) => Field(new KnobValues({
+        theme: knobs.theme,
+        type,
+        label: randomText(randomInt(1, 6)),
+        description: null,
+        message: null,
+        orientation: 'horizontal',
+      }))).join(''),
+    }),
+  ];
+
+  return `<form class="${knobs.modifier_class}" ${knobs.attributes}>${fieldsets.join('')}</form>`;
 };


### PR DESCRIPTION
https://github.com/civictheme/uikit/issues/277
https://github.com/civictheme/uikit/issues/279

## Checklist before requesting a review

- [x] I have formatted the subject to include the issue number
  as `[#123] Verb in past tense with a period at the end.`
- [x] I have provided information in the `Changed` section about WHY something was
  done if this was a bespoke implementation.
- [x] I have performed a self-review of my code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have run new and existing relevant tests locally with my changes,
  and they have passed.
- [x] I have provided screenshots, where applicable.

## Changed

1. Added `ct-field-horizontal-label-fixed-width-25` utility class.
2. This class can be added on the parent form element, and will set a width (of 25 * 8) on any child labels of horizontal fields (vertical fields are unaffected).
3. The available field spacings can be configured by overriding the base variable: `$ct-field-horizontal-label-fixed-widths: 10, 20, 30, 40` to whatever sizes are required.
4. Currently there is no test page in storybook for this, screenshot taken from a demo page set up locally.
5. Added a page `Field/Field Examples` to test field groups.

## Screenshots
![Screen Shot 2024-06-21 at 16 37 03-fullpage](https://github.com/civictheme/uikit/assets/12739575/c630ae70-6a38-484d-ab21-69d17da3908f)

## Testing Steps:

1. Go to https://66751fa7a79a962f93798ed3--civictheme-uikit.netlify.app/?path=/story/molecules-field--field-examples&knob-Additional%20class_General=ct-field-horizontal-label-fixed-width-25&knob-Theme_General=light (This will populate the additional class `ct-field-horizontal-label-fixed-width-25` needed).
2. Check that the labels have a consistent width.

Note: Due the Field using a constrained centered layout, the width of the label will be smaller than ct-spacing of 25. This is expected. Without the storybook centered constraint, the label should set width to 200px.
