### PR TITLE
[#468] Resize slider on font load.

### DIFF
--- a/components/03-organisms/slider/slider.js
+++ b/components/03-organisms/slider/slider.js
@@ -34,7 +34,7 @@ function CivicThemeSlider(el) {
   document.fonts.ready.then(() => {
     requestAnimationFrame(() => {
       this.refresh();
-    })
+    });
   });
 }
 

--- a/components/03-organisms/slider/slider.js
+++ b/components/03-organisms/slider/slider.js
@@ -29,6 +29,13 @@ function CivicThemeSlider(el) {
   this.hideAllSlidesExceptCurrent();
 
   this.refresh();
+
+  // Refresh slider on font-load.
+  document.fonts.ready.then(() => {
+    requestAnimationFrame(() => {
+      this.refresh();
+    })
+  });
 }
 
 CivicThemeSlider.prototype.refresh = function () {


### PR DESCRIPTION
## Checklist before requesting a review

- [ ] I have formatted the subject to include the issue number
  as `[#123] Verb in past tense with a period at the end.`
- [x] I have provided information in the `Changed` section about WHY something was
  done if this was a bespoke implementation.
- [x] I have performed a self-review of my code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have run new and existing relevant tests locally with my changes,
  and they have passed.
- [ ] I have provided screenshots, where applicable.

## Changed

1. Slider will often render before fonts have loaded. In this case a font may change the content size of a slide, and cause the height calculations to be incorrect. By calling resize after fonts have loaded, we ensure that the slides are correctly size if custom fonts are being used.

## Screenshots
