### PR TITLE
[#336] H2s are displaying twice in Table of contents (TOC)

### DIFF
--- a/components/02-molecules/table-of-contents/table-of-contents.js
+++ b/components/02-molecules/table-of-contents/table-of-contents.js
@@ -64,8 +64,9 @@ CivicThemeTableOfContents.prototype.init = function () {
 
 CivicThemeTableOfContents.prototype.findLinks = function (anchorSelector, scopeSelector) {
   const links = [];
+  const existingUrls = new Set(); // Track existing URLs.
 
-  // Fins links within provided scope selector.
+  // Find links within provided scope selector.
   document.querySelectorAll(scopeSelector).forEach((elScope) => {
     elScope.querySelectorAll(anchorSelector).forEach((elAnchor) => {
       // Respect existing ID.
@@ -75,21 +76,31 @@ CivicThemeTableOfContents.prototype.findLinks = function (anchorSelector, scopeS
       // Generate new ID if no existing ID.
       if (!anchorId || anchorId.length === 0) {
         anchorId = this.makeAnchorId(anchorText);
-        // Check if generated ID is already present on the page.
-        if (elScope.querySelectorAll(`#${anchorId}`).length) {
+        // Check if generated ID is already present on the page or links array.
+        while (elScope.querySelectorAll(`#${anchorId}`).length || existingUrls.has(`#${anchorId}`)) {
           // Add random 3 character suffix.
           anchorId = `${anchorId}-${Math.random().toString(36).substring(2, 5)}`;
         }
       }
 
+      const url = `#${anchorId}`;
+
+      // Skip adding the link if the URL already exists.
+      if (existingUrls.has(url)) {
+        return;
+      }
+
       links.push({
         title: anchorText,
-        url: `#${anchorId}`,
+        url,
       });
 
       // Update anchor with the id. This will "fix" any anchors with duplicated
       // IDs, which is not a valid HTML content.
       elAnchor.id = anchorId;
+
+      // Add the URL to the set of existing URLs.
+      existingUrls.add(url);
     });
   });
 


### PR DESCRIPTION
Closes https://github.com/civictheme/uikit/issues/336
## Checklist before requesting a review

- [x] I have formatted the subject to include the issue number
  as `[#123] Verb in past tense with a period at the end.`
- [x] I have provided information in the `Changed` section about WHY something was
  done if this was a bespoke implementation.
- [x] I have performed a self-review of my code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have run new and existing relevant tests locally with my changes,
  and they have passed.
- [ ] I have provided screenshots, where applicable.

## Changed

1. Added a check to  remove duplicates when `data-table-of-contents-anchor-scope-selector` may have duplicated clases

## Screenshots
