### PR TITLE
Add prefix and suffix variables to form elements.

### DIFF
--- a/components/01-atoms/fieldset/fieldset.twig
+++ b/components/01-atoms/fieldset/fieldset.twig
@@ -14,6 +14,8 @@
  * - is_required: [boolean] Denote if the fieldset is required. Optional.
  * - attributes: [string] Additional attributes for the fieldset. Optional.
  * - modifier_class: [string] Additional classes. Optional.
+ * - prefix: [string] The content to add before the fieldset children.
+ * - suffix: [string] The content to add after the fieldset children.
  */
 #}
 

--- a/components/02-molecules/field/__snapshots__/field.test.js.snap
+++ b/components/02-molecules/field/__snapshots__/field.test.js.snap
@@ -19,6 +19,7 @@ exports[`Field Component Field Component - empty title with textfield renders 0 
     >
       
 			
+			
 							
 
 	
@@ -29,6 +30,7 @@ exports[`Field Component Field Component - empty title with textfield renders 0 
       />
       
 
+			
 			
 					
     </div>
@@ -59,6 +61,7 @@ exports[`Field Component Field Component - hidden title with hidden input render
     >
       
 			
+			
 															
 
 	
@@ -68,6 +71,7 @@ exports[`Field Component Field Component - hidden title with hidden input render
         type="hidden"
       />
       
+			
 			
 					
     </div>
@@ -98,6 +102,7 @@ exports[`Field Component Field Component - hidden title with textfield renders 0
     >
       
 			
+			
 							
 
 	
@@ -108,6 +113,7 @@ exports[`Field Component Field Component - hidden title with textfield renders 0
       />
       
 
+			
 			
 					
     </div>
@@ -147,6 +153,7 @@ exports[`Field Component Field Component - invisible title with textfield render
     >
       
 			
+			
 							
 
 	
@@ -157,6 +164,7 @@ exports[`Field Component Field Component - invisible title with textfield render
       />
       
 
+			
 			
 					
     </div>
@@ -187,6 +195,7 @@ exports[`Field Component Field Component - visible title with hidden input rende
     >
       
 			
+			
 															
 
 	
@@ -196,6 +205,7 @@ exports[`Field Component Field Component - visible title with hidden input rende
         type="hidden"
       />
       
+			
 			
 					
     </div>
@@ -235,6 +245,7 @@ exports[`Field Component Field Component - visible title with textfield renders 
     >
       
 			
+			
 							
 
 	
@@ -245,6 +256,7 @@ exports[`Field Component Field Component - visible title with textfield renders 
       />
       
 
+			
 			
 					
     </div>
@@ -286,6 +298,7 @@ exports[`Field Component default input 1`] = `
     >
       
 			
+			
 															
 
 	
@@ -297,6 +310,7 @@ exports[`Field Component default input 1`] = `
         value="testvalue"
       />
       
+			
 			
 					
     </div>
@@ -327,6 +341,7 @@ exports[`Field Component default values 1`] = `
     >
       
 			
+			
 															
 
 	
@@ -336,6 +351,7 @@ exports[`Field Component default values 1`] = `
         type="hidden"
       />
       
+			
 			
 					
     </div>
@@ -374,6 +390,7 @@ exports[`Field Component multiple control as array propagation - checkbox 1`] = 
       class="ct-field__wrapper"
     >
       
+			
 			
 			
 																																								
@@ -447,6 +464,7 @@ exports[`Field Component multiple control as array propagation - checkbox 1`] = 
       
 
 			
+			
 					
     </div>
     
@@ -486,6 +504,7 @@ exports[`Field Component multiple control as array propagation - textfield 1`] =
     >
       
 			
+			
 							
 
 	
@@ -499,6 +518,7 @@ exports[`Field Component multiple control as array propagation - textfield 1`] =
       />
       
 
+			
 			
 					
     </div>
@@ -538,6 +558,7 @@ exports[`Field Component multiple control as array propagation with mixed levels
       class="ct-field__wrapper"
     >
       
+			
 			
 			
 																																								
@@ -609,6 +630,7 @@ exports[`Field Component multiple control as array propagation with mixed levels
       
 
 			
+			
 					
     </div>
     
@@ -657,6 +679,7 @@ exports[`Field Component radio 1`] = `
       class="ct-field__wrapper"
     >
       
+			
 			
 			
 																																								
@@ -730,6 +753,7 @@ exports[`Field Component radio 1`] = `
       
 
 			
+			
 					
     </div>
     
@@ -768,6 +792,7 @@ exports[`Field Component required, disabled, and description 1`] = `
     This is a description  
       </div>
       			
+			
 							
 
 	
@@ -780,6 +805,7 @@ exports[`Field Component required, disabled, and description 1`] = `
       />
       
 
+			
 			
 					
     </div>
@@ -821,6 +847,7 @@ exports[`Field Component select 1`] = `
     >
       
 			
+			
 							
 
 	
@@ -834,6 +861,7 @@ exports[`Field Component select 1`] = `
       </select>
       
 
+			
 			
 					
     </div>
@@ -874,6 +902,7 @@ exports[`Field Component single control as array propagation 1`] = `
     >
       
 			
+			
 							
 
 	
@@ -887,6 +916,7 @@ exports[`Field Component single control as array propagation 1`] = `
       />
       
 
+			
 			
 					
     </div>
@@ -927,6 +957,7 @@ exports[`Field Component single control as object propagation 1`] = `
     >
       
 			
+			
 							
 
 	
@@ -940,6 +971,7 @@ exports[`Field Component single control as object propagation 1`] = `
       />
       
 
+			
 			
 					
     </div>
@@ -981,6 +1013,7 @@ exports[`Field Component textarea with all attributes 1`] = `
     >
       
 			
+			
 							
 
   
@@ -994,6 +1027,7 @@ exports[`Field Component textarea with all attributes 1`] = `
       </textarea>
       
 
+			
 			
 							
 
@@ -1037,6 +1071,7 @@ exports[`Field Component textfield 1`] = `
     >
       
 			
+			
 							
 
 	
@@ -1049,6 +1084,7 @@ exports[`Field Component textfield 1`] = `
       />
       
 
+			
 			
 					
     </div>
@@ -1079,6 +1115,7 @@ exports[`Field Component theme, orientation, and invalid state 1`] = `
     >
       
 			
+			
 							
 
 	
@@ -1089,6 +1126,7 @@ exports[`Field Component theme, orientation, and invalid state 1`] = `
       />
       
 
+			
 			
 							
 
@@ -1121,6 +1159,7 @@ exports[`Field Component values 1`] = `
     >
       
 			
+			
 															
 
 	
@@ -1131,6 +1170,7 @@ exports[`Field Component values 1`] = `
         value="testvalue"
       />
       
+			
 			
 					
     </div>

--- a/components/02-molecules/field/field.twig
+++ b/components/02-molecules/field/field.twig
@@ -39,8 +39,8 @@
  *   - modifier_class: [string] Control additional classes. Optional.
  * - attributes: [string] Additional attributes. Optional.
  * - modifier_class: [string] Additional classes. Optional.
- * - prefix: [string] The content to add before the fieldset children.
- * - suffix: [string] The content to add after the fieldset children.
+ * - prefix: [string] The content to add before the field.
+ * - suffix: [string] The content to add after the field.
  */
 #}
 

--- a/components/02-molecules/field/field.twig
+++ b/components/02-molecules/field/field.twig
@@ -39,6 +39,8 @@
  *   - modifier_class: [string] Control additional classes. Optional.
  * - attributes: [string] Additional attributes. Optional.
  * - modifier_class: [string] Additional classes. Optional.
+ * - prefix: [string] The content to add before the fieldset children.
+ * - suffix: [string] The content to add after the fieldset children.
  */
 #}
 
@@ -108,6 +110,10 @@
 				} only %}
 			{% endif %}
 
+			{% if prefix is not empty %}
+				<div class="ct-field__prefix">{{- prefix|raw -}}</div>
+			{% endif %}
+
 			{% if type == 'textfield' %}
 				{% include '@atoms/textfield/textfield.twig' with control[0] only %}
 
@@ -139,6 +145,10 @@
 				{% set control0 = control[0] %}
 				{% set control0 = control0|merge({'type': type}) %}
 				{% include '@atoms/input/input.twig' with control0 only %}
+			{% endif %}
+
+			{% if suffix is not empty %}
+				<div class="ct-field__suffix">{{- suffix|raw -}}</div>
 			{% endif %}
 
 			{% if (message or is_invalid) and type != 'hidden' %}

--- a/components/02-molecules/pagination/__snapshots__/pagination.test.js.snap
+++ b/components/02-molecules/pagination/__snapshots__/pagination.test.js.snap
@@ -302,6 +302,7 @@ exports[`Pagination Component renders with optional attributes 1`] = `
         >
           
 			
+			
 							
 
 	
@@ -336,6 +337,7 @@ exports[`Pagination Component renders with optional attributes 1`] = `
           </select>
           
 
+			
 			
 					
         </div>


### PR DESCRIPTION
https://github.com/civictheme/monorepo-drupal/pull/1306

## Checklist before requesting a review

- [ ] I have formatted the subject to include the issue number
  as `[#123] Verb in past tense with a period at the end.`
- [ ] I have provided information in the `Changed` section about WHY something was
  done if this was a bespoke implementation.
- [ ] I have performed a self-review of my code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have run new and existing relevant tests locally with my changes,
  and they have passed.
- [ ] I have provided screenshots, where applicable.

## Changed

1. Added fix to support Form element prefix & suffix.

## Screenshots
