### PR TITLE
[#425] Group last word and icon in collapsible script.

### DIFF
--- a/components/00-base/collapsible/collapsible.js
+++ b/components/00-base/collapsible/collapsible.js
@@ -35,6 +35,7 @@ function CivicThemeCollapsible(el) {
   this.duration = this.el.hasAttribute('data-collapsible-duration') ? this.el.getAttribute('data-collapsible-duration') : 500;
   this.group = this.el.hasAttribute('data-collapsible-group') ? this.el.getAttribute('data-collapsible-group') : null;
   this.icon = '<svg class="ct-icon" width="24" height="24" aria-hidden="true" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path d="M18.6072 8.38619C18.3583 8.13884 18.0217 8 17.6709 8C17.32 8 16.9834 8.13884 16.7346 8.38619L11.9668 13.0876L7.26542 8.38619C7.01659 8.13884 6.67999 8 6.32913 8C5.97827 8 5.64167 8.13884 5.39284 8.38619C5.26836 8.50965 5.16956 8.65654 5.10214 8.81838C5.03471 8.98022 5 9.1538 5 9.32912C5 9.50445 5.03471 9.67803 5.10214 9.83987C5.16956 10.0017 5.26836 10.1486 5.39284 10.2721L11.0239 15.9031C11.1473 16.0276 11.2942 16.1264 11.4561 16.1938C11.6179 16.2612 11.7915 16.2959 11.9668 16.2959C12.1421 16.2959 12.3157 16.2612 12.4775 16.1938C12.6394 16.1264 12.7863 16.0276 12.9097 15.9031L18.6072 10.2721C18.7316 10.1486 18.8304 10.0017 18.8979 9.83987C18.9653 9.67803 19 9.50445 19 9.32912C19 9.1538 18.9653 8.98022 18.8979 8.81838C18.8304 8.65654 18.7316 8.50965 18.6072 8.38619Z" /></svg>';
+  this.iconGroupEnabled = this.el.hasAttribute('data-collapsible-icon-group');
 
   // Make sure that both trigger and a panel have required attributes set.
   this.trigger.setAttribute('data-collapsible-trigger', '');
@@ -43,7 +44,19 @@ function CivicThemeCollapsible(el) {
   if (!this.panel.hasAttribute('data-collapsible-trigger-no-icon') && !this.trigger.querySelector('.ct-collapsible__icon')) {
     const iconEl = this.htmlToElement(this.icon);
     iconEl.classList.add('ct-collapsible__icon');
-    this.trigger.append(iconEl);
+    // If multiple words - use last word and icon grouping.
+    if (this.iconGroupEnabled) {
+      const text = this.trigger.innerText.trim();
+      const lastWordIndex = text.lastIndexOf(' ');
+      const lastWord = lastWordIndex >= 0 ? text.substring(lastWordIndex + 1) : text;
+      const firstWords = lastWordIndex >= 0 ? text.substring(0, lastWordIndex + 1) : '';
+      const iconGroupEl = this.htmlToElement(`<span class="ct-text-icon__group">${lastWord} </span>`);
+      iconGroupEl.append(iconEl);
+      this.trigger.innerHTML = firstWords;
+      this.trigger.append(iconGroupEl);
+    } else {
+      this.trigger.append(iconEl);
+    }
   }
 
   // Attach event listener.

--- a/components/00-base/collapsible/collapsible.stories.twig
+++ b/components/00-base/collapsible/collapsible.stories.twig
@@ -134,11 +134,28 @@
 <div class="story-container">
   <div class="story-container__title">No trigger icon</div>
 
-  <div data-collapsible data-collapsible-trigger-no-icon>
-    <div>
+  <div data-collapsible>
+    <div data-collapsible-trigger>
       TRIGGER (click me)
     </div>
-    <div>
+    <div data-collapsible-panel data-collapsible-trigger-no-icon>
+      Collapsible demo panel Lorem ipsum dolor sit amet, consectetur adipisicing
+      elit. Consectetur harum magnam modi obcaecati vitae voluptatibus!
+      Accusamus
+      atque deleniti, distinctio esse facere, nam odio officiis omnis porro
+      quibusdam quis repudiandae veritatis.
+    </div>
+  </div>
+</div>
+
+<div class="story-container">
+  <div class="story-container__title">Trigger icon which wraps with last word</div>
+
+  <div data-collapsible data-collapsible-icon-group>
+    <div data-collapsible-trigger>
+      TRIGGER with long text Lorem ipsum est in labore do laboris dolor dolor labore labore do dolor adipisicing.
+    </div>
+    <div data-collapsible-panel>
       Collapsible demo panel Lorem ipsum dolor sit amet, consectetur adipisicing
       elit. Consectetur harum magnam modi obcaecati vitae voluptatibus!
       Accusamus

--- a/components/00-base/collapsible/collapsible.test.js
+++ b/components/00-base/collapsible/collapsible.test.js
@@ -1,12 +1,45 @@
 describe('Collapsible utility', () => {
-
-  beforeEach(() => {
+  beforeAll(() => {
     // jsdom doesn't support innerText by default.
     // https://github.com/jsdom/jsdom/issues/1245
     Object.defineProperty(HTMLDivElement.prototype, 'innerText', {
-      get: function() { return this.textContent; },
-      set: function(value) { this.textContent = value; }
+      get() {
+        return this.textContent;
+      },
+      set(value) {
+        this.textContent = value;
+      },
     });
+  });
+
+  beforeEach(() => {
+    jest.resetModules();
+  });
+
+  test('Clicking trigger when closed expands the panel', async () => {
+    document.body.innerHTML = `
+      <div data-collapsible data-collapsible-collapsed data-collapsible-duration="0">
+        <div data-collapsible-trigger>
+          My trigger
+        </div>
+        <div data-collapsible-panel>
+          My panel
+        </div>
+      </div>
+    `;
+
+    // eslint-disable-next-line global-require
+    require('./collapsible');
+
+    document.querySelector('[data-collapsible-trigger]').click();
+
+    expect(document.querySelector('[data-collapsible-trigger]').getAttribute('aria-expanded')).toEqual('true');
+    expect(document.querySelector('[data-collapsible-panel]').getAttribute('aria-hidden')).toEqual('false');
+
+    document.querySelector('[data-collapsible-trigger]').click();
+
+    expect(document.querySelector('[data-collapsible-trigger]').getAttribute('aria-expanded')).toEqual('false');
+    expect(document.querySelector('[data-collapsible-panel]').getAttribute('aria-hidden')).toEqual('true');
   });
 
   test('Renders icons when using icon group', async () => {
@@ -21,7 +54,8 @@ describe('Collapsible utility', () => {
       </div>
     `;
 
-    require('./collapsible.js');
+    // eslint-disable-next-line global-require
+    require('./collapsible');
 
     expect(document.querySelectorAll('[data-collapsible-trigger] .ct-text-icon__group')).toHaveLength(1);
     expect(document.querySelector('[data-collapsible-trigger] .ct-text-icon__group').textContent.trim()).toEqual('trigger');

--- a/components/00-base/collapsible/collapsible.test.js
+++ b/components/00-base/collapsible/collapsible.test.js
@@ -1,0 +1,29 @@
+describe('Collapsible utility', () => {
+
+  beforeEach(() => {
+    // jsdom doesn't support innerText by default.
+    // https://github.com/jsdom/jsdom/issues/1245
+    Object.defineProperty(HTMLDivElement.prototype, 'innerText', {
+      get: function() { return this.textContent; },
+      set: function(value) { this.textContent = value; }
+    });
+  });
+
+  test('Renders icons when using icon group', async () => {
+    document.body.innerHTML = `
+      <div data-collapsible data-collapsible-icon-group>
+        <div data-collapsible-trigger>
+          My trigger
+        </div>
+        <div data-collapsible-panel>
+          My panel
+        </div>
+      </div>
+    `;
+
+    require('./collapsible.js');
+
+    expect(document.querySelectorAll('[data-collapsible-trigger] .ct-text-icon__group')).toHaveLength(1);
+    expect(document.querySelector('[data-collapsible-trigger] .ct-text-icon__group').textContent.trim()).toEqual('trigger');
+  });
+});

--- a/components/03-organisms/navigation/__snapshots__/navigation.test.js.snap
+++ b/components/03-organisms/navigation/__snapshots__/navigation.test.js.snap
@@ -54,6 +54,7 @@ exports[`Navigation Component renders correctly when items have submenus 1`] = `
           data-collapsible-collapsed=""
           data-collapsible-duration="250"
           data-collapsible-group="main-nav"
+          data-collapsible-icon-group=""
         >
           
 
@@ -135,6 +136,7 @@ exports[`Navigation Component renders correctly when items have submenus 1`] = `
           data-collapsible-collapsed=""
           data-collapsible-duration="250"
           data-collapsible-group="main-nav"
+          data-collapsible-icon-group=""
         >
           
 

--- a/components/03-organisms/navigation/navigation.twig
+++ b/components/03-organisms/navigation/navigation.twig
@@ -28,7 +28,7 @@
     {% for key in items|keys %}
       {% if items[key].below %}
         {# Item attributes to convert them into a collapsible element. #}
-        {% set item_attributes = 'data-collapsible data-collapsible-collapsed data-collapsible-group=' ~ menu_id ~ ' ' ~ (is_animated ? 'data-collapsible-duration=250' : 'data-collapsible-duration=0') %}
+        {% set item_attributes = 'data-collapsible data-collapsible-collapsed data-collapsible-icon-group data-collapsible-group=' ~ menu_id ~ ' ' ~ (is_animated ? 'data-collapsible-duration=250' : 'data-collapsible-duration=0') %}
 
         {% if type == 'drawer' %}
           {# Item classes to style dynamically. #}


### PR DESCRIPTION
https://github.com/civictheme/uikit/issues/425

## Checklist before requesting a review

- [x] I have formatted the subject to include the issue number
  as `[#123] Verb in past tense with a period at the end.`
- [x] I have provided information in the `Changed` section about WHY something was
  done if this was a bespoke implementation.
- [x] I have performed a self-review of my code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have run new and existing relevant tests locally with my changes,
  and they have passed.
- [x] I have provided screenshots, where applicable.

## Changed

1. While links now use text-icon to group the last word with the icon to allow for both to wrap together, this does not happen on the menu because the icon is added through javascript, and not through the twig template. This change adds wrapping when the `data-collapsible-icon-group` attribute is applied to a collapsible element.

## Screenshots
![Screenshot 2024-12-02 at 2 24 12 pm](https://github.com/user-attachments/assets/b446ae80-8b52-4ae5-b2c2-0fd2dfdf1056)
