### PR TITLE
Added `title` to Promo and Event card arrows.

### DIFF
--- a/components/02-molecules/event-card/__snapshots__/event-card.test.js.snap
+++ b/components/02-molecules/event-card/__snapshots__/event-card.test.js.snap
@@ -242,6 +242,7 @@ exports[`Event Card Component renders with optional attributes 1`] = `
           class="ct-link ct-theme-dark    ct-link--only-icon ct-event-card__tags__link"
           href="https://example.com"
           tabindex="-1"
+          title="Learn more"
         >
               
               

--- a/components/02-molecules/event-card/event-card.test.js
+++ b/components/02-molecules/event-card/event-card.test.js
@@ -31,7 +31,7 @@ describe('Event Card Component', () => {
       date: '2023-01-01 12:00',
       date_iso: '2023-01-01T12:00:00Z',
       location: 'Event Location',
-      link: { url: 'https://example.com' },
+      link: { text: 'Learn more', url: 'https://example.com' },
       tags: ['Tag 1', 'Tag 2'],
       theme: 'dark',
       attributes: 'data-test="true"',

--- a/components/02-molecules/event-card/event-card.twig
+++ b/components/02-molecules/event-card/event-card.twig
@@ -156,6 +156,7 @@
               {% include '@atoms/link/link.twig' with {
                 theme: theme,
                 url: link.url,
+                title: link.text,
                 is_new_window: link.is_new_window,
                 is_external: false,
                 icon: 'right-arrow-2',

--- a/components/02-molecules/promo-card/__snapshots__/promo-card.test.js.snap
+++ b/components/02-molecules/promo-card/__snapshots__/promo-card.test.js.snap
@@ -77,6 +77,7 @@ exports[`Promo Card Component renders with link when provided 1`] = `
           class="ct-link ct-theme-light    ct-link--only-icon ct-promo-card__tags__link"
           href="https://example.com"
           tabindex="-1"
+          title="Learn more"
         >
               
               
@@ -358,6 +359,7 @@ exports[`Promo Card Component renders with optional attributes 1`] = `
           href="https://example.com"
           tabindex="-1"
           target="_blank"
+          title="Learn more"
         >
               
               

--- a/components/02-molecules/promo-card/promo-card.twig
+++ b/components/02-molecules/promo-card/promo-card.twig
@@ -161,6 +161,7 @@
                 {% include '@atoms/link/link.twig' with {
                   theme: theme,
                   url: link.url,
+                  title: link.text,
                   is_new_window: link.is_new_window,
                   is_external: false,
                   icon: 'right-arrow-2',


### PR DESCRIPTION
Arrows on cards are reported as missing description by A11y tools.