### PR TITLE
[#355] Fixed issue WCAG: Skip link targets empty anchor element (Issue A1)

### DIFF
--- a/components/00-base/layout/__snapshots__/layout.test.js.snap
+++ b/components/00-base/layout/__snapshots__/layout.test.js.snap
@@ -11,7 +11,9 @@ exports[`Layout Component hides sidebars when specified - contained 1`] = `
 	
   <main
     class="ct-layout ct-layout--no-sidebar-left ct-layout--no-sidebar-right ct-layout--no-top-left ct-layout--no-top-right ct-layout--no-bottom-left ct-layout--no-bottom-right"
+    id="main-content"
     role="main"
+    tabindex="-1"
   >
     
 							
@@ -53,7 +55,9 @@ exports[`Layout Component hides sidebars when specified 1`] = `
 	
   <main
     class="ct-layout ct-layout--no-sidebar-left ct-layout--no-sidebar-right ct-layout--no-top-left ct-layout--no-top-right ct-layout--no-bottom-left ct-layout--no-bottom-right"
+    id="main-content"
     role="main"
+    tabindex="-1"
   >
     
 							
@@ -95,7 +99,9 @@ exports[`Layout Component only main - contained 1`] = `
 	
   <main
     class="ct-layout ct-layout--no-top-left ct-layout--no-top-right ct-layout--no-bottom-left ct-layout--no-bottom-right"
+    id="main-content"
     role="main"
+    tabindex="-1"
   >
     
 							
@@ -137,7 +143,9 @@ exports[`Layout Component only main - not contained 1`] = `
 	
   <main
     class="ct-layout ct-layout--no-top-left ct-layout--no-top-right ct-layout--no-bottom-left ct-layout--no-bottom-right"
+    id="main-content"
     role="main"
+    tabindex="-1"
   >
     
 							
@@ -179,7 +187,9 @@ exports[`Layout Component renders with all sidebars and content sections 1`] = `
 	
   <main
     class="ct-layout ct-vertical-spacing--top"
+    id="main-content"
     role="main"
+    tabindex="-1"
   >
     
 					Top content		
@@ -250,7 +260,9 @@ exports[`Layout Component renders with custom attributes and classes 1`] = `
   <main
     class="ct-layout ct-layout--no-top-left ct-layout--no-top-right ct-layout--no-bottom-left ct-layout--no-bottom-right  custom-modifier"
     data-test="true"
+    id="main-content"
     role="main"
+    tabindex="-1"
   >
     
 							
@@ -292,7 +304,9 @@ exports[`Layout Component renders with default values 1`] = `
 	
   <main
     class="ct-layout ct-layout--no-top-left ct-layout--no-top-right ct-layout--no-bottom-left ct-layout--no-bottom-right"
+    id="main-content"
     role="main"
+    tabindex="-1"
   >
     
 							
@@ -334,7 +348,9 @@ exports[`Layout Component renders with sidebar bottom left 1`] = `
 	
   <main
     class="ct-layout ct-layout--no-top-left ct-layout--no-top-right  ct-layout--no-bottom-right ct-vertical-spacing--top"
+    id="main-content"
     role="main"
+    tabindex="-1"
   >
     
 							
@@ -383,7 +399,9 @@ exports[`Layout Component renders with sidebar bottom right 1`] = `
 	
   <main
     class="ct-layout ct-layout--no-top-left ct-layout--no-top-right ct-layout--no-bottom-left  ct-vertical-spacing--top"
+    id="main-content"
     role="main"
+    tabindex="-1"
   >
     
 							
@@ -432,7 +450,9 @@ exports[`Layout Component renders with sidebar top left 1`] = `
 	
   <main
     class="ct-layout ct-layout--no-top-right ct-layout--no-bottom-left ct-layout--no-bottom-right ct-vertical-spacing--top"
+    id="main-content"
     role="main"
+    tabindex="-1"
   >
     
 							
@@ -481,7 +501,9 @@ exports[`Layout Component renders with sidebar top right 1`] = `
 	
   <main
     class="ct-layout ct-layout--no-top-left  ct-layout--no-bottom-left ct-layout--no-bottom-right ct-vertical-spacing--top"
+    id="main-content"
     role="main"
+    tabindex="-1"
   >
     
 							

--- a/components/00-base/layout/layout.twig
+++ b/components/00-base/layout/layout.twig
@@ -46,7 +46,7 @@
 {% set modifier_class = modifier_class|trim %}
 
 {% if content %}
-	<main class="ct-layout {{ modifier_class -}}" role="main" {% if attributes is not empty %}{{- attributes|raw -}}{% endif %}>
+	<main id="main-content" tabindex="-1" class="ct-layout {{ modifier_class -}}" role="main" {% if attributes is not empty %}{{- attributes|raw -}}{% endif %}>
 		{% block content_top %}
 			{% if content_top is not empty %}
 				{{- content_top|raw -}}

--- a/components/03-organisms/banner/__snapshots__/banner.test.js.snap
+++ b/components/03-organisms/banner/__snapshots__/banner.test.js.snap
@@ -289,13 +289,6 @@ exports[`Banner Component renders with all attributes provided 1`] = `
           </div>
           
           
-          
-          <a
-            id="main-content"
-            tabindex="-1"
-          />
-          
-
                       
           <div
             class="row"
@@ -520,13 +513,6 @@ exports[`Banner Component renders with only required attributes 1`] = `
           
           
           
-          <a
-            id="main-content"
-            tabindex="-1"
-          />
-          
-
-          
                       
           <div
             class="row"
@@ -603,13 +589,6 @@ exports[`Banner Component renders without additional attributes and classes 1`] 
           
           
           
-          
-          <a
-            id="main-content"
-            tabindex="-1"
-          />
-          
-
           
                       
           <div

--- a/components/03-organisms/banner/banner.twig
+++ b/components/03-organisms/banner/banner.twig
@@ -96,8 +96,6 @@
             </div>
           {% endif %}
 
-          <a id="main-content" tabindex="-1"></a>
-
           {% if site_section is not empty %}
             <div class="row">
               {%- block site_section %}

--- a/components/03-organisms/footer/footer.twig
+++ b/components/03-organisms/footer/footer.twig
@@ -97,7 +97,7 @@
           {% endif %}
 
           {% if content_middle5 is not empty %}
-            {%- block content_middle4 %}
+            {%- block content_middle5 %}
               <div class="col-xxs-12">
                 <div class="ct-footer__middle__content-middle5">
                   {{- content_middle5|raw -}}

--- a/components/03-organisms/side-navigation/__snapshots__/side-navigation.test.js.snap
+++ b/components/03-organisms/side-navigation/__snapshots__/side-navigation.test.js.snap
@@ -18,32 +18,6 @@ exports[`Side Navigation Component renders with all attributes provided 1`] = `
     data-test="true"
   >
     
-    
-
-
-  
-    <div
-      class="ct-skip-link ct-theme-dark "
-    >
-      
-    
-
-
-  
-  
-      <a
-        class="ct-link ct-theme-dark     ct-skip-link__link ct-visually-hidden ct-focusable"
-        href="#main-content"
-        title="Skip to main content"
-      >
-        
-
-    Skip to main content  
-      </a>
-      
-  
-    </div>
-    
                   
 
 
@@ -216,32 +190,6 @@ exports[`Side Navigation Component renders with only required attributes 1`] = `
     class="ct-side-navigation ct-theme-light  "
   >
     
-    
-
-
-  
-    <div
-      class="ct-skip-link ct-theme-light "
-    >
-      
-    
-
-
-  
-  
-      <a
-        class="ct-link ct-theme-light     ct-skip-link__link ct-visually-hidden ct-focusable"
-        href="#main-content"
-        title="Skip to main content"
-      >
-        
-
-    Skip to main content  
-      </a>
-      
-  
-    </div>
-    
         
 
 
@@ -307,32 +255,6 @@ exports[`Side Navigation Component renders with some attributes missing 1`] = `
   <div
     class="ct-side-navigation ct-theme-light  "
   >
-    
-    
-
-
-  
-    <div
-      class="ct-skip-link ct-theme-light "
-    >
-      
-    
-
-
-  
-  
-      <a
-        class="ct-link ct-theme-light     ct-skip-link__link ct-visually-hidden ct-focusable"
-        href="#main-content"
-        title="Skip to main content"
-      >
-        
-
-    Skip to main content  
-      </a>
-      
-  
-    </div>
     
         
 

--- a/components/03-organisms/side-navigation/side-navigation.twig
+++ b/components/03-organisms/side-navigation/side-navigation.twig
@@ -19,10 +19,6 @@
 
 {% if items is not empty %}
   <div class="ct-side-navigation {{ modifier_class -}}" {% if attributes is not empty %}{{- attributes|raw -}}{% endif %}>
-    {% include '@organisms/skip-link/skip-link.twig' with {
-      theme: theme,
-      url: '#main-content',
-    } only %}
     {% if title %}
       {% block title %}
         {% include '@atoms/heading/heading.twig' with {

--- a/components/04-templates/page/__snapshots__/page.test.js.snap
+++ b/components/04-templates/page/__snapshots__/page.test.js.snap
@@ -308,7 +308,9 @@ exports[`Page Component renders all blocks with complex attributes and classes 1
 	
     <main
       class="ct-layout ct-vertical-spacing--top"
+      id="main-content"
       role="main"
+      tabindex="-1"
     >
       
 					Content Top		
@@ -662,13 +664,7 @@ exports[`Page Component renders content block with permutations: {
     />
     
 
-            
-    <a
-      id="main-content"
-      tabindex="-1"
-    />
-    
-      
+        
   
       
 
@@ -679,7 +675,9 @@ exports[`Page Component renders content block with permutations: {
 	
     <main
       class="ct-layout ct-vertical-spacing--top"
+      id="main-content"
       role="main"
+      tabindex="-1"
     >
       
 							
@@ -833,13 +831,7 @@ exports[`Page Component renders content block with permutations: {
     />
     
 
-            
-    <a
-      id="main-content"
-      tabindex="-1"
-    />
-    
-      
+        
   
       
 
@@ -850,7 +842,9 @@ exports[`Page Component renders content block with permutations: {
 	
     <main
       class="ct-layout ct-layout--no-sidebar-right  ct-layout--no-top-right  ct-layout--no-bottom-right ct-vertical-spacing--top"
+      id="main-content"
       role="main"
+      tabindex="-1"
     >
       
 							
@@ -990,13 +984,7 @@ exports[`Page Component renders content block with permutations: {
     />
     
 
-            
-    <a
-      id="main-content"
-      tabindex="-1"
-    />
-    
-      
+        
   
       
 
@@ -1007,7 +995,9 @@ exports[`Page Component renders content block with permutations: {
 	
     <main
       class="ct-layout ct-layout--no-sidebar-left  ct-layout--no-top-left  ct-layout--no-bottom-left  ct-vertical-spacing--top"
+      id="main-content"
       role="main"
+      tabindex="-1"
     >
       
 							
@@ -1147,13 +1137,7 @@ exports[`Page Component renders content block with permutations: {
     />
     
 
-            
-    <a
-      id="main-content"
-      tabindex="-1"
-    />
-    
-      
+        
   
       
 
@@ -1164,7 +1148,9 @@ exports[`Page Component renders content block with permutations: {
 	
     <main
       class="ct-layout ct-layout--no-sidebar-left ct-layout--no-sidebar-right ct-layout--no-top-left ct-layout--no-top-right ct-layout--no-bottom-left ct-layout--no-bottom-right"
+      id="main-content"
       role="main"
+      tabindex="-1"
     >
       
 							
@@ -1283,13 +1269,7 @@ exports[`Page Component renders with custom theme and attributes 1`] = `
     />
     
 
-            
-    <a
-      id="main-content"
-      tabindex="-1"
-    />
-    
-      
+        
   
       
 
@@ -1388,13 +1368,7 @@ exports[`Page Component renders with default values 1`] = `
     />
     
 
-            
-    <a
-      id="main-content"
-      tabindex="-1"
-    />
-    
-      
+        
   
       
 
@@ -1494,13 +1468,7 @@ exports[`Page Component strips HTML tags from attributes 1`] = `
     />
     
 
-            
-    <a
-      id="main-content"
-      tabindex="-1"
-    />
-    
-      
+        
   
       
 

--- a/components/04-templates/page/page.twig
+++ b/components/04-templates/page/page.twig
@@ -36,8 +36,6 @@
   {% block banner %}
     {% if banner is not empty %}
       {{ banner|raw }}
-    {% else %}
-      <a id="main-content" tabindex="-1"></a>
     {% endif %}
   {% endblock %}
 


### PR DESCRIPTION
Closes https://github.com/civictheme/uikit/issues/355

## Checklist before requesting a review

- [x] I have formatted the subject to include the issue number
  as `[#123] Verb in past tense with a period at the end.`
- [x] I have provided information in the `Changed` section about WHY something was
  done if this was a bespoke implementation.
- [x] I have performed a self-review of my code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have run new and existing relevant tests locally with my changes,
  and they have passed.
- [ ] I have provided screenshots, where applicable.

## Changed

1. Removed two empty anchor elements in the code with duplicate id attributes.
2. Moved the `id="main-content"` to the main content (actual content) ie:` <main> </main>`

## Screenshots
