### PR TITLE
[#321] Added SCSS var to set a border color for back-to-top component.

### DIFF
--- a/components/00-base/_variables.components.scss
+++ b/components/00-base/_variables.components.scss
@@ -681,6 +681,7 @@ $ct-attachment-dark-wrapper-background-color: ct-color-dark('background') !defau
 $ct-back-to-top-space-bottom: ct-spacing(8) !default;
 $ct-back-to-top-space-right: ct-spacing(2) !default;
 $ct-back-to-top-background-color: ct-color-light('interaction-background') !default;
+$ct-back-to-top-border-color: $ct-back-to-top-background-color !default;
 $ct-back-to-top-color: ct-color-light('interaction-text') !default;
 $ct-back-to-top-outline-color: transparent !default;
 

--- a/components/02-molecules/back-to-top/back-to-top.scss
+++ b/components/02-molecules/back-to-top/back-to-top.scss
@@ -20,7 +20,7 @@
       border-radius: ct-particle(12);
       padding: ct-spacing();
       background-color: $ct-back-to-top-background-color;
-      border-color: $ct-back-to-top-background-color;
+      border-color: $ct-back-to-top-border-color;
       color: $ct-back-to-top-color;
       line-height: 0;
       outline-color: $ct-back-to-top-outline-color;


### PR DESCRIPTION
Closes #321

## Checklist before requesting a review

- [x] I have formatted the subject to include the issue number
  as `[#123] Verb in past tense with a period at the end.`
- [x] I have provided information in the `Changed` section about WHY something was
  done if this was a bespoke implementation.
- [x] I have performed a self-review of my code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have run new and existing relevant tests locally with my changes,
  and they have passed.
- [ ] I have provided screenshots, where applicable.

## Changed

1. Added SCSS variable to set a border color for back-to-top component.
2. Made the default the background color (same as existing implementation).

## Screenshots
