### PR TITLE
Added default border colour for Back-To-Top.

### DIFF
--- a/components/00-base/_variables.components.scss
+++ b/components/00-base/_variables.components.scss
@@ -681,7 +681,7 @@ $ct-attachment-dark-wrapper-background-color: ct-color-dark('background') !defau
 $ct-back-to-top-space-bottom: ct-spacing(8) !default;
 $ct-back-to-top-space-right: ct-spacing(2) !default;
 $ct-back-to-top-background-color: ct-color-light('interaction-background') !default;
-$ct-back-to-top-border-color: $ct-back-to-top-background-color !default;
+$ct-back-to-top-border-color: ct-color-light('background-light') !default;
 $ct-back-to-top-color: ct-color-light('interaction-text') !default;
 $ct-back-to-top-outline-color: transparent !default;
 


### PR DESCRIPTION
#322 added CSS var to set a border and defaulted the border to the colour of the button background to match the current designs.

<img width="212" alt="Cursor_and_DrevOps_-_CivicTheme__Design_System_v1_8_0" src="https://github.com/user-attachments/assets/6dab7b9b-2be8-4580-a433-7596d5c1b0ce">

But on the client sites there is almost always a need to set the border colour to make this component appear visually contrasting to the dark footer (where this component often appears).

This PR updates the default colour value used for the border to match the lightest background colour: this means that the border will not be visible on the light page content but will be in a contrast on footer.

<img width="190" alt="Homepage___Australian_Submarine_Agency" src="https://github.com/user-attachments/assets/85f6c417-c836-4c50-9c11-407ad2f1d0df">

