### PR TITLE
[#330] Fixed card link arrows being read-out by screen readers and tabbed to.

### DIFF
--- a/components/02-molecules/event-card/__snapshots__/event-card.test.js.snap
+++ b/components/02-molecules/event-card/__snapshots__/event-card.test.js.snap
@@ -242,8 +242,10 @@ exports[`Event Card Component renders with optional attributes 1`] = `
   
   
         <a
+          aria-hidden="true"
           class="ct-link ct-theme-dark    ct-link--only-icon ct-event-card__tags__link"
           href="https://example.com"
+          tabindex="-1"
         >
                     
               

--- a/components/02-molecules/event-card/event-card.twig
+++ b/components/02-molecules/event-card/event-card.twig
@@ -160,6 +160,7 @@
                 is_external: false,
                 icon: 'right-arrow-2',
                 modifier_class: 'ct-event-card__tags__link',
+                attributes: 'aria-hidden="true" tabindex="-1"',
               } only %}
             {% endif %}
           </div>

--- a/components/02-molecules/promo-card/__snapshots__/promo-card.test.js.snap
+++ b/components/02-molecules/promo-card/__snapshots__/promo-card.test.js.snap
@@ -77,8 +77,10 @@ exports[`Promo Card Component renders with link when provided 1`] = `
   
   
         <a
+          aria-hidden="true"
           class="ct-link ct-theme-light    ct-link--only-icon ct-promo-card__tags__link"
           href="https://example.com"
+          tabindex="-1"
         >
                     
               
@@ -359,9 +361,11 @@ exports[`Promo Card Component renders with optional attributes 1`] = `
   
   
         <a
+          aria-hidden="true"
           aria-label="Opens in a new tab"
           class="ct-link ct-theme-dark    ct-link--only-icon ct-promo-card__tags__link"
           href="https://example.com"
+          tabindex="-1"
           target="_blank"
         >
                     

--- a/components/02-molecules/promo-card/promo-card.twig
+++ b/components/02-molecules/promo-card/promo-card.twig
@@ -165,6 +165,7 @@
                   is_external: false,
                   icon: 'right-arrow-2',
                   modifier_class: 'ct-promo-card__tags__link',
+                  attributes: 'aria-hidden="true" tabindex="-1"',
                 } only %}
               {% endif %}
             </div>


### PR DESCRIPTION
https://github.com/civictheme/uikit/issues/330

## Checklist before requesting a review

- [x] I have formatted the subject to include the issue number
  as `[#123] Verb in past tense with a period at the end.`
- [x] I have provided information in the `Changed` section about WHY something was
  done if this was a bespoke implementation.
- [x] I have performed a self-review of my code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have run new and existing relevant tests locally with my changes,
  and they have passed.
- [ ] I have provided screenshots, where applicable.

## Changed

1. Ignore arrow links from tabbing and screen readers.

## Screenshots
