### PR TITLE
[#356] WCAG 4.1.3 AA: Success message not announced by screen readers (Issue 37)

### DIFF
--- a/components/03-organisms/message/__snapshots__/message.test.js.snap
+++ b/components/03-organisms/message/__snapshots__/message.test.js.snap
@@ -9,6 +9,7 @@ exports[`Message Component does not render when description and title are empty 
 
   <div
     aria-label="warning"
+    aria-live="assertive"
     class="ct-message ct-theme-light ct-message--warning "
     role="contentinfo"
   >
@@ -146,6 +147,7 @@ exports[`Message Component renders with default type and theme 1`] = `
 
   <div
     aria-label="information"
+    aria-live="assertive"
     class="ct-message ct-theme-light ct-message--information "
     role="contentinfo"
   >
@@ -214,6 +216,7 @@ exports[`Message Component renders without description 1`] = `
 
   <div
     aria-label="success"
+    aria-live="assertive"
     class="ct-message ct-theme-light ct-message--success additional-class"
     role="contentinfo"
   >

--- a/components/03-organisms/message/message.test.js
+++ b/components/03-organisms/message/message.test.js
@@ -35,7 +35,7 @@ describe('Message Component', () => {
     expect(c.querySelector('.ct-message__summary').textContent.trim()).toBe('This is a default message.');
     expect(c.querySelector('.ct-message').getAttribute('role')).toBe('contentinfo');
     expect(c.querySelector('.ct-message').getAttribute('aria-label')).toBe('information');
-    expect(c.querySelector('.ct-message').getAttribute('aria-live')).toBeNull();
+    expect(c.querySelector('.ct-message').getAttribute('aria-live')).toBe('assertive');
 
     assertUniqueCssClasses(c);
   });
@@ -55,7 +55,7 @@ describe('Message Component', () => {
     expect(c.querySelector('.ct-message__summary')).toBeNull();
     expect(c.querySelector('.ct-message').getAttribute('role')).toBe('contentinfo');
     expect(c.querySelector('.ct-message').getAttribute('aria-label')).toBe('success');
-    expect(c.querySelector('.ct-message').getAttribute('aria-live')).toBeNull();
+    expect(c.querySelector('.ct-message').getAttribute('aria-live')).toBe('assertive');
 
     assertUniqueCssClasses(c);
   });

--- a/components/03-organisms/message/message.twig
+++ b/components/03-organisms/message/message.twig
@@ -27,7 +27,7 @@
   class="ct-message {{ modifier_class -}}"
   role="{% if type == 'error' %}alert{% else %}contentinfo{% endif %}"
   aria-label="{{ type }}"
-  {% if type == 'error' %}aria-live="polite"{% endif %}
+  {% if type == 'error' %}aria-live="polite"{% else %}aria-live="assertive"{% endif %}
   {% if attributes is not empty %}{{- attributes|raw -}}{% endif %}
 >
   {% if icons[type] is defined %}


### PR DESCRIPTION
Closes https://github.com/civictheme/uikit/issues/356

## Checklist before requesting a review

- [x] I have formatted the subject to include the issue number
  as `[#123] Verb in past tense with a period at the end.`
- [x] I have provided information in the `Changed` section about WHY something was
  done if this was a bespoke implementation.
- [x] I have performed a self-review of my code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have run new and existing relevant tests locally with my changes,
  and they have passed.
- [ ] I have provided screenshots, where applicable.

## Changed

1. Add the aria-live="assertive" attribute to the < div > element that contains the status message.

## Screenshots
