### PR TITLE
[#389] Removed aria-label from button with 'is_new_window'.

### DIFF
--- a/components/01-atoms/button/__snapshots__/button.test.js.snap
+++ b/components/01-atoms/button/__snapshots__/button.test.js.snap
@@ -6,7 +6,6 @@ exports[`Button Component renders as a link with optional attributes 1`] = `
 
   
   <a
-    aria-label="Opens in a new tab"
     class="ct-button ct-theme-dark  ct-button--link ct-button--regular   custom-class"
     data-component-name="button"
     data-test="true"
@@ -60,7 +59,6 @@ exports[`Button Component renders as a link with optional attributes, is externa
 
   
   <a
-    aria-label="Opens in a new tab"
     class="ct-button ct-theme-dark  ct-button--link ct-button--regular  ct-button--external custom-class"
     data-component-name="button"
     data-test="true"

--- a/components/01-atoms/button/button.twig
+++ b/components/01-atoms/button/button.twig
@@ -74,7 +74,7 @@
     data-component-name="button"
     {% if url %}href="{{ url }}"{% endif %}
     {% if is_disabled %}disabled="disabled" aria-disabled="true"{% endif %}
-    {% if is_new_window %}target="_blank" aria-label="Opens in a new tab"{% endif %}
+    {% if is_new_window %}target="_blank"{% endif %}
     {% if attributes is not empty %}{{- attributes|raw -}}{% endif %}
   >
     {{- button_content -}}

--- a/components/02-molecules/callout/__snapshots__/callout.test.js.snap
+++ b/components/02-molecules/callout/__snapshots__/callout.test.js.snap
@@ -199,7 +199,6 @@ exports[`Callout Component renders with optional attributes 1`] = `
 
   
                 <a
-                  aria-label="Opens in a new tab"
                   class="ct-button ct-theme-dark ct-button--primary ct-button--link ct-button--regular  ct-button--external "
                   data-component-name="button"
                   href="https://example.com"

--- a/components/02-molecules/map/__snapshots__/map.test.js.snap
+++ b/components/02-molecules/map/__snapshots__/map.test.js.snap
@@ -57,7 +57,6 @@ exports[`Map Component renders with default view text 1`] = `
 
   
           <a
-            aria-label="Opens in a new tab"
             class="ct-button ct-theme-light ct-button--tertiary ct-button--link ct-button--regular  ct-button--external ct-map__link"
             data-component-name="button"
             href="https://maps.google.com"
@@ -188,7 +187,6 @@ exports[`Map Component renders with optional attributes 1`] = `
 
   
           <a
-            aria-label="Opens in a new tab"
             class="ct-button ct-theme-dark ct-button--tertiary ct-button--link ct-button--regular  ct-button--external ct-map__link"
             data-component-name="button"
             href="https://maps.google.com"

--- a/components/02-molecules/social-links/__snapshots__/social-links.test.js.snap
+++ b/components/02-molecules/social-links/__snapshots__/social-links.test.js.snap
@@ -34,7 +34,6 @@ exports[`Social Links Component renders with icon HTML 1`] = `
 
   
         <a
-          aria-label="Opens in a new tab"
           class="ct-button ct-theme-light ct-button--tertiary ct-button--link ct-button--regular   ct-social-links__button"
           data-component-name="button"
           href="https://facebook.com"
@@ -61,7 +60,6 @@ exports[`Social Links Component renders with icon HTML 1`] = `
 
   
         <a
-          aria-label="Opens in a new tab"
           class="ct-button ct-theme-light ct-button--tertiary ct-button--link ct-button--regular   ct-social-links__button"
           data-component-name="button"
           href="https://twitter.com"
@@ -118,7 +116,6 @@ exports[`Social Links Component renders with optional attributes 1`] = `
 
   
         <a
-          aria-label="Opens in a new tab"
           class="ct-button ct-theme-dark ct-button--tertiary ct-button--link ct-button--regular   ct-social-links__button"
           data-component-name="button"
           href="https://facebook.com"
@@ -145,7 +142,6 @@ exports[`Social Links Component renders with optional attributes 1`] = `
 
   
         <a
-          aria-label="Opens in a new tab"
           class="ct-button ct-theme-dark ct-button--tertiary ct-button--link ct-button--regular   ct-social-links__button"
           data-component-name="button"
           href="https://twitter.com"
@@ -201,7 +197,6 @@ exports[`Social Links Component renders with required attributes 1`] = `
 
   
         <a
-          aria-label="Opens in a new tab"
           class="ct-button ct-theme-light ct-button--tertiary ct-button--link ct-button--regular   ct-social-links__button"
           data-component-name="button"
           href="https://facebook.com"
@@ -246,7 +241,6 @@ exports[`Social Links Component renders with required attributes 1`] = `
 
   
         <a
-          aria-label="Opens in a new tab"
           class="ct-button ct-theme-light ct-button--tertiary ct-button--link ct-button--regular   ct-social-links__button"
           data-component-name="button"
           href="https://twitter.com"

--- a/components/02-molecules/video-player/__snapshots__/video-player.test.js.snap
+++ b/components/02-molecules/video-player/__snapshots__/video-player.test.js.snap
@@ -215,7 +215,6 @@ exports[`Video Component renders with transcript link 1`] = `
 
   
         <a
-          aria-label="Opens in a new tab"
           class="ct-button ct-theme-light ct-button--tertiary ct-button--link ct-button--small   "
           data-component-name="button"
           href="transcript.html"

--- a/components/03-organisms/campaign/__snapshots__/campaign.test.js.snap
+++ b/components/03-organisms/campaign/__snapshots__/campaign.test.js.snap
@@ -152,7 +152,6 @@ exports[`Campaign Component renders with attributes 1`] = `
 
   
                 <a
-                  aria-label="Opens in a new tab"
                   class="ct-button ct-theme-dark ct-button--primary ct-button--link ct-button--regular  ct-button--external "
                   data-component-name="button"
                   href="http://example.com/1"

--- a/components/03-organisms/promo/__snapshots__/promo.test.js.snap
+++ b/components/03-organisms/promo/__snapshots__/promo.test.js.snap
@@ -88,7 +88,6 @@ exports[`Promo Component renders with all attributes provided 1`] = `
 
   
               <a
-                aria-label="Opens in a new tab"
                 class="ct-button ct-theme-dark ct-button--secondary ct-button--link ct-button--large  ct-button--external ct-promo__button"
                 data-component-name="button"
                 href="https://example.com"


### PR DESCRIPTION
https://github.com/civictheme/uikit/issues/389

## Checklist before requesting a review

- [x] I have formatted the subject to include the issue number
  as `[#123] Verb in past tense with a period at the end.`
- [x] I have provided information in the `Changed` section about WHY something was
  done if this was a bespoke implementation.
- [x] I have performed a self-review of my code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have run new and existing relevant tests locally with my changes,
  and they have passed.
- [x] I have provided screenshots, where applicable.

## Changed

1. The aria-label in this case would override whatever text was present within the button, meaning buttons lose context if used with a screen reader.

## Screenshots
![Screenshot 2024-09-25 at 2 31 19 pm](https://github.com/user-attachments/assets/c278b740-a201-4e7e-abc8-508e5c0a45b5)
