### PR TITLE
[#436] Removed aria-label from link with 'is_new_window'.

### DIFF
--- a/components/01-atoms/link/__snapshots__/link.test.js.snap
+++ b/components/01-atoms/link/__snapshots__/link.test.js.snap
@@ -17,7 +17,6 @@ exports[`Link Component renders with optional attributes, is external 1`] = `
   
   
   <a
-    aria-label="Opens in a new tab"
     class="ct-link ct-theme-dark ct-link--external ct-link--active ct-link--disabled  custom-class"
     data-test="true"
     disabled=""
@@ -114,7 +113,6 @@ exports[`Link Component renders with optional attributes, not external 1`] = `
   
   
   <a
-    aria-label="Opens in a new tab"
     class="ct-link ct-theme-dark  ct-link--active ct-link--disabled  custom-class"
     data-test="true"
     disabled=""

--- a/components/01-atoms/link/link.test.js
+++ b/components/01-atoms/link/link.test.js
@@ -36,7 +36,7 @@ describe('Link Component', () => {
     expect(c.querySelector('.ct-link').getAttribute('href')).toEqual('https://example.com');
     expect(c.querySelector('.ct-link').getAttribute('title')).toEqual('Example Title');
     expect(c.querySelector('.ct-link').getAttribute('target')).toEqual('_blank');
-    expect(c.querySelector('.ct-link').getAttribute('aria-label')).toEqual('Opens in a new tab');
+    expect(c.querySelector('.ct-link').textContent).toContain('(Opens in a new tab/window)');
     expect(c.querySelector('.ct-link').getAttribute('data-test')).toEqual('true');
     expect(c.querySelectorAll('.ct-link .ct-link__icon')).toHaveLength(1);
 
@@ -64,7 +64,7 @@ describe('Link Component', () => {
     expect(c.querySelector('.ct-link').getAttribute('href')).toEqual('https://example.com');
     expect(c.querySelector('.ct-link').getAttribute('title')).toEqual('Example Title');
     expect(c.querySelector('.ct-link').getAttribute('target')).toEqual('_blank');
-    expect(c.querySelector('.ct-link').getAttribute('aria-label')).toEqual('Opens in a new tab');
+    expect(c.querySelector('.ct-link').textContent).toContain('(Opens in a new tab/window)');
     expect(c.querySelector('.ct-link').getAttribute('data-test')).toEqual('true');
     expect(c.querySelectorAll('.ct-link .ct-link__icon')).toHaveLength(1);
 

--- a/components/01-atoms/link/link.twig
+++ b/components/01-atoms/link/link.twig
@@ -50,7 +50,7 @@
     class="ct-link {{ modifier_class -}}"
     {% if url is not empty %}href="{{ url }}"{% endif %}
     {% if title is not empty %}title="{{ title }}"{% endif %}
-    {% if is_new_window %}target="_blank" aria-label="Opens in a new tab"{% endif %}
+    {% if is_new_window %}target="_blank"{% endif %}
     {% if is_disabled %}disabled{% endif %}
     {% if attributes is not empty %}{{- attributes|raw -}}{% endif %}
   >

--- a/components/01-atoms/popover/__snapshots__/popover.test.js.snap
+++ b/components/01-atoms/popover/__snapshots__/popover.test.js.snap
@@ -28,7 +28,6 @@ exports[`Popover Component renders with optional attributes 1`] = `
   
   
     <a
-      aria-label="Opens in a new tab"
       class="ct-link ct-theme-dark     ct-popover__link"
       data-collapsible-trigger=""
       href="https://example.com"

--- a/components/02-molecules/navigation-card/__snapshots__/navigation-card.test.js.snap
+++ b/components/02-molecules/navigation-card/__snapshots__/navigation-card.test.js.snap
@@ -242,7 +242,6 @@ exports[`Navigation Card Component renders with optional attributes, no icon, im
   
   
         <a
-          aria-label="Opens in a new tab"
           class="ct-link ct-theme-dark     ct-navigation-card__title__link"
           href="https://example.com"
           target="_blank"
@@ -420,7 +419,6 @@ exports[`Navigation Card Component renders with optional attributes, with icon 1
   
   
         <a
-          aria-label="Opens in a new tab"
           class="ct-link ct-theme-dark     ct-navigation-card__title__link"
           href="https://example.com"
           target="_blank"

--- a/components/02-molecules/next-step/__snapshots__/next-step.test.js.snap
+++ b/components/02-molecules/next-step/__snapshots__/next-step.test.js.snap
@@ -197,7 +197,6 @@ exports[`Next Steps Component renders with optional attributes 1`] = `
   
   
                 <a
-                  aria-label="Opens in a new tab"
                   class="ct-link ct-theme-dark ct-link--external    ct-next-step__title__link"
                   href="https://example.com"
                   target="_blank"

--- a/components/02-molecules/promo-card/__snapshots__/promo-card.test.js.snap
+++ b/components/02-molecules/promo-card/__snapshots__/promo-card.test.js.snap
@@ -249,7 +249,6 @@ exports[`Promo Card Component renders with optional attributes 1`] = `
   
   
         <a
-          aria-label="Opens in a new tab"
           class="ct-link ct-theme-dark     ct-promo-card__title__link"
           href="https://example.com"
           target="_blank"
@@ -359,7 +358,6 @@ exports[`Promo Card Component renders with optional attributes 1`] = `
   
         <a
           aria-hidden="true"
-          aria-label="Opens in a new tab"
           class="ct-link ct-theme-dark    ct-link--only-icon ct-promo-card__tags__link"
           href="https://example.com"
           tabindex="-1"

--- a/components/02-molecules/service-card/__snapshots__/service-card.test.js.snap
+++ b/components/02-molecules/service-card/__snapshots__/service-card.test.js.snap
@@ -162,7 +162,6 @@ exports[`Service Card Component renders with optional attributes 1`] = `
   
   
           <a
-            aria-label="Opens in a new tab"
             class="ct-link ct-theme-dark ct-link--external"
             href="https://example.com/link1"
             target="_blank"

--- a/components/02-molecules/snippet/__snapshots__/snippet.test.js.snap
+++ b/components/02-molecules/snippet/__snapshots__/snippet.test.js.snap
@@ -229,7 +229,6 @@ exports[`Snippet Component renders with optional attributes 1`] = `
   
   
         <a
-          aria-label="Opens in a new tab"
           class="ct-link ct-theme-dark     ct-snippet__title__link"
           href="https://example.com/read-more"
           target="_blank"

--- a/components/02-molecules/subject-card/__snapshots__/subject-card.test.js.snap
+++ b/components/02-molecules/subject-card/__snapshots__/subject-card.test.js.snap
@@ -180,7 +180,6 @@ exports[`Subject Card Component renders with optional attributes 1`] = `
   
   
         <a
-          aria-label="Opens in a new tab"
           class="ct-link ct-theme-dark     ct-subject-card__title__link"
           href="https://example.com/read-more"
           target="_blank"


### PR DESCRIPTION
https://github.com/civictheme/uikit/issues/436

## Checklist before requesting a review

- [x] I have formatted the subject to include the issue number
  as `[#123] Verb in past tense with a period at the end.`
- [x] I have provided information in the `Changed` section about WHY something was
  done if this was a bespoke implementation.
- [x] I have performed a self-review of my code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have run new and existing relevant tests locally with my changes,
  and they have passed.
- [x] I have provided screenshots, where applicable.

## Changed

1. Removed aria-label from link with 'is_new_window'. See issue for reasoning.

## Screenshots
![Screenshot 2024-12-01 at 11 03 18 am](https://github.com/user-attachments/assets/a0602de6-80c8-4ed9-85b9-029a3fae2817)
