### PR TITLE
[#364] Added focus state for Back-to-Top link.

### DIFF
--- a/components/00-base/_variables.components.scss
+++ b/components/00-base/_variables.components.scss
@@ -683,7 +683,7 @@ $ct-back-to-top-space-right: ct-spacing(2) !default;
 $ct-back-to-top-background-color: ct-color-light('interaction-background') !default;
 $ct-back-to-top-border-color: $ct-back-to-top-background-color !default;
 $ct-back-to-top-color: ct-color-light('interaction-text') !default;
-$ct-back-to-top-outline-color: transparent !default;
+$ct-back-to-top-outline-color: ct-color-light('interaction-focus') !default;
 
 //
 // Basic content.


### PR DESCRIPTION
Closes #364 

UIKit already had a focus state, but it was set to transparent as per designs - the design does not have a focus state.


<img width="212" alt="Cursor_and_DrevOps_-_CivicTheme__Design_System_v1_8_0" src="https://github.com/user-attachments/assets/f34927e9-590e-4b01-80fc-557c22fb414d">
