### PR TITLE
[#356] Updated aria-live for error message to assertive.

### DIFF
--- a/components/03-organisms/message/__snapshots__/message.test.js.snap
+++ b/components/03-organisms/message/__snapshots__/message.test.js.snap
@@ -71,7 +71,7 @@ exports[`Message Component renders with all attributes provided 1`] = `
 
   <div
     aria-label="error"
-    aria-live="polite"
+    aria-live="assertive"
     class="ct-message ct-theme-dark ct-message--error additional-class"
     role="alert"
   >

--- a/components/03-organisms/message/message.test.js
+++ b/components/03-organisms/message/message.test.js
@@ -18,7 +18,7 @@ describe('Message Component', () => {
     expect(c.querySelector('.ct-message__summary').textContent.trim()).toBe('This is an error message.');
     expect(c.querySelector('.ct-message').getAttribute('role')).toBe('alert');
     expect(c.querySelector('.ct-message').getAttribute('aria-label')).toBe('error');
-    expect(c.querySelector('.ct-message').getAttribute('aria-live')).toBe('polite');
+    expect(c.querySelector('.ct-message').getAttribute('aria-live')).toBe('assertive');
 
     assertUniqueCssClasses(c);
   });

--- a/components/03-organisms/message/message.twig
+++ b/components/03-organisms/message/message.twig
@@ -27,7 +27,7 @@
   class="ct-message {{ modifier_class -}}"
   role="{% if type == 'error' %}alert{% else %}contentinfo{% endif %}"
   aria-label="{{ type }}"
-  {% if type == 'error' %}aria-live="polite"{% else %}aria-live="assertive"{% endif %}
+  aria-live="assertive"
   {% if attributes is not empty %}{{- attributes|raw -}}{% endif %}
 >
   {% if icons[type] is defined %}


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have formatted the subject to include the issue number
  as `[#123] Verb in past tense with a period at the end.`
- [x] I have provided information in the `Changed` section about WHY something was
  done if this was a bespoke implementation.
- [x] I have performed a self-review of my code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have run new and existing relevant tests locally with my changes,
  and they have passed.
- [x] I have provided screenshots, where applicable.

## Changed

1. Updated `aria-live` for error message to `assertive`.

## Screenshots
![Screenshot 2025-01-17 at 3 15 14 pm](https://github.com/user-attachments/assets/f920ddbf-e418-47ac-8d8d-db033a720700)

