### PR TITLE
Fixed an issue in storybook, where the asset directory cannot be found.

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,4 +1,4 @@
-import '../dist/civictheme.css'; // eslint-disable-line import/no-unresolved
+import '../dist/civictheme.storybook.css'; // eslint-disable-line import/no-unresolved
 import '../dist/civictheme.stories.css'; // eslint-disable-line import/no-unresolved
 import '../dist/civictheme.storybook'; // eslint-disable-line import/no-unresolved, import/extensions
 

--- a/build.js
+++ b/build.js
@@ -190,7 +190,7 @@ function buildStylesStorybook() {
     let file = fs.readFileSync(STYLE_FILE_OUT, 'utf-8')
     file = file.replaceAll(DIR_CT_ASSETS, DIR_SB_ASSETS)
     fs.writeFileSync(STYLE_STORYBOOK_FILE_OUT, file, 'utf-8')
-    console.log(`Saved: Component styles (storybook) ${time()}`)
+    successReporter(`Saved: Component styles (storybook) ${time()}`)
   }
 }
 

--- a/build.js
+++ b/build.js
@@ -107,8 +107,9 @@ const STYLE_LAYOUT_FILE_OUT     = `${DIR_OUT}/${STYLE_NAME}.layout.css`
 const STYLE_STORIES_FILE_OUT    = `${DIR_OUT}/${STYLE_NAME}.stories.css`
 
 const DIR_CT_ASSETS             = `/themes/custom/${THEME_NAME}/dist/assets/`
-const DIR_STORYBOOK_ASSETS      = `/assets/`
+const DIR_SB_ASSETS             = `/assets/`
 const VAR_CT_ASSETS_DIRECTORY   = `$civic-assets-directory: '${DIR_CT_ASSETS}';`
+const VAR_SB_ASSETS_DIRECTORY   = `$civic-assets-directory: '${DIR_SB_ASSETS}';`
 
 const JS_FILE_OUT               = `${DIR_OUT}/${SCRIPT_NAME}.js`
 const JS_STORYBOOK_FILE_OUT     = `${DIR_OUT}/${SCRIPT_NAME}.storybook.js`
@@ -186,7 +187,7 @@ function buildStylesStorybook() {
   if (config.styles && config.styles_storybook) {
     // Replace the asset path.
     let file = fs.readFileSync(STYLE_FILE_OUT, 'utf-8')
-    file = file.replaceAll(DIR_CT_ASSETS, DIR_STORYBOOK_ASSETS)
+    file = file.replaceAll(DIR_CT_ASSETS, DIR_SB_ASSETS)
     fs.writeFileSync(STYLE_STORYBOOK_FILE_OUT, file, 'utf-8')
     console.log(`Saved: Component styles (storybook) ${time()}`)
   }
@@ -237,7 +238,7 @@ function buildStylesVariables() {
 function buildStylesStories() {
   if (config.styles_stories) {
     const storybookcss = [
-      VAR_CT_ASSETS_DIRECTORY,
+      VAR_SB_ASSETS_DIRECTORY,
       loadStyleFile(STYLE_STORIES_FILE_IN, COMPONENT_DIR),
     ].join('\n')
 

--- a/build.js
+++ b/build.js
@@ -90,6 +90,7 @@ const DIR_ASSETS_OUT            = fullPath('./dist/assets/')
 const COMPONENT_DIR             = config.base ? DIR_COMPONENTS_IN : DIR_COMPONENTS_OUT
 const STYLE_NAME                = config.base ? 'civictheme' : 'styles'
 const SCRIPT_NAME               = config.base ? 'civictheme' : 'scripts'
+const DRUPAL_THEME_FOLDER       = config.base ? 'contrib' : 'custom'
 
 const STYLE_FILE_IN             = `${COMPONENT_DIR}/style.scss`
 const STYLE_VARIABLE_FILE_IN    = `${COMPONENT_DIR}/style.css_variables.scss`
@@ -106,10 +107,10 @@ const STYLE_ADMIN_FILE_OUT      = `${DIR_OUT}/${STYLE_NAME}.admin.css`
 const STYLE_LAYOUT_FILE_OUT     = `${DIR_OUT}/${STYLE_NAME}.layout.css`
 const STYLE_STORIES_FILE_OUT    = `${DIR_OUT}/${STYLE_NAME}.stories.css`
 
-const DIR_CT_ASSETS             = `/themes/custom/${THEME_NAME}/dist/assets/`
+const DIR_CT_ASSETS             = `/themes/${DRUPAL_THEME_FOLDER}/${THEME_NAME}/dist/assets/`
 const DIR_SB_ASSETS             = `/assets/`
-const VAR_CT_ASSETS_DIRECTORY   = `$civic-assets-directory: '${DIR_CT_ASSETS}';`
-const VAR_SB_ASSETS_DIRECTORY   = `$civic-assets-directory: '${DIR_SB_ASSETS}';`
+const VAR_CT_ASSETS_DIRECTORY   = `$ct-assets-directory: '${DIR_CT_ASSETS}';`
+const VAR_SB_ASSETS_DIRECTORY   = `$ct-assets-directory: '${DIR_SB_ASSETS}';`
 
 const JS_FILE_OUT               = `${DIR_OUT}/${SCRIPT_NAME}.js`
 const JS_STORYBOOK_FILE_OUT     = `${DIR_OUT}/${SCRIPT_NAME}.storybook.js`

--- a/build.js
+++ b/build.js
@@ -30,6 +30,7 @@ const config = {
   lintex: false,
   combine: false,
   styles: false,
+  styles_storybook: false,
   styles_editor: false,
   styles_admin: false,
   styles_layout: false,
@@ -55,6 +56,7 @@ if (['cli', 'lintex'].indexOf(flags[0]) >= 0) {
     config.watch = flags.indexOf('watch') >= 0
     config.combine = true
     config.styles = true
+    config.styles_storybook = true
     config.styles_editor = true
     config.styles_variables = true
     config.styles_stories = true
@@ -97,13 +99,16 @@ const STYLE_EDITOR_FILE_IN      = `${DIR_ASSETS_IN}/sass/theme.editor.scss`
 const STYLE_ADMIN_FILE_IN       = `${DIR_ASSETS_IN}/sass/theme.admin.scss`
 const STYLE_LAYOUT_FILE_IN      = `${DIR_ASSETS_IN}/sass/theme.layout.scss`
 const STYLE_FILE_OUT            = `${DIR_OUT}/${STYLE_NAME}.css`
+const STYLE_STORYBOOK_FILE_OUT  = `${DIR_OUT}/${STYLE_NAME}.storybook.css`
 const STYLE_EDITOR_FILE_OUT     = `${DIR_OUT}/${STYLE_NAME}.editor.css`
 const STYLE_VARIABLE_FILE_OUT   = `${DIR_OUT}/${STYLE_NAME}.variables.css`
 const STYLE_ADMIN_FILE_OUT      = `${DIR_OUT}/${STYLE_NAME}.admin.css`
 const STYLE_LAYOUT_FILE_OUT     = `${DIR_OUT}/${STYLE_NAME}.layout.css`
 const STYLE_STORIES_FILE_OUT    = `${DIR_OUT}/${STYLE_NAME}.stories.css`
 
-const VAR_CT_ASSETS_DIRECTORY   = `$ct-assets-directory: '/themes/custom/${THEME_NAME}/dist/assets/';`
+const DIR_CT_ASSETS             = `/themes/custom/${THEME_NAME}/dist/assets/`
+const DIR_STORYBOOK_ASSETS      = `/assets/`
+const VAR_CT_ASSETS_DIRECTORY   = `$civic-assets-directory: '${DIR_CT_ASSETS}';`
 
 const JS_FILE_OUT               = `${DIR_OUT}/${SCRIPT_NAME}.js`
 const JS_STORYBOOK_FILE_OUT     = `${DIR_OUT}/${SCRIPT_NAME}.storybook.js`
@@ -174,6 +179,16 @@ function buildStyles() {
       .join('\n')
     fs.writeFileSync(STYLE_FILE_OUT, compiledImportAtTop, 'utf-8')
     successReporter(`Saved: Component styles ${time()}`)
+  }
+}
+
+function buildStylesStorybook() {
+  if (config.styles && config.styles_storybook) {
+    // Replace the asset path.
+    let file = fs.readFileSync(STYLE_FILE_OUT, 'utf-8')
+    file = file.replaceAll(DIR_CT_ASSETS, DIR_STORYBOOK_ASSETS)
+    fs.writeFileSync(STYLE_STORYBOOK_FILE_OUT, file, 'utf-8')
+    console.log(`Saved: Component styles (storybook) ${time()}`)
   }
 }
 
@@ -315,6 +330,7 @@ async function build() {
     buildOutDirectory()
     buildCombineDirectories()
     buildStyles()
+    buildStylesStorybook()
     buildStylesEditor()
     buildStylesAdmin()
     buildStylesLayout()

--- a/package.json
+++ b/package.json
@@ -19,8 +19,8 @@
   "type": "module",
   "scripts": {
     "build": "npm run build-storybook",
-    "dist": "node build.js base build styles styles_variables styles_stories js_storybook assets constants",
-    "dist:watch": "node build.js base build watch styles styles_variables styles_stories js_storybook assets constants",
+    "dist": "node build.js base build styles styles_storybook styles_variables styles_stories js_storybook assets constants",
+    "dist:watch": "node build.js base build watch styles styles_storybook styles_variables styles_stories js_storybook assets constants",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "npm run dist && storybook build",
     "dev": "npm run dist && node build.js cli \"dist:watch\" \"storybook\"",


### PR DESCRIPTION
## Checklist before requesting a review

- [ ] I have formatted the subject to include the issue number
  as `[#123] Verb in past tense with a period at the end.`
- [x] I have provided information in the `Changed` section about WHY something was
  done if this was a bespoke implementation.
- [x] I have performed a self-review of my code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have run new and existing relevant tests locally with my changes,
  and they have passed.
- [ ] I have provided screenshots, where applicable.

## Changed

1. Create a `civictheme.storybook.css` file which replaces the `/theme/custom/MYTHEME/dist/assets/` path with `/assets/`, which is suitable for the storybook. 
2. Currently this only runs for the main stylesheet. `.editor`, `.layout` are not used in storybook. `.stories` is only used in storybook, so this will use the `/assets/` path by default.

## Screenshots
![Screenshot 2025-02-13 at 9 31 13 am](https://github.com/user-attachments/assets/3d9be3fd-211c-4464-9bd7-56d40d73f62e)
