### PR TITLE
[#367] Remove focus for inactive slider item.

### DIFF
--- a/components/03-organisms/slider/slider.js
+++ b/components/03-organisms/slider/slider.js
@@ -1,3 +1,4 @@
+// phpcs:ignoreFile
 /**
  * Slider component.
  */
@@ -85,6 +86,7 @@ CivicThemeSlider.prototype.disableSlideInteraction = function () {
 CivicThemeSlider.prototype.showAllSlides = function () {
   this.slides.forEach((slide) => {
     slide.setAttribute('data-slider-slide-hidden', true);
+    slide.removeAttribute('inert');
   });
 };
 
@@ -92,6 +94,7 @@ CivicThemeSlider.prototype.hideAllSlidesExceptCurrent = function () {
   this.slides.forEach((slide, idx) => {
     if (idx !== this.currentSlide) {
       slide.removeAttribute('data-slider-slide-hidden');
+      slide.setAttribute('inert', true);
     }
   });
 };


### PR DESCRIPTION

Fixed: https://github.com/civictheme/uikit/issues/367

## Checklist before requesting a review

- [x] I have formatted the subject to include the issue number
  as `[#123] Verb in past tense with a period at the end.`
- [x] I have provided information in the `Changed` section about WHY something was
  done if this was a bespoke implementation.
- [x] I have performed a self-review of my code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have run new and existing relevant tests locally with my changes,
  and they have passed.
- [x] I have provided screenshots, where applicable.

## Changed

1.  Remove focus for inactive slider item using `inert` attribute.

https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/inert

## Screenshots
N/A