### PR TITLE
[#392] Fixed Content Link underline thickness.

### DIFF
--- a/components/00-base/mixins/_content-link.scss
+++ b/components/00-base/mixins/_content-link.scss
@@ -4,7 +4,7 @@
 
 @mixin ct-content-link-base() {
   text-decoration: underline;
-  text-decoration-thickness: ct-particle(0.25);
+  text-decoration-thickness: ct-particle(0.125);
   text-underline-offset: ct-particle(0.375);
   padding: ct-spacing(0.375) 0 ct-spacing(0.25);
   word-break: break-word;


### PR DESCRIPTION
In Figma, the underline is `1px`, but in UIKit it is erroneously `2px`.

<img width="588" alt="DrevOps_-_CivicTheme__Design_System_v1_8_0" src="https://github.com/user-attachments/assets/b3bb0bcb-672a-4ea7-855c-a508507299d6">


Before:

<img width="61" alt="Atoms___Content_Link_-_Content_Link_⋅_Storybook" src="https://github.com/user-attachments/assets/4d014243-ec4d-404c-8390-167eb5792fa7">


After:
<img width="79" alt="Atoms___Content_Link_-_Content_Link_⋅_Storybook" src="https://github.com/user-attachments/assets/c64ee4aa-3b12-4950-8b92-5b5fb5e8d06f">

