### PR TITLE
Fixed skip link having no target when Banner is not on the page.

### DIFF
--- a/components/04-templates/page/__snapshots__/page.test.js.snap
+++ b/components/04-templates/page/__snapshots__/page.test.js.snap
@@ -263,12 +263,12 @@ exports[`Page Component renders all blocks with complex attributes and classes 1
     />
     
 
-      
+            
     <strong>
       Banner Content
     </strong>
     
-  
+      
             
     <div
       class="container"
@@ -658,8 +658,13 @@ exports[`Page Component renders content block with permutations: {
     />
     
 
+            
+    <a
+      id="main-content"
+      tabindex="-1"
+    />
+    
       
-  
   
       
 
@@ -821,8 +826,13 @@ exports[`Page Component renders content block with permutations: {
     />
     
 
+            
+    <a
+      id="main-content"
+      tabindex="-1"
+    />
+    
       
-  
   
       
 
@@ -970,8 +980,13 @@ exports[`Page Component renders content block with permutations: {
     />
     
 
+            
+    <a
+      id="main-content"
+      tabindex="-1"
+    />
+    
       
-  
   
       
 
@@ -1119,8 +1134,13 @@ exports[`Page Component renders content block with permutations: {
     />
     
 
+            
+    <a
+      id="main-content"
+      tabindex="-1"
+    />
+    
       
-  
   
       
 
@@ -1247,8 +1267,13 @@ exports[`Page Component renders with custom theme and attributes 1`] = `
     />
     
 
+            
+    <a
+      id="main-content"
+      tabindex="-1"
+    />
+    
       
-  
   
       
 
@@ -1344,8 +1369,13 @@ exports[`Page Component renders with default values 1`] = `
     />
     
 
+            
+    <a
+      id="main-content"
+      tabindex="-1"
+    />
+    
       
-  
   
       
 
@@ -1442,8 +1472,13 @@ exports[`Page Component strips HTML tags from attributes 1`] = `
     />
     
 
+            
+    <a
+      id="main-content"
+      tabindex="-1"
+    />
+    
       
-  
   
       
 

--- a/components/04-templates/page/page.twig
+++ b/components/04-templates/page/page.twig
@@ -34,7 +34,11 @@
   <a id="banner"></a>
 
   {% block banner %}
-    {{ banner|raw }}
+    {% if banner is not empty %}
+      {{ banner|raw }}
+    {% else %}
+      <a id="main-content" tabindex="-1"></a>
+    {% endif %}
   {% endblock %}
 
   {% if highlighted is not empty %}


### PR DESCRIPTION
this is a tricky one

The Skip link skips to the `main-content` anchor. This anchor is set within the Banner to allow including of the page heading into what is considered to be a "whole page content".

On the pages where the banner is not present (if a banner is replaced by another component, for example), the anchor is not rendered.

This PR adds the anchor on the page if the banner is not present.
