### PR TITLE
[#308] Fixed Layout masonry is not applied when nested Layout is used.

### DIFF
--- a/components/00-base/layout/layout.stories.js
+++ b/components/00-base/layout/layout.stories.js
@@ -21,29 +21,24 @@ export const Layout = (parentKnobs = {}) => {
     sidebar_bottom_right: knobBoolean('Show bottom right sidebar', true, parentKnobs.sidebar_bottom_right, parentKnobs.knobTab) ? placeholder('Bottom right sidebar', useLargePlaceholders ? randomInt(30, 100) : 0) : '',
     hide_sidebar_right: knobBoolean('Hide right sidebar', false, parentKnobs.hide_sidebar_right, parentKnobs.knobTab),
     is_contained: knobBoolean('Is contained', false, parentKnobs.is_contained, parentKnobs.knobTab),
-    vertical_spacing: knobRadios(
-      'Vertical spacing',
-      {
-        None: 'none',
-        Top: 'top',
-        Bottom: 'bottom',
-        Both: 'both',
-      },
-      'none',
-      parentKnobs.vertical_spacing,
-      parentKnobs.knobTab,
-    ),
   };
 
   const showNested = knobBoolean('Show nested layout', false, parentKnobs.show_nested_layout, parentKnobs.knobTab);
 
-  knobs.content = showNested ? CivicThemeLayout({
+  // Show nested only if parent content is shown.
+  knobs.content = knobs.content && showNested ? CivicThemeLayout({
     ...{
-      sidebar_top_left: placeholder('Nested top left sidebar', useLargePlaceholders ? randomInt(30, 100) : 0),
-      sidebar_bottom_left: placeholder('Nested bottom left sidebar', useLargePlaceholders ? randomInt(30, 100) : 0),
-      content: placeholder('Nested content', useLargePlaceholders ? randomInt(500, 1000) : 0),
-      sidebar_top_right: placeholder('Nested top right sidebar', useLargePlaceholders ? randomInt(30, 100) : 0),
-      sidebar_bottom_right: placeholder('Nested bottom right sidebar', useLargePlaceholders ? randomInt(30, 100) : 0),
+      sidebar_top_left: knobBoolean('Show nested top left sidebar', true, parentKnobs.nested_sidebar_top_left, parentKnobs.knobTab) ? placeholder('Nested top left sidebar', useLargePlaceholders ? randomInt(30, 100) : 0) : '',
+      sidebar_top_left_attributes: 'data-story-nested-layout',
+      sidebar_bottom_left: knobBoolean('Show nested bottom left sidebar', true, parentKnobs.nested_sidebar_bottom_left, parentKnobs.knobTab) ? placeholder('Nested bottom left sidebar', useLargePlaceholders ? randomInt(30, 100) : 0) : '',
+      sidebar_bottom_left_attributes: 'data-story-nested-layout',
+      content: knobBoolean('Show nested content', true, parentKnobs.nested_content, parentKnobs.knobTab) ? placeholder('Nested content', useLargePlaceholders ? randomInt(500, 1000) : 0) : '',
+      content_attributes: 'data-story-nested-layout',
+      sidebar_top_right: knobBoolean('Show nested top right sidebar', true, parentKnobs.nested_sidebar_top_right, parentKnobs.knobTab) ? placeholder('Nested top right sidebar', useLargePlaceholders ? randomInt(30, 100) : 0) : '',
+      sidebar_top_right_attributes: 'data-story-nested-layout',
+      sidebar_bottom_right: knobBoolean('Show nested bottom right sidebar', true, parentKnobs.nested_sidebar_bottom_right, parentKnobs.knobTab) ? placeholder('Nested bottom right sidebar', useLargePlaceholders ? randomInt(30, 100) : 0) : '',
+      sidebar_bottom_right_attributes: 'data-story-nested-layout',
+      attributes: 'data-story-nested-layout',
     },
     ...slotKnobs([
       'content_top',
@@ -52,6 +47,19 @@ export const Layout = (parentKnobs = {}) => {
   }) : knobs.content;
 
   const showOutlines = knobBoolean('Show outlines', false, parentKnobs.show_outlines, parentKnobs.knobTab);
+
+  knobs.vertical_spacing = knobRadios(
+    'Vertical spacing',
+    {
+      None: 'none',
+      Top: 'top',
+      Bottom: 'bottom',
+      Both: 'both',
+    },
+    'none',
+    parentKnobs.vertical_spacing,
+    parentKnobs.knobTab,
+  );
 
   const attributesTab = 'Attributes';
   knobs.sidebar_top_left_attributes = knobs.sidebar_top_left ? knobText('Top left sidebar attributes', '', parentKnobs.sidebar_top_left_attributes, attributesTab) : '';

--- a/components/00-base/layout/layout.stories.scss
+++ b/components/00-base/layout/layout.stories.scss
@@ -2,6 +2,21 @@
 // Layout component stories.
 //
 
+@use 'sass:color';
+
+// Nested layout.
+.ct-layout {
+  .ct-layout {
+    .story-placeholder {
+      $_color: #6b5394;
+
+      background-color: color.adjust($_color, $alpha: -0.7);
+      border: dashed 1px color.adjust($_color, $alpha: -0.3);
+      color: color.adjust($_color, $lightness: -30%);
+    }
+  }
+}
+
 .story-layout-outlines {
   $_viewport-color: blue;
   $_layout-color: green;

--- a/components/00-base/storybook/storybook.generators.utils.js
+++ b/components/00-base/storybook/storybook.generators.utils.js
@@ -10,7 +10,7 @@ export const themes = () => ({
   dark: 'Dark',
 });
 
-export const placeholder = (content = 'Content placeholder', words = 0, cssClass = 'story-placeholder') => `<div class="${cssClass}">${content}${words > 0 ? ` ${randomSentence(words)}` : ''}</div>`;
+export const placeholder = (content = 'Content placeholder', words = 0, cssClass = 'story-placeholder') => `<div class="${cssClass}" contenteditable="true">${content}${words > 0 ? ` ${randomSentence(words)}` : ''}</div>`;
 
 export const code = (content) => `<code>${content}</code>`;
 

--- a/components/00-base/storybook/storybook.generators.utils.test.js
+++ b/components/00-base/storybook/storybook.generators.utils.test.js
@@ -15,17 +15,17 @@ describe('Domain-Specific Generators', () => {
   describe('placeholder', () => {
     it('returns placeholder with default parameters', () => {
       expect(placeholder())
-        .toBe('<div class="story-placeholder">Content placeholder</div>');
+        .toBe('<div class="story-placeholder" contenteditable="true">Content placeholder</div>');
     });
 
     it('returns placeholder with custom content and class', () => {
       expect(placeholder('Custom content', 0, 'custom-class'))
-        .toBe('<div class="custom-class">Custom content</div>');
+        .toBe('<div class="custom-class" contenteditable="true">Custom content</div>');
     });
 
     it('returns placeholder with random sentence', () => {
       const result = placeholder('Custom content', 5);
-      expect(result.startsWith('<div class="story-placeholder">Custom content '))
+      expect(result.startsWith('<div class="story-placeholder" contenteditable="true">Custom content '))
         .toBe(true);
     });
   });


### PR DESCRIPTION
closes #308

This PR changes 2 things:
1. We are no longer observing the grid's items - we are observing grid's items' children to track the change of their heigh.
2. The selection of the grid elements is now scoped to the immediate children to allow binding to nested layouts correctly.


https://github.com/civictheme/uikit/assets/378794/72b69d25-f6c2-4b43-ad4c-a83b06451359

