### PR TITLE
[#309] Fixed `Layout` gaps for nested layouts.

### DIFF
--- a/components/00-base/layout/layout.scss
+++ b/components/00-base/layout/layout.scss
@@ -17,6 +17,7 @@
     #{$root}.ct-vertical-spacing--both {
       margin-top: 0;
     }
+
     #{$root}.ct-vertical-spacing--bottom,
     #{$root}.ct-vertical-spacing--both {
       margin-bottom: 0;
@@ -24,22 +25,20 @@
   }
 
   &__inner {
+    $inner: &;
+
     display: grid;
     grid-template-columns: repeat($ct-layout-columns, 1fr);
-    gap: $ct-layout-row-gap $ct-layout-column-gap;
+    row-gap: $ct-layout-row-gap;
     grid-template-rows: auto 1fr;
     grid-template-rows: masonry;
 
     @include ct-breakpoint($ct-layout-breakpoint) {
+      // Activate masonry layout.
       --js-masonry-enabled: 1;
 
-      #{$root}--no-top-left#{$root}--no-bottom-left & {
-        gap: $ct-layout-row-gap-right-only $ct-layout-column-gap-right-only;
-      }
-
-      #{$root}--no-top-right#{$root}--no-bottom-right & {
-        gap: $ct-layout-row-gap-left-only $ct-layout-column-gap-left-only;
-      }
+      // See the responsive layout rules at the bottom of this file.
+      column-gap: $ct-layout-column-gap;
     }
 
     --stl: 1;
@@ -247,6 +246,75 @@
 
       #{$root}--no-top-right > #{$root}__inner > & {
         grid-row: 1 / span 2;
+      }
+    }
+  }
+}
+
+//
+// Layout has larger gaps when only one sidebar is present.
+// Nested layouts should have the smae larger gaps when only one sidebar is
+// present, but only when the parent layout has no sidebars.
+//
+@include ct-breakpoint($ct-layout-breakpoint) {
+  .ct-layout {
+    $root: &;
+
+    // stylelint-disable-next-line no-duplicate-selectors
+    &#{$root}--no-top-left#{$root}--no-bottom-left > #{$root}__inner {
+      column-gap: $ct-layout-column-gap-right-only;
+    }
+
+    // stylelint-disable-next-line no-duplicate-selectors
+    &#{$root}--no-top-right#{$root}--no-bottom-right > #{$root}__inner {
+      column-gap: $ct-layout-column-gap-left-only;
+    }
+
+    & > #{$root}__inner {
+      #{$root} {
+        > #{$root}__inner {
+          column-gap: $ct-layout-column-gap;
+        }
+      }
+    }
+
+    // stylelint-disable-next-line no-duplicate-selectors
+    &#{$root}--no-top-left#{$root}--no-bottom-left > #{$root}__inner {
+      #{$root} {
+        &#{$root}--no-top-left#{$root}--no-bottom-left,
+        &#{$root}--no-top-right#{$root}--no-bottom-right {
+          > #{$root}__inner {
+            column-gap: $ct-layout-column-gap;
+          }
+        }
+      }
+    }
+
+    // stylelint-disable-next-line no-duplicate-selectors
+    &#{$root}--no-top-right#{$root}--no-bottom-right > #{$root}__inner {
+      #{$root} {
+        &#{$root}--no-top-left#{$root}--no-bottom-left,
+        &#{$root}--no-top-right#{$root}--no-bottom-right {
+          > #{$root}__inner {
+            column-gap: $ct-layout-column-gap;
+          }
+        }
+      }
+    }
+
+    &#{$root}--no-top-left#{$root}--no-bottom-left#{$root}--no-top-right#{$root}--no-bottom-right > #{$root}__inner {
+      #{$root} {
+        &#{$root}--no-top-left#{$root}--no-bottom-left {
+          > #{$root}__inner {
+            column-gap: $ct-layout-column-gap-right-only;
+          }
+        }
+
+        &#{$root}--no-top-right#{$root}--no-bottom-right {
+          > #{$root}__inner {
+            column-gap: $ct-layout-column-gap-right-only;
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
Closes #309 

<img width="848" alt="Base___Layout_-_Layout_⋅_Storybook-2" src="https://github.com/civictheme/uikit/assets/378794/d1c7b3ce-9e37-4d38-b7ba-8e94f0776cfc">
<img width="852" alt="Cursor_and_Base___Layout_-_Layout_⋅_Storybook-2" src="https://github.com/civictheme/uikit/assets/378794/66caf423-6375-4a82-96be-a7a4db0ef69f">
<img width="844" alt="Base___Layout_-_Layout_⋅_Storybook-5" src="https://github.com/civictheme/uikit/assets/378794/f960f6a5-963e-4034-ad65-73ff782c0f8d">
<img width="822" alt="Base___Layout_-_Layout_⋅_Storybook" src="https://github.com/civictheme/uikit/assets/378794/cbe48e6c-fb36-4f8b-9e05-05e87c22d3af">
<img width="839" alt="Base___Layout_-_Layout_⋅_Storybook-3" src="https://github.com/civictheme/uikit/assets/378794/c7cf7dd4-7656-496e-a228-3cd331eef46e">
<img width="841" alt="Base___Layout_-_Layout_⋅_Storybook-6" src="https://github.com/civictheme/uikit/assets/378794/bff9b4b8-7654-4f89-a55c-28002c80e14b">
<img width="838" alt="Base___Layout_-_Layout_⋅_Storybook-4" src="https://github.com/civictheme/uikit/assets/378794/e1ca6e48-d47e-4792-8fa5-a69b21939ec4">


