### PR TITLE
[#359] Added visually hidden text to read out on back-to-top button.

### DIFF
--- a/components/02-molecules/back-to-top/__snapshots__/back-to-top.test.js.snap
+++ b/components/02-molecules/back-to-top/__snapshots__/back-to-top.test.js.snap
@@ -21,8 +21,12 @@ exports[`Back to Top Component button contains correct icon 1`] = `
       href="#top"
       role="button"
     >
-          
-              
+                
+      <span
+        class="ct-visually-hidden"
+      >
+        Return focus to the top of the page
+      </span>
       
 
 
@@ -46,8 +50,7 @@ exports[`Back to Top Component button contains correct icon 1`] = `
       </svg>
       
 
-          
-      
+  
     </a>
     
 
@@ -78,8 +81,12 @@ exports[`Back to Top Component renders button with correct attributes 1`] = `
       href="#top"
       role="button"
     >
-          
-              
+                
+      <span
+        class="ct-visually-hidden"
+      >
+        Return focus to the top of the page
+      </span>
       
 
 
@@ -103,8 +110,7 @@ exports[`Back to Top Component renders button with correct attributes 1`] = `
       </svg>
       
 
-          
-      
+  
     </a>
     
 
@@ -135,8 +141,12 @@ exports[`Back to Top Component renders correctly 1`] = `
       href="#top"
       role="button"
     >
-          
-              
+                
+      <span
+        class="ct-visually-hidden"
+      >
+        Return focus to the top of the page
+      </span>
       
 
 
@@ -160,8 +170,7 @@ exports[`Back to Top Component renders correctly 1`] = `
       </svg>
       
 
-          
-      
+  
     </a>
     
 

--- a/components/02-molecules/back-to-top/back-to-top.twig
+++ b/components/02-molecules/back-to-top/back-to-top.twig
@@ -11,7 +11,8 @@
     type: 'primary',
     icon: 'up-arrow',
     url: '#top',
-    title: 'Return focus to the top of the page',
+    text: '<span class="ct-visually-hidden">Return focus to the top of the page</span>',
+    allow_html: true,
     modifier_class: 'ct-back-to-top__button',
   } only %}
 </div>

--- a/components/04-templates/page/__snapshots__/page.test.js.snap
+++ b/components/04-templates/page/__snapshots__/page.test.js.snap
@@ -585,9 +585,13 @@ exports[`Page Component renders all blocks with complex attributes and classes 1
         href="#top"
         role="button"
       >
-            
-              
-      
+                  
+        <span
+          class="ct-visually-hidden"
+        >
+          Return focus to the top of the page
+        </span>
+        
 
 
                                     
@@ -610,8 +614,7 @@ exports[`Page Component renders all blocks with complex attributes and classes 1
         </svg>
         
 
-          
-      
+  
       </a>
       
 
@@ -748,9 +751,13 @@ exports[`Page Component renders content block with permutations: {
         href="#top"
         role="button"
       >
-            
-              
-      
+                  
+        <span
+          class="ct-visually-hidden"
+        >
+          Return focus to the top of the page
+        </span>
+        
 
 
                                     
@@ -773,8 +780,7 @@ exports[`Page Component renders content block with permutations: {
         </svg>
         
 
-          
-      
+  
       </a>
       
 
@@ -897,9 +903,13 @@ exports[`Page Component renders content block with permutations: {
         href="#top"
         role="button"
       >
-            
-              
-      
+                  
+        <span
+          class="ct-visually-hidden"
+        >
+          Return focus to the top of the page
+        </span>
+        
 
 
                                     
@@ -922,8 +932,7 @@ exports[`Page Component renders content block with permutations: {
         </svg>
         
 
-          
-      
+  
       </a>
       
 
@@ -1046,9 +1055,13 @@ exports[`Page Component renders content block with permutations: {
         href="#top"
         role="button"
       >
-            
-              
-      
+                  
+        <span
+          class="ct-visually-hidden"
+        >
+          Return focus to the top of the page
+        </span>
+        
 
 
                                     
@@ -1071,8 +1084,7 @@ exports[`Page Component renders content block with permutations: {
         </svg>
         
 
-          
-      
+  
       </a>
       
 
@@ -1181,9 +1193,13 @@ exports[`Page Component renders content block with permutations: {
         href="#top"
         role="button"
       >
-            
-              
-      
+                  
+        <span
+          class="ct-visually-hidden"
+        >
+          Return focus to the top of the page
+        </span>
+        
 
 
                                     
@@ -1206,8 +1222,7 @@ exports[`Page Component renders content block with permutations: {
         </svg>
         
 
-          
-      
+  
       </a>
       
 
@@ -1279,9 +1294,13 @@ exports[`Page Component renders with custom theme and attributes 1`] = `
         href="#top"
         role="button"
       >
-            
-              
-      
+                  
+        <span
+          class="ct-visually-hidden"
+        >
+          Return focus to the top of the page
+        </span>
+        
 
 
                                     
@@ -1304,8 +1323,7 @@ exports[`Page Component renders with custom theme and attributes 1`] = `
         </svg>
         
 
-          
-      
+  
       </a>
       
 
@@ -1376,9 +1394,13 @@ exports[`Page Component renders with default values 1`] = `
         href="#top"
         role="button"
       >
-            
-              
-      
+                  
+        <span
+          class="ct-visually-hidden"
+        >
+          Return focus to the top of the page
+        </span>
+        
 
 
                                     
@@ -1401,8 +1423,7 @@ exports[`Page Component renders with default values 1`] = `
         </svg>
         
 
-          
-      
+  
       </a>
       
 
@@ -1474,9 +1495,13 @@ exports[`Page Component strips HTML tags from attributes 1`] = `
         href="#top"
         role="button"
       >
-            
-              
-      
+                  
+        <span
+          class="ct-visually-hidden"
+        >
+          Return focus to the top of the page
+        </span>
+        
 
 
                                     
@@ -1499,8 +1524,7 @@ exports[`Page Component strips HTML tags from attributes 1`] = `
         </svg>
         
 
-          
-      
+  
       </a>
       
 


### PR DESCRIPTION
https://github.com/civictheme/uikit/issues/359

## Checklist before requesting a review

- [x] I have formatted the subject to include the issue number
  as `[#123] Verb in past tense with a period at the end.`
- [x] I have provided information in the `Changed` section about WHY something was
  done if this was a bespoke implementation.
- [x] I have performed a self-review of my code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have run new and existing relevant tests locally with my changes,
  and they have passed.
- [x] I have provided screenshots, where applicable.

## Changed

1. Added visually hidden text to read out on back-to-top button.

## Screenshots
![Screenshot 2024-09-25 at 2 46 55 pm](https://github.com/user-attachments/assets/f2d2d328-5225-4149-80ea-de11b27d0a21)
