### PR TITLE
[CIVIC-2031] Fixed breadcrumbs to have arrows inline.

### DIFF
--- a/components/00-base/icon/__snapshots__/icon.test.js.snap
+++ b/components/00-base/icon/__snapshots__/icon.test.js.snap
@@ -1,20 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Icon Component does not render when symbol is empty 1`] = `
-<div>
-  
-
-
-
-</div>
-`;
+exports[`Icon Component does not render when symbol is empty 1`] = `<div />`;
 
 exports[`Icon Component renders with additional attributes and classes 1`] = `
 <div>
-  
-
-
-                                    
   <svg
     aria-hidden="true"
     class="ct-icon  custom-modifier"
@@ -35,16 +24,11 @@ exports[`Icon Component renders with additional attributes and classes 1`] = `
   </svg>
   
 
-  
 </div>
 `;
 
 exports[`Icon Component renders with custom size 1`] = `
 <div>
-  
-
-
-                                    
   <svg
     alt="Test Icon"
     aria-hidden="true"
@@ -65,16 +49,11 @@ exports[`Icon Component renders with custom size 1`] = `
   </svg>
   
 
-  
 </div>
 `;
 
 exports[`Icon Component renders with default values 1`] = `
 <div>
-  
-
-
-                                    
   <svg
     aria-hidden="true"
     class="ct-icon  "
@@ -94,6 +73,5 @@ exports[`Icon Component renders with default values 1`] = `
   </svg>
   
 
-  
 </div>
 `;

--- a/components/00-base/icon/icon.twig
+++ b/components/00-base/icon/icon.twig
@@ -13,18 +13,18 @@
  */
 #}
 
-{% set assets_dir = assets_dir|default('@civictheme/../assets') %}
+{%- set assets_dir = assets_dir|default('@civictheme/../assets') -%}
 
-{% if symbol is not empty %}
-  {% set source = source(assets_dir ~ '/icons/' ~ symbol ~ '.svg', true) %}
-  {% if source is not empty %}
-    {% set size_class = size ? 'ct-icon--size-' ~ size : '' %}
-    {% set base_class = 'ct-icon ' ~ size_class %}
-    {% set modifier = modifier_class|default('') %}
-    {% set aria_attributes = 'aria-hidden="true" role="img"' %}
-    {% set alt_attribute = alt is defined ? 'alt="' ~ alt ~ '"' : '' %}
-    {% set additional_attributes = attributes|default('') %}
-    {% set attributes = 'class="' ~ base_class ~ ' ' ~ modifier ~ '" ' ~ aria_attributes ~ ' ' ~ alt_attribute ~ ' ' ~ additional_attributes %}
-    {{ source|replace({'<svg ': '<svg ' ~ attributes ~ ' '})|raw }}
-  {% endif %}
-{% endif %}
+{%- if symbol is not empty %}
+  {%- set source = source(assets_dir ~ '/icons/' ~ symbol ~ '.svg', true) -%}
+  {%- if source is not empty -%}
+    {%- set size_class = size ? 'ct-icon--size-' ~ size : '' -%}
+    {%- set base_class = 'ct-icon ' ~ size_class -%}
+    {%- set modifier = modifier_class|default('') -%}
+    {%- set aria_attributes = 'aria-hidden="true" role="img"' -%}
+    {%- set alt_attribute = alt is defined ? 'alt="' ~ alt ~ '"' : '' -%}
+    {%- set additional_attributes = attributes|default('') -%}
+    {%- set attributes = 'class="' ~ base_class ~ ' ' ~ modifier ~ '" ' ~ aria_attributes ~ ' ' ~ alt_attribute ~ ' ' ~ additional_attributes -%}
+    {{- source|replace({'<svg ': '<svg ' ~ attributes ~ ' '})|raw -}}
+  {%- endif -%}
+{%- endif -%}

--- a/components/00-base/menu/__snapshots__/menu.test.js.snap
+++ b/components/00-base/menu/__snapshots__/menu.test.js.snap
@@ -27,21 +27,14 @@ exports[`Menu Component renders collapsible menu 1`] = `
       
 
         
-
-
-  
-  
       <a
         class="ct-link ct-theme-light     ct-menu__item__link"
         href="/"
         title="Home"
       >
-        
-
-    Home  
+        Home
       </a>
       
-
         
         
       
@@ -59,21 +52,14 @@ exports[`Menu Component renders collapsible menu 1`] = `
       
 
         
-
-
-  
-  
       <a
         class="ct-link ct-theme-light     ct-menu__item__link"
         href="/about"
         title="About"
       >
-        
-
-    About  
+        About
       </a>
       
-
         
         
       
@@ -94,22 +80,15 @@ exports[`Menu Component renders collapsible menu 1`] = `
       
 
         
-
-
-  
-  
       <a
         aria-current="page"
         class="ct-link ct-theme-light     ct-menu__item__link"
         href="/services"
         title="Services"
       >
-        
-
-    Services  
+        Services
       </a>
       
-
                   
       <a
         aria-expanded="true"
@@ -145,21 +124,14 @@ exports[`Menu Component renders collapsible menu 1`] = `
             
 
         
-
-
-  
-  
             <a
               class="ct-link ct-theme-light     ct-menu__item__link"
               href="/services/consulting"
               title="Consulting"
             >
-              
-
-    Consulting  
+              Consulting
             </a>
             
-
         
         
       
@@ -177,21 +149,14 @@ exports[`Menu Component renders collapsible menu 1`] = `
             
 
         
-
-
-  
-  
             <a
               class="ct-link ct-theme-light     ct-menu__item__link"
               href="/services/development"
               title="Development"
             >
-              
-
-    Development  
+              Development
             </a>
             
-
         
         
       
@@ -247,21 +212,14 @@ exports[`Menu Component renders menu items with additional attributes 1`] = `
       
 
         
-
-
-  
-  
       <a
         class="ct-link ct-theme-light     ct-menu__item__link"
         href="/"
         title="Home"
       >
-        
-
-    Home  
+        Home
       </a>
       
-
         
         
       
@@ -281,21 +239,14 @@ exports[`Menu Component renders menu items with additional attributes 1`] = `
       
 
         
-
-
-  
-  
       <a
         class="ct-link ct-theme-light     ct-menu__item__link"
         href="/about"
         title="About"
       >
-        
-
-    About  
+        About
       </a>
       
-
         
         
       
@@ -315,21 +266,14 @@ exports[`Menu Component renders menu items with additional attributes 1`] = `
       
 
         
-
-
-  
-  
       <a
         class="ct-link ct-theme-light     ct-menu__item__link"
         href="/services"
         title="Services"
       >
-        
-
-    Services  
+        Services
       </a>
       
-
         
                             
       <div
@@ -356,21 +300,14 @@ exports[`Menu Component renders menu items with additional attributes 1`] = `
             
 
         
-
-
-  
-  
             <a
               class="ct-link ct-theme-light     ct-menu__item__link"
               href="/services/consulting"
               title="Consulting"
             >
-              
-
-    Consulting  
+              Consulting
             </a>
             
-
         
         
       
@@ -390,21 +327,14 @@ exports[`Menu Component renders menu items with additional attributes 1`] = `
             
 
         
-
-
-  
-  
             <a
               class="ct-link ct-theme-light     ct-menu__item__link"
               href="/services/development"
               title="Development"
             >
-              
-
-    Development  
+              Development
             </a>
             
-
         
         
       
@@ -459,21 +389,14 @@ exports[`Menu Component renders menu items with correct attributes 1`] = `
       
 
         
-
-
-  
-  
       <a
         class="ct-link ct-theme-light     ct-menu__item__link"
         href="/"
         title="Home"
       >
-        
-
-    Home  
+        Home
       </a>
       
-
         
         
       
@@ -492,21 +415,14 @@ exports[`Menu Component renders menu items with correct attributes 1`] = `
       
 
         
-
-
-  
-  
       <a
         class="ct-link ct-theme-light     ct-menu__item__link"
         href="/about"
         title="About"
       >
-        
-
-    About  
+        About
       </a>
       
-
         
         
       
@@ -525,21 +441,14 @@ exports[`Menu Component renders menu items with correct attributes 1`] = `
       
 
         
-
-
-  
-  
       <a
         class="ct-link ct-theme-light     ct-menu__item__link"
         href="/services"
         title="Services"
       >
-        
-
-    Services  
+        Services
       </a>
       
-
         
                             
       <div
@@ -565,21 +474,14 @@ exports[`Menu Component renders menu items with correct attributes 1`] = `
             
 
         
-
-
-  
-  
             <a
               class="ct-link ct-theme-light     ct-menu__item__link"
               href="/services/consulting"
               title="Consulting"
             >
-              
-
-    Consulting  
+              Consulting
             </a>
             
-
         
         
       
@@ -598,21 +500,14 @@ exports[`Menu Component renders menu items with correct attributes 1`] = `
             
 
         
-
-
-  
-  
             <a
               class="ct-link ct-theme-light     ct-menu__item__link"
               href="/services/development"
               title="Development"
             >
-              
-
-    Development  
+              Development
             </a>
             
-
         
         
       
@@ -666,21 +561,14 @@ exports[`Menu Component renders with default values - submenu 1`] = `
       
 
         
-
-
-  
-  
       <a
         class="ct-link ct-theme-light     ct-menu__item__link"
         href="/"
         title="Home"
       >
-        
-
-    Home  
+        Home
       </a>
       
-
         
         
       
@@ -698,21 +586,14 @@ exports[`Menu Component renders with default values - submenu 1`] = `
       
 
         
-
-
-  
-  
       <a
         class="ct-link ct-theme-light     ct-menu__item__link"
         href="/about"
         title="About"
       >
-        
-
-    About  
+        About
       </a>
       
-
         
         
       
@@ -730,21 +611,14 @@ exports[`Menu Component renders with default values - submenu 1`] = `
       
 
         
-
-
-  
-  
       <a
         class="ct-link ct-theme-light     ct-menu__item__link"
         href="/services"
         title="Services"
       >
-        
-
-    Services  
+        Services
       </a>
       
-
         
                             
       <div
@@ -769,21 +643,14 @@ exports[`Menu Component renders with default values - submenu 1`] = `
             
 
         
-
-
-  
-  
             <a
               class="ct-link ct-theme-light     ct-menu__item__link"
               href="/services/consulting"
               title="Consulting"
             >
-              
-
-    Consulting  
+              Consulting
             </a>
             
-
         
         
       
@@ -801,21 +668,14 @@ exports[`Menu Component renders with default values - submenu 1`] = `
             
 
         
-
-
-  
-  
             <a
               class="ct-link ct-theme-light     ct-menu__item__link"
               href="/services/development"
               title="Development"
             >
-              
-
-    Development  
+              Development
             </a>
             
-
         
         
       
@@ -869,21 +729,14 @@ exports[`Menu Component renders with default values 1`] = `
       
 
         
-
-
-  
-  
       <a
         class="ct-link ct-theme-light     ct-menu__item__link"
         href="/"
         title="Home"
       >
-        
-
-    Home  
+        Home
       </a>
       
-
         
         
       
@@ -901,21 +754,14 @@ exports[`Menu Component renders with default values 1`] = `
       
 
         
-
-
-  
-  
       <a
         class="ct-link ct-theme-light     ct-menu__item__link"
         href="/about"
         title="About"
       >
-        
-
-    About  
+        About
       </a>
       
-
         
         
       
@@ -957,21 +803,14 @@ exports[`Menu Component renders with theme and custom classes 1`] = `
       
 
         
-
-
-  
-  
       <a
         class="ct-link ct-theme-dark     ct-menu__item__link"
         href="/"
         title="Home"
       >
-        
-
-    Home  
+        Home
       </a>
       
-
         
         
       
@@ -989,21 +828,14 @@ exports[`Menu Component renders with theme and custom classes 1`] = `
       
 
         
-
-
-  
-  
       <a
         class="ct-link ct-theme-dark     ct-menu__item__link"
         href="/about"
         title="About"
       >
-        
-
-    About  
+        About
       </a>
       
-
         
         
       
@@ -1021,21 +853,14 @@ exports[`Menu Component renders with theme and custom classes 1`] = `
       
 
         
-
-
-  
-  
       <a
         class="ct-link ct-theme-dark     ct-menu__item__link"
         href="/services"
         title="Services"
       >
-        
-
-    Services  
+        Services
       </a>
       
-
         
                             
       <div
@@ -1060,21 +885,14 @@ exports[`Menu Component renders with theme and custom classes 1`] = `
             
 
         
-
-
-  
-  
             <a
               class="ct-link ct-theme-dark     ct-menu__item__link"
               href="/services/consulting"
               title="Consulting"
             >
-              
-
-    Consulting  
+              Consulting
             </a>
             
-
         
         
       
@@ -1092,21 +910,14 @@ exports[`Menu Component renders with theme and custom classes 1`] = `
             
 
         
-
-
-  
-  
             <a
               class="ct-link ct-theme-dark     ct-menu__item__link"
               href="/services/development"
               title="Development"
             >
-              
-
-    Development  
+              Development
             </a>
             
-
         
         
       

--- a/components/00-base/text-icon/text-icon.twig
+++ b/components/00-base/text-icon/text-icon.twig
@@ -15,76 +15,74 @@
  */
 #}
 
-{% set icon = icon and is_external and icon_single_only ? 'upper-right-arrow' : icon %}
+{%- set icon = icon and is_external and icon_single_only ? 'upper-right-arrow' : icon -%}
 
-{% apply spaceless %}
-  {% set icon_placement = icon_placement in ['before', 'after'] ? icon_placement : 'after' %}
+{%- set icon_placement = icon_placement in ['before', 'after'] ? icon_placement : 'after' -%}
 
-  {% set content_markup %}
-    {% if icon or is_external %}
+{%- set content_markup -%}
+  {%- if icon or is_external -%}
 
-      {% if icon %}
-        {% set icon_markup %}
-          {%- include '@base/icon/icon.twig' with {
-            symbol: icon,
-            modifier_class: icon_class|default(''),
-          } only %}
-        {% endset -%}
-      {% endif %}
+    {%- if icon -%}
+      {%- set icon_markup -%}
+        {%- include '@base/icon/icon.twig' with {
+          symbol: icon,
+          modifier_class: icon_class|default(''),
+        } only -%}
+      {%- endset -%}
+    {%- endif -%}
 
-      {% if text is not empty %}
+    {%- if text is not empty -%}
 
-        {% if icon and icon_placement == 'before' and not is_external %}
-          {{- icon_markup -}}{{- text|raw -}}
-        {% else %}
-          {# Prepare the text #}
-          {% set text_arr = text|trim|split(' ') %}
-          {% set text_start = text_arr|slice(0, -1)|join(' ') %}
-          {% set text_end = text_arr|last %}
+      {%- if icon and icon_placement == 'before' and not is_external -%}
+        {{- icon_markup -}}{{- text|raw -}}
+      {%- else -%}
+        {# Prepare the text #}
+        {%- set text_arr = text|trim|split(' ') -%}
+        {%- set text_start = text_arr|slice(0, -1)|join(' ') -%}
+        {%- set text_end = text_arr|last -%}
 
-          {# Place text in groups #}
-          {% set before_group = text_start %}
-          {% set within_group = text_end %}
+        {# Place text in groups #}
+        {%- set before_group = text_start -%}
+        {%- set within_group = text_end -%}
 
-          {# Place icon before or after text #}
-          {% if icon_placement == 'before' %}
-            {% set before_group = icon_markup|raw ~ before_group %}
-          {% else %}
-            {% set within_group = within_group ~ icon_markup|raw %}
-          {% endif %}
+        {# Place icon before or after text #}
+        {%- if icon_placement == 'before' -%}
+          {%- set before_group = icon_markup|raw ~ before_group -%}
+        {%- else -%}
+          {%- set within_group = within_group ~ ' ' ~ icon_markup|raw -%}
+        {%- endif -%}
 
-          {# Add external icon #}
-          {% if is_external and not icon_single_only %}
-            {% set is_external_content %}
-              {%- include '@base/icon/icon.twig' with {
-                symbol: 'upper-right-arrow',
-              } only -%}
-            {% endset %}
-            {% set within_group = within_group|raw ~ is_external_content|raw %}
-          {% endif %}
+        {# Add external icon #}
+        {%- if is_external and not icon_single_only -%}
+          {%- set is_external_content -%}
+            {%- include '@base/icon/icon.twig' with {
+              symbol: 'upper-right-arrow',
+            } only -%}
+          {%- endset -%}
+          {%- set within_group = within_group|raw ~ ' ' ~ is_external_content|raw -%}
+        {%- endif -%}
 
-          {# Set the markup #}
-          {% if icon_group_disabled %}
-            {{- before_group|raw }} {{ within_group|raw -}}
-          {% else %}
-            {{- before_group|raw }} <span class="ct-text-icon__group">{{- within_group|raw -}}</span>
-          {% endif %}
-        {% endif %}
+        {# Set the markup #}
+        {%- if icon_group_disabled -%}
+          {{- before_group|raw }} {{ within_group|raw -}}
+        {%- else -%}
+          {{- before_group|raw }} <span class="ct-text-icon__group">{{- within_group|raw -}}</span>
+        {%- endif -%}
+      {%- endif -%}
 
-      {% else %}
-        {{- icon_markup -}}
-      {% endif %}
+    {%- else -%}
+      {{- icon_markup -}}
+    {%- endif -%}
 
-    {% else %}
-      {{- text|raw -}}
-    {% endif %}
-  {% endset %}
+  {%- else -%}
+    {{- text|raw -}}
+  {%- endif -%}
+{%- endset -%}
 
-  {% if is_new_window %}
-    {% set is_new_window_content -%}
-      <span class="ct-visually-hidden">(Opens in a new tab/window)</span>
-    {%- endset %}
-  {% endif %}
-{% endapply %}
+{%- if is_new_window -%}
+  {%- set is_new_window_content -%}
+    <span class="ct-visually-hidden">(Opens in a new tab/window)</span>
+  {%- endset -%}
+{%- endif -%}
 
 {{- content_markup -}}{{- is_new_window_content -}}

--- a/components/01-atoms/button/__snapshots__/button.test.js.snap
+++ b/components/01-atoms/button/__snapshots__/button.test.js.snap
@@ -13,15 +13,6 @@ exports[`Button Component renders as a link with optional attributes 1`] = `
     role="button"
     target="_blank"
   >
-    
-
-    
-              
-      
-        
-
-
-                                    
     <svg
       aria-hidden="true"
       class="ct-icon  ct-button__icon"
@@ -40,10 +31,7 @@ exports[`Button Component renders as a link with optional attributes 1`] = `
 
     </svg>
     
-
-          Click me
-      
-      
+Click me
     <span
       class="ct-visually-hidden"
     >
@@ -68,24 +56,6 @@ exports[`Button Component renders as a link with optional attributes, is externa
     role="button"
     target="_blank"
   >
-    
-
-    
-              
-      
-                  
-                              
-          
-                    
-          
-                                
-          
-                                            
-          
-          
-
-
-                                    
     <svg
       aria-hidden="true"
       class="ct-icon  ct-button__icon"
@@ -104,15 +74,11 @@ exports[`Button Component renders as a link with optional attributes, is externa
 
     </svg>
     
-
-          Click 
+Click 
     <span
       class="ct-text-icon__group"
     >
-      me
-
-
-                                    
+      me 
       <svg
         aria-hidden="true"
         class="ct-icon  "
@@ -132,12 +98,7 @@ exports[`Button Component renders as a link with optional attributes, is externa
       </svg>
       
 
-  
     </span>
-    
-                  
-      
-      
     <span
       class="ct-visually-hidden"
     >
@@ -192,9 +153,7 @@ exports[`Button Component renders with disabled state 1`] = `
     data-component-name="button"
     disabled="disabled"
   >
-    
-
-    Click me  
+    Click me
   </button>
   
 
@@ -210,9 +169,7 @@ exports[`Button Component renders with required attributes 1`] = `
     class="ct-button ct-theme-light  ct-button--button ct-button--regular   "
     data-component-name="button"
   >
-    
-
-    Click me  
+    Click me
   </button>
   
 

--- a/components/01-atoms/chip/__snapshots__/chip.test.js.snap
+++ b/components/01-atoms/chip/__snapshots__/chip.test.js.snap
@@ -25,9 +25,6 @@ exports[`Chip Component renders with optional attributes 1`] = `
       type="checkbox"
     />
     Sample Chip        
-
-
-                                    
     <svg
       aria-hidden="true"
       class="ct-icon  ct-chip__dismiss"
@@ -46,8 +43,7 @@ exports[`Chip Component renders with optional attributes 1`] = `
 
     </svg>
     
-
-            
+          
   </label>
   
   

--- a/components/01-atoms/content-link/__snapshots__/content-link.test.js.snap
+++ b/components/01-atoms/content-link/__snapshots__/content-link.test.js.snap
@@ -22,28 +22,11 @@ exports[`Content Link Component renders with optional attributes 1`] = `
     target="_blank"
     title="Example Title"
   >
-    
-
-    
-      
-      
-                  
-                              
-          
-                    
-          
-                                
-          
-                                            
-          
-          Sample 
+    Sample 
     <span
       class="ct-text-icon__group"
     >
-      Link
-
-
-                                    
+      Link  
       <svg
         aria-hidden="true"
         class="ct-icon  "
@@ -63,12 +46,7 @@ exports[`Content Link Component renders with optional attributes 1`] = `
       </svg>
       
 
-  
     </span>
-    
-                  
-      
-      
     <span
       class="ct-visually-hidden"
     >
@@ -90,9 +68,7 @@ exports[`Content Link Component renders with required attributes 1`] = `
     class="ct-content-link ct-theme-light  "
     href="https://example.com"
   >
-    
-
-    Sample Link  
+    Sample Link
   </a>
   
 

--- a/components/01-atoms/field-message/__snapshots__/field-message.test.js.snap
+++ b/components/01-atoms/field-message/__snapshots__/field-message.test.js.snap
@@ -10,9 +10,6 @@ exports[`Field Message Component allows HTML content 1`] = `
   >
     
           
-
-
-                                    
     <svg
       aria-hidden="true"
       class="ct-icon ct-icon--size-regular ct-field-message__icon"
@@ -31,8 +28,7 @@ exports[`Field Message Component allows HTML content 1`] = `
 
     </svg>
     
-
-          
+        
     <strong>
       This is an HTML message
     </strong>
@@ -60,9 +56,6 @@ exports[`Field Message Component renders with additional attributes and classes 
   >
     
           
-
-
-                                    
     <svg
       aria-hidden="true"
       class="ct-icon ct-icon--size-regular ct-field-message__icon"
@@ -81,8 +74,7 @@ exports[`Field Message Component renders with additional attributes and classes 
 
     </svg>
     
-
-          This is a message  
+        This is a message  
   </div>
 </div>
 `;
@@ -97,9 +89,6 @@ exports[`Field Message Component renders with custom theme and type 1`] = `
   >
     
           
-
-
-                                    
     <svg
       aria-hidden="true"
       class="ct-icon ct-icon--size-regular ct-field-message__icon"
@@ -118,8 +107,7 @@ exports[`Field Message Component renders with custom theme and type 1`] = `
 
     </svg>
     
-
-          This is an error message  
+        This is an error message  
   </div>
 </div>
 `;
@@ -134,9 +122,6 @@ exports[`Field Message Component renders with default values 1`] = `
   >
     
           
-
-
-                                    
     <svg
       aria-hidden="true"
       class="ct-icon ct-icon--size-regular ct-field-message__icon"
@@ -155,8 +140,7 @@ exports[`Field Message Component renders with default values 1`] = `
 
     </svg>
     
-
-          This is a message  
+        This is a message  
   </div>
 </div>
 `;
@@ -171,9 +155,6 @@ exports[`Field Message Component renders with icons 1`] = `
   >
     
           
-
-
-                                    
     <svg
       aria-hidden="true"
       class="ct-icon ct-icon--size-regular ct-field-message__icon"
@@ -192,8 +173,7 @@ exports[`Field Message Component renders with icons 1`] = `
 
     </svg>
     
-
-          This is a warning message  
+        This is a warning message  
   </div>
 </div>
 `;
@@ -208,9 +188,6 @@ exports[`Field Message Component strips HTML content 1`] = `
   >
     
           
-
-
-                                    
     <svg
       aria-hidden="true"
       class="ct-icon ct-icon--size-regular ct-field-message__icon"
@@ -229,8 +206,7 @@ exports[`Field Message Component strips HTML content 1`] = `
 
     </svg>
     
-
-          Start &lt;strong&gt;prefix&lt;/strong&gt; middle &lt;script&gt;alert("XSS")&lt;/script&gt; end  
+        Start &lt;strong&gt;prefix&lt;/strong&gt; middle &lt;script&gt;alert("XSS")&lt;/script&gt; end  
   </div>
 </div>
 `;

--- a/components/01-atoms/fieldset/__snapshots__/fieldset.test.js.snap
+++ b/components/01-atoms/fieldset/__snapshots__/fieldset.test.js.snap
@@ -277,9 +277,6 @@ exports[`Fieldset Component renders with message 1`] = `
       >
         
           
-
-
-                                    
         <svg
           aria-hidden="true"
           class="ct-icon ct-icon--size-regular ct-field-message__icon"
@@ -298,8 +295,7 @@ exports[`Fieldset Component renders with message 1`] = `
 
         </svg>
         
-
-          
+        
         <strong>
           Test Message
         </strong>

--- a/components/01-atoms/link/__snapshots__/link.test.js.snap
+++ b/components/01-atoms/link/__snapshots__/link.test.js.snap
@@ -1,21 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Link Component does not render when text and icon are empty 1`] = `
-<div>
-  
-
-
-
-</div>
-`;
+exports[`Link Component does not render when text and icon are empty 1`] = `<div />`;
 
 exports[`Link Component renders with optional attributes, is external 1`] = `
 <div>
-  
-
-
-  
-  
   <a
     class="ct-link ct-theme-dark ct-link--external ct-link--active ct-link--disabled  custom-class"
     data-test="true"
@@ -24,24 +12,6 @@ exports[`Link Component renders with optional attributes, is external 1`] = `
     target="_blank"
     title="Example Title"
   >
-    
-
-    
-              
-      
-                  
-                              
-          
-                    
-          
-                                
-          
-                                            
-          
-          
-
-
-                                    
     <svg
       aria-hidden="true"
       class="ct-icon  ct-link__icon"
@@ -60,15 +30,11 @@ exports[`Link Component renders with optional attributes, is external 1`] = `
 
     </svg>
     
-
-          Sample 
+Sample 
     <span
       class="ct-text-icon__group"
     >
-      Link
-
-
-                                    
+      Link 
       <svg
         aria-hidden="true"
         class="ct-icon  "
@@ -88,30 +54,18 @@ exports[`Link Component renders with optional attributes, is external 1`] = `
       </svg>
       
 
-  
     </span>
-    
-                  
-      
-      
     <span
       class="ct-visually-hidden"
     >
       (Opens in a new tab/window)
     </span>
   </a>
-  
-
 </div>
 `;
 
 exports[`Link Component renders with optional attributes, not external 1`] = `
 <div>
-  
-
-
-  
-  
   <a
     class="ct-link ct-theme-dark  ct-link--active ct-link--disabled  custom-class"
     data-test="true"
@@ -120,15 +74,6 @@ exports[`Link Component renders with optional attributes, not external 1`] = `
     target="_blank"
     title="Example Title"
   >
-    
-
-    
-              
-      
-        
-
-
-                                    
     <svg
       aria-hidden="true"
       class="ct-icon  ct-link__icon"
@@ -147,37 +92,23 @@ exports[`Link Component renders with optional attributes, not external 1`] = `
 
     </svg>
     
-
-          Sample Link
-      
-      
+Sample Link
     <span
       class="ct-visually-hidden"
     >
       (Opens in a new tab/window)
     </span>
   </a>
-  
-
 </div>
 `;
 
 exports[`Link Component renders with required attributes 1`] = `
 <div>
-  
-
-
-  
-  
   <a
     class="ct-link ct-theme-light"
     href="https://example.com"
   >
-    
-
-    Sample Link  
+    Sample Link
   </a>
-  
-
 </div>
 `;

--- a/components/01-atoms/link/link.twig
+++ b/components/01-atoms/link/link.twig
@@ -21,19 +21,18 @@
  */
 #}
 
-{% set text = text|default('') %}
-{% set only_icon_class = icon is not empty and text is empty ? 'ct-link--only-icon' : '' %}
-{% set icon_placement = icon_placement in ['before', 'after'] ? icon_placement : 'after' %}
-{% set is_external_class = is_external ? 'ct-link--external' : '' %}
-{% set is_active_class = is_active ? 'ct-link--active' : '' %}
-{% set is_disabled_class = is_disabled ? 'ct-link--disabled' : '' %}
-{% set theme_class = 'ct-theme-%s'|format(theme|default('light')) %}
-{% set modifier_class = '%s %s %s %s %s %s'|format(theme_class, is_external_class, is_active_class, is_disabled_class, only_icon_class, modifier_class|default(''))|trim %}
+{%- set text = text|default('') -%}
+{%- set only_icon_class = icon is not empty and text is empty ? 'ct-link--only-icon' : '' -%}
+{%- set icon_placement = icon_placement in ['before', 'after'] ? icon_placement : 'after' -%}
+{%- set is_external_class = is_external ? 'ct-link--external' : '' -%}
+{%- set is_active_class = is_active ? 'ct-link--active' : '' -%}
+{%- set is_disabled_class = is_disabled ? 'ct-link--disabled' : '' -%}
+{%- set theme_class = 'ct-theme-%s'|format(theme|default('light')) -%}
+{%- set modifier_class = '%s %s %s %s %s %s'|format(theme_class, is_external_class, is_active_class, is_disabled_class, only_icon_class, modifier_class|default(''))|trim -%}
+{%- set attributes = is_disabled ? attributes ~ ' disabled' : attributes -%}
 
-{% set attributes = is_disabled ? attributes ~ ' disabled' : attributes %}
-
-{% if text is not empty or icon is not empty %}
-  {% set link_content %}
+{%- if text is not empty or icon is not empty -%}
+  {%- set link_content -%}
     {%- include '@base/text-icon/text-icon.twig' with {
       text: text,
       is_new_window: is_new_window,
@@ -44,7 +43,7 @@
       icon_group_disabled: icon_group_disabled|default(false),
       icon_single_only: icon_single_only|default(false),
     } only -%}
-  {% endset %}
+  {%- endset -%}
 
   <a
     class="ct-link {{ modifier_class -}}"
@@ -56,4 +55,4 @@
   >
     {{- link_content -}}
   </a>
-{% endif %}
+{%- endif -%}

--- a/components/01-atoms/popover/__snapshots__/popover.test.js.snap
+++ b/components/01-atoms/popover/__snapshots__/popover.test.js.snap
@@ -23,10 +23,6 @@ exports[`Popover Component renders with optional attributes 1`] = `
   >
     
     
-
-
-  
-  
     <a
       class="ct-link ct-theme-dark     ct-popover__link"
       data-collapsible-trigger=""
@@ -34,9 +30,7 @@ exports[`Popover Component renders with optional attributes 1`] = `
       tabindex="0"
       target="_blank"
     >
-      
-
-    Sample Trigger  
+      Sample Trigger
       <span
         class="ct-visually-hidden"
       >
@@ -44,7 +38,6 @@ exports[`Popover Component renders with optional attributes 1`] = `
       </span>
     </a>
     
-
     
     <div
       class="ct-popover__content"
@@ -86,21 +79,14 @@ exports[`Popover Component renders with required attributes 1`] = `
   >
     
     
-
-
-  
-  
     <a
       class="ct-link ct-theme-light     ct-popover__link"
       data-collapsible-trigger=""
       tabindex="0"
     >
-      
-
-    Sample Trigger  
+      Sample Trigger
     </a>
     
-
     
     <div
       class="ct-popover__content"

--- a/components/01-atoms/tag/__snapshots__/tag.test.js.snap
+++ b/components/01-atoms/tag/__snapshots__/tag.test.js.snap
@@ -26,9 +26,6 @@ exports[`Tag Component renders with optional attributes 1`] = `
   >
                 
                 
-
-
-                                    
     <svg
       aria-hidden="true"
       class="ct-icon  ct-tag__icon"
@@ -47,8 +44,7 @@ exports[`Tag Component renders with optional attributes 1`] = `
 
     </svg>
     
-
-         Sample Tag
+       Sample Tag
               
     <span
       class="ct-visually-hidden"
@@ -57,9 +53,6 @@ exports[`Tag Component renders with optional attributes 1`] = `
     </span>
     
           
-
-
-                                    
     <svg
       aria-hidden="true"
       class="ct-icon  "
@@ -78,8 +71,7 @@ exports[`Tag Component renders with optional attributes 1`] = `
 
     </svg>
     
-
-      
+    
   </a>
   
 

--- a/components/02-molecules/attachment/__snapshots__/attachment.test.js.snap
+++ b/components/02-molecules/attachment/__snapshots__/attachment.test.js.snap
@@ -52,9 +52,6 @@ exports[`Attachment Component renders with multiple files and attributes 1`] = `
                 class="ct-item-list__item"
               >
                                   
-
-
-                                    
                 <svg
                   aria-hidden="true"
                   class="ct-icon ct-icon--size-large ct-attachment__links__link__icon"
@@ -79,7 +76,6 @@ exports[`Attachment Component renders with multiple files and attributes 1`] = `
                 </svg>
                 
 
-  
                   
                 <div
                   class="ct-attachment__links__link__wrapper"
@@ -87,27 +83,19 @@ exports[`Attachment Component renders with multiple files and attributes 1`] = `
                   
                                                               
                     
-
-
-  
-  
                   <a
                     class="ct-link ct-theme-light     ct-attachment__links__link"
                     href="https://example.com/file1.pdf"
                     title="Download File 1"
                   >
-                    
-
-    File 1 
+                    File 1 
                     <span
                       class="ct-attachment__links__link__extension"
                     >
                       (pdf, 1MB)
                     </span>
-                      
                   </a>
                   
-
                                           
 
 
@@ -128,9 +116,6 @@ exports[`Attachment Component renders with multiple files and attributes 1`] = `
                 class="ct-item-list__item"
               >
                                   
-
-
-                                    
                 <svg
                   aria-hidden="true"
                   class="ct-icon ct-icon--size-large ct-attachment__links__link__icon"
@@ -155,7 +140,6 @@ exports[`Attachment Component renders with multiple files and attributes 1`] = `
                 </svg>
                 
 
-  
                   
                 <div
                   class="ct-attachment__links__link__wrapper"
@@ -163,27 +147,19 @@ exports[`Attachment Component renders with multiple files and attributes 1`] = `
                   
                                                               
                     
-
-
-  
-  
                   <a
                     class="ct-link ct-theme-light     ct-attachment__links__link"
                     href="https://example.com/file2.docx"
                     title="Download File 2"
                   >
-                    
-
-    File 2 
+                    File 2 
                     <span
                       class="ct-attachment__links__link__extension"
                     >
                       (docx, 2MB)
                     </span>
-                      
                   </a>
                   
-
                                           
 
 
@@ -302,9 +278,6 @@ exports[`Attachment Component renders with optional attributes 1`] = `
                 class="ct-item-list__item"
               >
                                   
-
-
-                                    
                 <svg
                   aria-hidden="true"
                   class="ct-icon ct-icon--size-large ct-attachment__links__link__icon"
@@ -329,7 +302,6 @@ exports[`Attachment Component renders with optional attributes 1`] = `
                 </svg>
                 
 
-  
                   
                 <div
                   class="ct-attachment__links__link__wrapper"
@@ -337,27 +309,19 @@ exports[`Attachment Component renders with optional attributes 1`] = `
                   
                                                               
                     
-
-
-  
-  
                   <a
                     class="ct-link ct-theme-dark     ct-attachment__links__link"
                     href="https://example.com/file1.pdf"
                     title="Download File 1"
                   >
-                    
-
-    File 1 
+                    File 1 
                     <span
                       class="ct-attachment__links__link__extension"
                     >
                       (pdf, 1MB)
                     </span>
-                      
                   </a>
                   
-
                                           
 
 
@@ -447,9 +411,6 @@ exports[`Attachment Component renders with required attributes 1`] = `
                 class="ct-item-list__item"
               >
                                   
-
-
-                                    
                 <svg
                   aria-hidden="true"
                   class="ct-icon ct-icon--size-large ct-attachment__links__link__icon"
@@ -474,7 +435,6 @@ exports[`Attachment Component renders with required attributes 1`] = `
                 </svg>
                 
 
-  
                   
                 <div
                   class="ct-attachment__links__link__wrapper"
@@ -482,27 +442,19 @@ exports[`Attachment Component renders with required attributes 1`] = `
                   
                                                               
                     
-
-
-  
-  
                   <a
                     class="ct-link ct-theme-light     ct-attachment__links__link"
                     href="https://example.com/file1.pdf"
                     title="Download File 1"
                   >
-                    
-
-    File 1 
+                    File 1 
                     <span
                       class="ct-attachment__links__link__extension"
                     >
                       (pdf, 1MB)
                     </span>
-                      
                   </a>
                   
-
                                           
 
 
@@ -523,9 +475,6 @@ exports[`Attachment Component renders with required attributes 1`] = `
                 class="ct-item-list__item"
               >
                                   
-
-
-                                    
                 <svg
                   aria-hidden="true"
                   class="ct-icon ct-icon--size-large ct-attachment__links__link__icon"
@@ -550,7 +499,6 @@ exports[`Attachment Component renders with required attributes 1`] = `
                 </svg>
                 
 
-  
                   
                 <div
                   class="ct-attachment__links__link__wrapper"
@@ -558,27 +506,19 @@ exports[`Attachment Component renders with required attributes 1`] = `
                   
                                                               
                     
-
-
-  
-  
                   <a
                     class="ct-link ct-theme-light     ct-attachment__links__link"
                     href="https://example.com/file2.docx"
                     title="Download File 2"
                   >
-                    
-
-    File 2 
+                    File 2 
                     <span
                       class="ct-attachment__links__link__extension"
                     >
                       (docx, 2MB)
                     </span>
-                      
                   </a>
                   
-
                                           
 
 

--- a/components/02-molecules/back-to-top/__snapshots__/back-to-top.test.js.snap
+++ b/components/02-molecules/back-to-top/__snapshots__/back-to-top.test.js.snap
@@ -28,10 +28,6 @@ exports[`Back to Top Component button contains correct icon 1`] = `
       >
         Return focus to the top of the page
       </span>
-      
-
-
-                                    
       <svg
         aria-hidden="true"
         class="ct-icon  ct-button__icon"
@@ -51,7 +47,6 @@ exports[`Back to Top Component button contains correct icon 1`] = `
       </svg>
       
 
-  
     </a>
     
 
@@ -89,10 +84,6 @@ exports[`Back to Top Component renders button with correct attributes 1`] = `
       >
         Return focus to the top of the page
       </span>
-      
-
-
-                                    
       <svg
         aria-hidden="true"
         class="ct-icon  ct-button__icon"
@@ -112,7 +103,6 @@ exports[`Back to Top Component renders button with correct attributes 1`] = `
       </svg>
       
 
-  
     </a>
     
 
@@ -150,10 +140,6 @@ exports[`Back to Top Component renders correctly 1`] = `
       >
         Return focus to the top of the page
       </span>
-      
-
-
-                                    
       <svg
         aria-hidden="true"
         class="ct-icon  ct-button__icon"
@@ -173,7 +159,6 @@ exports[`Back to Top Component renders correctly 1`] = `
       </svg>
       
 
-  
     </a>
     
 

--- a/components/02-molecules/breadcrumb/__snapshots__/breadcrumb.test.js.snap
+++ b/components/02-molecules/breadcrumb/__snapshots__/breadcrumb.test.js.snap
@@ -14,12 +14,9 @@ exports[`Breadcrumb Component renders active element as span when active_is_link
     
           
       
-                            
                 
       
-                            
                               
-      
       
           
           
@@ -35,23 +32,10 @@ exports[`Breadcrumb Component renders active element as span when active_is_link
         class="ct-item-list__item"
       >
                 
-
-
-  
-  
         <a
-          class="ct-link ct-theme-light"
+          class="ct-link ct-theme-light     ct-breadcrumb__links__link"
           href="/category"
         >
-          
-
-    
-              
-      
-        
-
-
-                                    
           <svg
             aria-hidden="true"
             class="ct-icon  ct-link__icon"
@@ -70,13 +54,9 @@ exports[`Breadcrumb Component renders active element as span when active_is_link
 
           </svg>
           
-
-          Category
-      
-      
+Category
         </a>
-        
-      
+              
       </li>
       
             
@@ -94,32 +74,12 @@ exports[`Breadcrumb Component renders active element as span when active_is_link
       <li
         class="ct-item-list__item"
       >
-                
-                  
-
-
-  
-  
         <a
           class="ct-link ct-theme-light     ct-breadcrumb__links__link"
           href="/"
         >
-          
-
-    Home  
+          Home
         </a>
-        
-              
-      </li>
-      
-                        
-      <li
-        class="ct-item-list__item"
-      >
-                  
-
-
-                                    
         <svg
           aria-hidden="true"
           class="ct-icon  ct-breadcrumb__links__separator"
@@ -139,39 +99,18 @@ exports[`Breadcrumb Component renders active element as span when active_is_link
         </svg>
         
 
-          
       </li>
       
                         
       <li
         class="ct-item-list__item"
       >
-                
-                  
-
-
-  
-  
         <a
           class="ct-link ct-theme-light     ct-breadcrumb__links__link"
           href="/category"
         >
-          
-
-    Category  
+          Category
         </a>
-        
-              
-      </li>
-      
-                        
-      <li
-        class="ct-item-list__item"
-      >
-                  
-
-
-                                    
         <svg
           aria-hidden="true"
           class="ct-icon  ct-breadcrumb__links__separator"
@@ -191,23 +130,18 @@ exports[`Breadcrumb Component renders active element as span when active_is_link
         </svg>
         
 
-          
       </li>
       
                         
       <li
         class="ct-item-list__item"
       >
-                
-                  
         <span
           aria-current="location"
           class="ct-breadcrumb__links__link ct-breadcrumb__links__link--active"
         >
           Subcategory
         </span>
-        
-              
       </li>
       
             
@@ -235,12 +169,9 @@ exports[`Breadcrumb Component renders with optional attributes 1`] = `
     
           
       
-                            
                 
       
-                            
                               
-      
       
           
           
@@ -256,23 +187,10 @@ exports[`Breadcrumb Component renders with optional attributes 1`] = `
         class="ct-item-list__item"
       >
                 
-
-
-  
-  
         <a
-          class="ct-link ct-theme-dark"
+          class="ct-link ct-theme-dark     ct-breadcrumb__links__link"
           href="/category"
         >
-          
-
-    
-              
-      
-        
-
-
-                                    
           <svg
             aria-hidden="true"
             class="ct-icon  ct-link__icon"
@@ -291,13 +209,9 @@ exports[`Breadcrumb Component renders with optional attributes 1`] = `
 
           </svg>
           
-
-          Category
-      
-      
+Category
         </a>
-        
-      
+              
       </li>
       
             
@@ -315,32 +229,12 @@ exports[`Breadcrumb Component renders with optional attributes 1`] = `
       <li
         class="ct-item-list__item"
       >
-                
-                  
-
-
-  
-  
         <a
           class="ct-link ct-theme-dark     ct-breadcrumb__links__link"
           href="/"
         >
-          
-
-    Home  
+          Home
         </a>
-        
-              
-      </li>
-      
-                        
-      <li
-        class="ct-item-list__item"
-      >
-                  
-
-
-                                    
         <svg
           aria-hidden="true"
           class="ct-icon  ct-breadcrumb__links__separator"
@@ -360,39 +254,18 @@ exports[`Breadcrumb Component renders with optional attributes 1`] = `
         </svg>
         
 
-          
       </li>
       
                         
       <li
         class="ct-item-list__item"
       >
-                
-                  
-
-
-  
-  
         <a
           class="ct-link ct-theme-dark     ct-breadcrumb__links__link"
           href="/category"
         >
-          
-
-    Category  
+          Category
         </a>
-        
-              
-      </li>
-      
-                        
-      <li
-        class="ct-item-list__item"
-      >
-                  
-
-
-                                    
         <svg
           aria-hidden="true"
           class="ct-icon  ct-breadcrumb__links__separator"
@@ -412,30 +285,19 @@ exports[`Breadcrumb Component renders with optional attributes 1`] = `
         </svg>
         
 
-          
       </li>
       
                         
       <li
         class="ct-item-list__item"
       >
-                
-                  
-
-
-  
-  
         <a
           aria-current="location"
           class="ct-link ct-theme-dark  ct-link--active   ct-breadcrumb__links__link ct-breadcrumb__links__link--active"
           href="/category/subcategory"
         >
-          
-
-    Subcategory  
+          Subcategory
         </a>
-        
-              
       </li>
       
             
@@ -462,12 +324,9 @@ exports[`Breadcrumb Component renders with required attributes 1`] = `
     
           
       
-                            
                 
       
-                            
                               
-      
       
           
           
@@ -483,23 +342,10 @@ exports[`Breadcrumb Component renders with required attributes 1`] = `
         class="ct-item-list__item"
       >
                 
-
-
-  
-  
         <a
-          class="ct-link ct-theme-light"
+          class="ct-link ct-theme-light     ct-breadcrumb__links__link"
           href="/category"
         >
-          
-
-    
-              
-      
-        
-
-
-                                    
           <svg
             aria-hidden="true"
             class="ct-icon  ct-link__icon"
@@ -518,13 +364,9 @@ exports[`Breadcrumb Component renders with required attributes 1`] = `
 
           </svg>
           
-
-          Category
-      
-      
+Category
         </a>
-        
-      
+              
       </li>
       
             
@@ -542,32 +384,12 @@ exports[`Breadcrumb Component renders with required attributes 1`] = `
       <li
         class="ct-item-list__item"
       >
-                
-                  
-
-
-  
-  
         <a
           class="ct-link ct-theme-light     ct-breadcrumb__links__link"
           href="/"
         >
-          
-
-    Home  
+          Home
         </a>
-        
-              
-      </li>
-      
-                        
-      <li
-        class="ct-item-list__item"
-      >
-                  
-
-
-                                    
         <svg
           aria-hidden="true"
           class="ct-icon  ct-breadcrumb__links__separator"
@@ -587,39 +409,18 @@ exports[`Breadcrumb Component renders with required attributes 1`] = `
         </svg>
         
 
-          
       </li>
       
                         
       <li
         class="ct-item-list__item"
       >
-                
-                  
-
-
-  
-  
         <a
           class="ct-link ct-theme-light     ct-breadcrumb__links__link"
           href="/category"
         >
-          
-
-    Category  
+          Category
         </a>
-        
-              
-      </li>
-      
-                        
-      <li
-        class="ct-item-list__item"
-      >
-                  
-
-
-                                    
         <svg
           aria-hidden="true"
           class="ct-icon  ct-breadcrumb__links__separator"
@@ -639,23 +440,18 @@ exports[`Breadcrumb Component renders with required attributes 1`] = `
         </svg>
         
 
-          
       </li>
       
                         
       <li
         class="ct-item-list__item"
       >
-                
-                  
         <span
           aria-current="location"
           class="ct-breadcrumb__links__link ct-breadcrumb__links__link--active"
         >
           Subcategory
         </span>
-        
-              
       </li>
       
             

--- a/components/02-molecules/breadcrumb/breadcrumb.test.js
+++ b/components/02-molecules/breadcrumb/breadcrumb.test.js
@@ -14,10 +14,15 @@ describe('Breadcrumb Component', () => {
     expect(c.querySelector('.ct-breadcrumb__links__link--active').textContent.trim()).toEqual('Subcategory');
 
     const links = c.querySelectorAll('.ct-breadcrumb__links__link');
-    expect(links).toHaveLength(3);
-    expect(links[0].textContent.trim()).toEqual('Home');
-    expect(links[1].textContent.trim()).toEqual('Category');
-    expect(links[2].textContent.trim()).toEqual('Subcategory');
+    expect(links).toHaveLength(4);
+
+    // Mobile.
+    expect(links[0].textContent.trim()).toEqual('Category');
+
+    // Desktop.
+    expect(links[1].textContent.trim()).toEqual('Home');
+    expect(links[2].textContent.trim()).toEqual('Category');
+    expect(links[3].textContent.trim()).toEqual('Subcategory');
 
     const separators = c.querySelectorAll('.ct-breadcrumb__links__separator');
     expect(separators).toHaveLength(2);

--- a/components/02-molecules/breadcrumb/breadcrumb.twig
+++ b/components/02-molecules/breadcrumb/breadcrumb.twig
@@ -25,7 +25,7 @@
     {% set link_items = [] %}
 
     {% for link in links %}
-      {% set link_item %}
+      {% set link_item -%}
         {% set link = {
           text: link.text,
           url: link.url,
@@ -35,24 +35,20 @@
           modifier_class: (loop.index == links_count) ? 'ct-breadcrumb__links__link ct-breadcrumb__links__link--active' : 'ct-breadcrumb__links__link',
         } %}
 
-        {% if (not active_is_link or link.url is empty) and (loop.index == links_count) %}
+        {%- if (not active_is_link or link.url is empty) and (loop.index == links_count) -%}
           <span class="ct-breadcrumb__links__link ct-breadcrumb__links__link--active" aria-current="location">{{ link.text }}</span>
-        {% else %}
-          {% include '@atoms/link/link.twig' with link only %}
+        {%- else -%}
+          {%- include '@atoms/link/link.twig' with link only -%}
+          {%- if loop.index < links_count -%}
+            {%- include '@base/icon/icon.twig' with {
+              symbol: 'right-arrow-1',
+              modifier_class: 'ct-breadcrumb__links__separator',
+            } only -%}
+          {% endif -%}
         {% endif %}
-      {% endset %}
+      {%- endset %}
 
       {% set link_items = link_items|merge([link_item]) %}
-
-      {% if loop.index < links_count %}
-        {% set link_item %}
-          {% include '@base/icon/icon.twig' with {
-            symbol: 'right-arrow-1',
-            modifier_class: 'ct-breadcrumb__links__separator',
-          } only %}
-        {% endset %}
-        {% set link_items = link_items|merge([link_item]) %}
-      {% endif %}
 
       {% if loop.index == links_count - 1 %}
         {% set parent = {
@@ -61,6 +57,7 @@
           theme: theme,
           icon: 'left-arrow',
           icon_placement: 'before',
+          modifier_class: 'ct-breadcrumb__links__link',
         } %}
       {% endif %}
     {% endfor %}

--- a/components/02-molecules/callout/__snapshots__/callout.test.js.snap
+++ b/components/02-molecules/callout/__snapshots__/callout.test.js.snap
@@ -51,9 +51,7 @@ exports[`Callout Component renders with multiple links 1`] = `
                   href="https://example.com"
                   role="button"
                 >
-                  
-
-    Link 1  
+                  Link 1
                 </a>
                 
               
@@ -72,9 +70,7 @@ exports[`Callout Component renders with multiple links 1`] = `
                   href="https://example.com"
                   role="button"
                 >
-                  
-
-    Link 2  
+                  Link 2
                 </a>
                 
               
@@ -93,9 +89,7 @@ exports[`Callout Component renders with multiple links 1`] = `
                   href="https://example.com"
                   role="button"
                 >
-                  
-
-    Link 3  
+                  Link 3
                 </a>
                 
               
@@ -211,28 +205,11 @@ exports[`Callout Component renders with optional attributes 1`] = `
                   role="button"
                   target="_blank"
                 >
-                  
-
-    
-      
-      
-                  
-                              
-          
-                    
-          
-                                
-          
-                                            
-          
-          Link 
+                  Link 
                   <span
                     class="ct-text-icon__group"
                   >
-                    1
-
-
-                                    
+                    1  
                     <svg
                       aria-hidden="true"
                       class="ct-icon  "
@@ -252,12 +229,7 @@ exports[`Callout Component renders with optional attributes 1`] = `
                     </svg>
                     
 
-  
                   </span>
-                  
-                  
-      
-      
                   <span
                     class="ct-visually-hidden"
                   >
@@ -281,9 +253,7 @@ exports[`Callout Component renders with optional attributes 1`] = `
                   href="https://example.com"
                   role="button"
                 >
-                  
-
-    Link 2  
+                  Link 2
                 </a>
                 
               

--- a/components/02-molecules/event-card/__snapshots__/event-card.test.js.snap
+++ b/components/02-molecules/event-card/__snapshots__/event-card.test.js.snap
@@ -68,9 +68,6 @@ exports[`Event Card Component renders with optional attributes 1`] = `
         >
                       
                 
-
-
-                                    
           <svg
             aria-hidden="true"
             class="ct-icon  ct-tag__icon"
@@ -89,8 +86,7 @@ exports[`Event Card Component renders with optional attributes 1`] = `
 
           </svg>
           
-
-                       
+                     
           <span
             class="ct-datetime "
           >
@@ -123,20 +119,13 @@ exports[`Event Card Component renders with optional attributes 1`] = `
         class="ct-heading ct-theme-dark ct-event-card__title"
       >
                                   
-
-
-  
-  
         <a
           class="ct-link ct-theme-dark     ct-event-card__title__link"
           href="https://example.com"
         >
-          
-
-    Event Title  
+          Event Title
         </a>
-        
-                      
+                              
       </h4>
       
               
@@ -235,24 +224,12 @@ exports[`Event Card Component renders with optional attributes 1`] = `
         
             
                           
-
-
-  
-  
         <a
           aria-hidden="true"
           class="ct-link ct-theme-dark    ct-link--only-icon ct-event-card__tags__link"
           href="https://example.com"
           tabindex="-1"
         >
-          
-
-    
-              
-      
-
-
-                                    
           <svg
             aria-hidden="true"
             class="ct-icon  ct-link__icon"
@@ -272,11 +249,8 @@ exports[`Event Card Component renders with optional attributes 1`] = `
           </svg>
           
 
-          
-      
         </a>
-        
-                      
+                              
       </div>
       
               
@@ -330,9 +304,6 @@ exports[`Event Card Component renders with required attributes 1`] = `
         >
                       
                 
-
-
-                                    
           <svg
             aria-hidden="true"
             class="ct-icon  ct-tag__icon"
@@ -351,8 +322,7 @@ exports[`Event Card Component renders with required attributes 1`] = `
 
           </svg>
           
-
-                       
+                     
           <span
             class="ct-datetime "
           >

--- a/components/02-molecules/figure/__snapshots__/figure.test.js.snap
+++ b/components/02-molecules/figure/__snapshots__/figure.test.js.snap
@@ -36,9 +36,6 @@ exports[`Figure Component renders with optional attributes 1`] = `
     >
       
         
-
-
-                                    
       <svg
         aria-hidden="true"
         class="ct-icon  "
@@ -67,8 +64,7 @@ exports[`Figure Component renders with optional attributes 1`] = `
 
       </svg>
       
-
-          This is the image caption.
+        This is the image caption.
       
     </figcaption>
     

--- a/components/02-molecules/group-filter/__snapshots__/group-filter.test.js.snap
+++ b/components/02-molecules/group-filter/__snapshots__/group-filter.test.js.snap
@@ -111,21 +111,14 @@ exports[`Group Filter Component renders with content top and bottom 1`] = `
                     >
                       
     
-
-
-  
-  
                       <a
                         class="ct-link ct-theme-light     ct-popover__link"
                         data-collapsible-trigger=""
                         tabindex="0"
                       >
-                        
-
-    Filter 1  
+                        Filter 1
                       </a>
                       
-
     
                       <div
                         class="ct-popover__content"
@@ -168,21 +161,14 @@ exports[`Group Filter Component renders with content top and bottom 1`] = `
                     >
                       
     
-
-
-  
-  
                       <a
                         class="ct-link ct-theme-light     ct-popover__link"
                         data-collapsible-trigger=""
                         tabindex="0"
                       >
-                        
-
-    Filter 2  
+                        Filter 2
                       </a>
                       
-
     
                       <div
                         class="ct-popover__content"
@@ -237,15 +223,6 @@ exports[`Group Filter Component renders with content top and bottom 1`] = `
                   data-component-name="button"
                   type="submit"
                 >
-                  
-
-    
-              
-      
-        
-
-
-                                    
                   <svg
                     aria-hidden="true"
                     class="ct-icon  ct-button__icon"
@@ -264,10 +241,7 @@ exports[`Group Filter Component renders with content top and bottom 1`] = `
 
                   </svg>
                   
-
-          Apply filters
-      
-      
+Apply filters
                 </button>
                 
 								
@@ -402,21 +376,14 @@ exports[`Group Filter Component renders with custom attributes and classes 1`] =
                     >
                       
     
-
-
-  
-  
                       <a
                         class="ct-link ct-theme-light     ct-popover__link"
                         data-collapsible-trigger=""
                         tabindex="0"
                       >
-                        
-
-    Filter 1  
+                        Filter 1
                       </a>
                       
-
     
                       <div
                         class="ct-popover__content"
@@ -459,21 +426,14 @@ exports[`Group Filter Component renders with custom attributes and classes 1`] =
                     >
                       
     
-
-
-  
-  
                       <a
                         class="ct-link ct-theme-light     ct-popover__link"
                         data-collapsible-trigger=""
                         tabindex="0"
                       >
-                        
-
-    Filter 2  
+                        Filter 2
                       </a>
                       
-
     
                       <div
                         class="ct-popover__content"
@@ -528,15 +488,6 @@ exports[`Group Filter Component renders with custom attributes and classes 1`] =
                   data-component-name="button"
                   type="submit"
                 >
-                  
-
-    
-              
-      
-        
-
-
-                                    
                   <svg
                     aria-hidden="true"
                     class="ct-icon  ct-button__icon"
@@ -555,10 +506,7 @@ exports[`Group Filter Component renders with custom attributes and classes 1`] =
 
                   </svg>
                   
-
-          Apply filters
-      
-      
+Apply filters
                 </button>
                 
 								
@@ -685,21 +633,14 @@ exports[`Group Filter Component renders with custom title and submit text 1`] = 
                     >
                       
     
-
-
-  
-  
                       <a
                         class="ct-link ct-theme-light     ct-popover__link"
                         data-collapsible-trigger=""
                         tabindex="0"
                       >
-                        
-
-    Filter 1  
+                        Filter 1
                       </a>
                       
-
     
                       <div
                         class="ct-popover__content"
@@ -742,21 +683,14 @@ exports[`Group Filter Component renders with custom title and submit text 1`] = 
                     >
                       
     
-
-
-  
-  
                       <a
                         class="ct-link ct-theme-light     ct-popover__link"
                         data-collapsible-trigger=""
                         tabindex="0"
                       >
-                        
-
-    Filter 2  
+                        Filter 2
                       </a>
                       
-
     
                       <div
                         class="ct-popover__content"
@@ -811,15 +745,6 @@ exports[`Group Filter Component renders with custom title and submit text 1`] = 
                   data-component-name="button"
                   type="submit"
                 >
-                  
-
-    
-              
-      
-        
-
-
-                                    
                   <svg
                     aria-hidden="true"
                     class="ct-icon  ct-button__icon"
@@ -838,10 +763,7 @@ exports[`Group Filter Component renders with custom title and submit text 1`] = 
 
                   </svg>
                   
-
-          Submit Filters
-      
-      
+Submit Filters
                 </button>
                 
 								
@@ -968,21 +890,14 @@ exports[`Group Filter Component renders with default values 1`] = `
                     >
                       
     
-
-
-  
-  
                       <a
                         class="ct-link ct-theme-light     ct-popover__link"
                         data-collapsible-trigger=""
                         tabindex="0"
                       >
-                        
-
-    Filter 1  
+                        Filter 1
                       </a>
                       
-
     
                       <div
                         class="ct-popover__content"
@@ -1025,21 +940,14 @@ exports[`Group Filter Component renders with default values 1`] = `
                     >
                       
     
-
-
-  
-  
                       <a
                         class="ct-link ct-theme-light     ct-popover__link"
                         data-collapsible-trigger=""
                         tabindex="0"
                       >
-                        
-
-    Filter 2  
+                        Filter 2
                       </a>
                       
-
     
                       <div
                         class="ct-popover__content"
@@ -1094,15 +1002,6 @@ exports[`Group Filter Component renders with default values 1`] = `
                   data-component-name="button"
                   type="submit"
                 >
-                  
-
-    
-              
-      
-        
-
-
-                                    
                   <svg
                     aria-hidden="true"
                     class="ct-icon  ct-button__icon"
@@ -1121,10 +1020,7 @@ exports[`Group Filter Component renders with default values 1`] = `
 
                   </svg>
                   
-
-          Apply filters
-      
-      
+Apply filters
                 </button>
                 
 								
@@ -1258,21 +1154,14 @@ exports[`Group Filter Component renders with form attributes and hidden fields 1
                       >
                         
     
-
-
-  
-  
                         <a
                           class="ct-link ct-theme-light     ct-popover__link"
                           data-collapsible-trigger=""
                           tabindex="0"
                         >
-                          
-
-    Filter 1  
+                          Filter 1
                         </a>
                         
-
     
                         <div
                           class="ct-popover__content"
@@ -1315,21 +1204,14 @@ exports[`Group Filter Component renders with form attributes and hidden fields 1
                       >
                         
     
-
-
-  
-  
                         <a
                           class="ct-link ct-theme-light     ct-popover__link"
                           data-collapsible-trigger=""
                           tabindex="0"
                         >
-                          
-
-    Filter 2  
+                          Filter 2
                         </a>
                         
-
     
                         <div
                           class="ct-popover__content"
@@ -1384,15 +1266,6 @@ exports[`Group Filter Component renders with form attributes and hidden fields 1
                     data-component-name="button"
                     type="submit"
                   >
-                    
-
-    
-              
-      
-        
-
-
-                                    
                     <svg
                       aria-hidden="true"
                       class="ct-icon  ct-button__icon"
@@ -1411,10 +1284,7 @@ exports[`Group Filter Component renders with form attributes and hidden fields 1
 
                     </svg>
                     
-
-          Apply filters
-      
-      
+Apply filters
                   </button>
                   
 								

--- a/components/02-molecules/map/__snapshots__/map.test.js.snap
+++ b/components/02-molecules/map/__snapshots__/map.test.js.snap
@@ -63,28 +63,11 @@ exports[`Map Component renders with default view text 1`] = `
             role="button"
             target="_blank"
           >
-            
-
-    
-      
-      
-                  
-                              
-          
-                    
-          
-                                
-          
-                                            
-          
-          View in Google 
+            View in Google 
             <span
               class="ct-text-icon__group"
             >
-              Maps
-
-
-                                    
+              Maps  
               <svg
                 aria-hidden="true"
                 class="ct-icon  "
@@ -104,12 +87,7 @@ exports[`Map Component renders with default view text 1`] = `
               </svg>
               
 
-  
             </span>
-            
-                  
-      
-      
             <span
               class="ct-visually-hidden"
             >
@@ -196,28 +174,11 @@ exports[`Map Component renders with optional attributes 1`] = `
             role="button"
             target="_blank"
           >
-            
-
-    
-      
-      
-                  
-                              
-          
-                    
-          
-                                
-          
-                                            
-          
-          View in Google 
+            View in Google 
             <span
               class="ct-text-icon__group"
             >
-              Maps
-
-
-                                    
+              Maps  
               <svg
                 aria-hidden="true"
                 class="ct-icon  "
@@ -237,12 +198,7 @@ exports[`Map Component renders with optional attributes 1`] = `
               </svg>
               
 
-  
             </span>
-            
-                  
-      
-      
             <span
               class="ct-visually-hidden"
             >

--- a/components/02-molecules/navigation-card/__snapshots__/navigation-card.test.js.snap
+++ b/components/02-molecules/navigation-card/__snapshots__/navigation-card.test.js.snap
@@ -101,32 +101,11 @@ exports[`Navigation Card Component renders with link when provided 1`] = `
         class="ct-heading ct-theme-light ct-navigation-card__title"
       >
                                   
-
-
-  
-  
         <a
           class="ct-link ct-theme-light     ct-navigation-card__title__link"
           href="https://example.com"
         >
-          
-
-    
-              
-      
-                  
-                              
-          
-                    
-          
-                                
-          
-          
-          
-          Card Title
-
-
-                                    
+          Card Title 
           <svg
             aria-hidden="true"
             class="ct-icon  ct-link__icon"
@@ -146,12 +125,8 @@ exports[`Navigation Card Component renders with link when provided 1`] = `
           </svg>
           
 
-                  
-      
-      
         </a>
-        
-                      
+                              
       </h4>
       
               
@@ -237,33 +212,12 @@ exports[`Navigation Card Component renders with optional attributes, no icon, im
         class="ct-heading ct-theme-dark ct-navigation-card__title"
       >
                                   
-
-
-  
-  
         <a
           class="ct-link ct-theme-dark     ct-navigation-card__title__link"
           href="https://example.com"
           target="_blank"
         >
-          
-
-    
-              
-      
-                  
-                              
-          
-                    
-          
-                                
-          
-          
-          
-          Card Title
-
-
-                                    
+          Card Title 
           <svg
             aria-hidden="true"
             class="ct-icon  ct-link__icon"
@@ -283,17 +237,13 @@ exports[`Navigation Card Component renders with optional attributes, no icon, im
           </svg>
           
 
-                  
-      
-      
           <span
             class="ct-visually-hidden"
           >
             (Opens in a new tab/window)
           </span>
         </a>
-        
-                      
+                              
       </h4>
       
               
@@ -362,9 +312,6 @@ exports[`Navigation Card Component renders with optional attributes, with icon 1
       >
         
                           
-
-
-                                    
         <svg
           aria-hidden="true"
           class="ct-icon ct-icon--size-extra-large "
@@ -383,8 +330,7 @@ exports[`Navigation Card Component renders with optional attributes, with icon 1
 
         </svg>
         
-
-                                        
+                                      
         <div
           class="ct-icon ct-icon--size-extra-large ct-navigation-card__icon__image"
         >
@@ -414,33 +360,12 @@ exports[`Navigation Card Component renders with optional attributes, with icon 1
         class="ct-heading ct-theme-dark ct-navigation-card__title"
       >
                                   
-
-
-  
-  
         <a
           class="ct-link ct-theme-dark     ct-navigation-card__title__link"
           href="https://example.com"
           target="_blank"
         >
-          
-
-    
-              
-      
-                  
-                              
-          
-                    
-          
-                                
-          
-          
-          
-          Card Title
-
-
-                                    
+          Card Title 
           <svg
             aria-hidden="true"
             class="ct-icon  ct-link__icon"
@@ -460,17 +385,13 @@ exports[`Navigation Card Component renders with optional attributes, with icon 1
           </svg>
           
 
-                  
-      
-      
           <span
             class="ct-visually-hidden"
           >
             (Opens in a new tab/window)
           </span>
         </a>
-        
-                      
+                              
       </h4>
       
               

--- a/components/02-molecules/next-step/__snapshots__/next-step.test.js.snap
+++ b/components/02-molecules/next-step/__snapshots__/next-step.test.js.snap
@@ -53,32 +53,11 @@ exports[`Next Steps Component renders with link when provided 1`] = `
                 class="ct-heading ct-theme-light ct-next-step__title"
               >
                                                                   
-
-
-  
-  
                 <a
                   class="ct-link ct-theme-light     ct-next-step__title__link"
                   href="https://example.com"
                 >
-                  
-
-    
-              
-      
-                  
-                              
-          
-                    
-          
-                                
-          
-          
-          
-          Next Steps Title
-
-
-                                    
+                  Next Steps Title 
                   <svg
                     aria-hidden="true"
                     class="ct-icon  ct-link__icon"
@@ -98,12 +77,8 @@ exports[`Next Steps Component renders with link when provided 1`] = `
                   </svg>
                   
 
-                  
-      
-      
                 </a>
-                
-                                              
+                                                              
               </h4>
               
                                       
@@ -192,33 +167,12 @@ exports[`Next Steps Component renders with optional attributes 1`] = `
                 class="ct-heading ct-theme-dark ct-next-step__title"
               >
                                                                   
-
-
-  
-  
                 <a
                   class="ct-link ct-theme-dark ct-link--external    ct-next-step__title__link"
                   href="https://example.com"
                   target="_blank"
                 >
-                  
-
-    
-              
-      
-                  
-                              
-          
-                    
-          
-                                
-          
-          
-          
-          Next Steps Title
-
-
-                                    
+                  Next Steps Title 
                   <svg
                     aria-hidden="true"
                     class="ct-icon  ct-link__icon"
@@ -238,17 +192,13 @@ exports[`Next Steps Component renders with optional attributes 1`] = `
                   </svg>
                   
 
-                  
-      
-      
                   <span
                     class="ct-visually-hidden"
                   >
                     (Opens in a new tab/window)
                   </span>
                 </a>
-                
-                                              
+                                                              
               </h4>
               
                                       

--- a/components/02-molecules/pagination/__snapshots__/pagination.test.js.snap
+++ b/components/02-molecules/pagination/__snapshots__/pagination.test.js.snap
@@ -42,24 +42,11 @@ exports[`Pagination Component renders current page correctly 1`] = `
         
                           
         
-
-
-  
-  
         <a
           class="ct-link ct-theme-light     ct-pagination__link"
           href="#previous"
           title="Go to previous page - page 1"
         >
-          
-
-    
-              
-      
-        
-
-
-                                    
           <svg
             aria-hidden="true"
             class="ct-icon  ct-link__icon"
@@ -78,13 +65,9 @@ exports[`Pagination Component renders current page correctly 1`] = `
 
           </svg>
           
-
-          Previous
-      
-      
+Previous
         </a>
-        
-      
+              
       </li>
       
 
@@ -96,21 +79,14 @@ exports[`Pagination Component renders current page correctly 1`] = `
       >
         
                                           
-
-
-  
-  
         <a
           class="ct-link ct-theme-light     ct-pagination__item__link"
           href="#1"
           title="Go to page 1 of 3"
         >
-          
-
-    1  
+          1
         </a>
-        
-        
+                
       </li>
       
 
@@ -122,21 +98,14 @@ exports[`Pagination Component renders current page correctly 1`] = `
       >
         
                                           
-
-
-  
-  
         <a
           class="ct-link ct-theme-light  ct-link--active   ct-pagination__item__link"
           href="#2"
           title="Current page"
         >
-          
-
-    2  
+          2
         </a>
-        
-        
+                
       </li>
       
 
@@ -148,21 +117,14 @@ exports[`Pagination Component renders current page correctly 1`] = `
       >
         
                                           
-
-
-  
-  
         <a
           class="ct-link ct-theme-light     ct-pagination__item__link"
           href="#3"
           title="Go to page 3 of 3"
         >
-          
-
-    3  
+          3
         </a>
-        
-        
+                
       </li>
       
 
@@ -175,38 +137,17 @@ exports[`Pagination Component renders current page correctly 1`] = `
         
                           
         
-
-
-  
-  
         <a
           class="ct-link ct-theme-light   ct-link--disabled  ct-pagination__link"
           disabled=""
           href="#next"
           title="Go to next page"
         >
-          
-
-    
-              
-      
-                  
-                              
-          
-                    
-          
-                                
-          
-          
-          
            
           <span
             class="ct-text-icon__group"
           >
-            Next
-
-
-                                    
+            Next 
             <svg
               aria-hidden="true"
               class="ct-icon  ct-link__icon"
@@ -226,15 +167,9 @@ exports[`Pagination Component renders current page correctly 1`] = `
             </svg>
             
 
-          
           </span>
-          
-                  
-      
-      
         </a>
-        
-      
+              
       </li>
       
 
@@ -361,24 +296,11 @@ exports[`Pagination Component renders with optional attributes 1`] = `
       >
         
                     
-
-
-  
-  
         <a
           class="ct-link ct-theme-dark     ct-pagination__link"
           href="#first"
           title="Go to first page"
         >
-          
-
-    
-              
-      
-        
-
-
-                                    
           <svg
             aria-hidden="true"
             class="ct-icon  ct-link__icon"
@@ -397,13 +319,9 @@ exports[`Pagination Component renders with optional attributes 1`] = `
 
           </svg>
           
-
-          First
-      
-      
+First
         </a>
-        
-        
+                
       </li>
       
       
@@ -415,24 +333,11 @@ exports[`Pagination Component renders with optional attributes 1`] = `
         
                           
         
-
-
-  
-  
         <a
           class="ct-link ct-theme-dark     ct-pagination__link"
           href="#previous"
           title="Go to previous page - page 1"
         >
-          
-
-    
-              
-      
-        
-
-
-                                    
           <svg
             aria-hidden="true"
             class="ct-icon  ct-link__icon"
@@ -451,13 +356,9 @@ exports[`Pagination Component renders with optional attributes 1`] = `
 
           </svg>
           
-
-          Previous
-      
-      
+Previous
         </a>
-        
-      
+              
       </li>
       
 
@@ -469,21 +370,14 @@ exports[`Pagination Component renders with optional attributes 1`] = `
       >
         
                                           
-
-
-  
-  
         <a
           class="ct-link ct-theme-dark     ct-pagination__item__link"
           href="#1"
           title="Go to page 1 of 3"
         >
-          
-
-    1  
+          1
         </a>
-        
-        
+                
       </li>
       
 
@@ -495,21 +389,14 @@ exports[`Pagination Component renders with optional attributes 1`] = `
       >
         
                                           
-
-
-  
-  
         <a
           class="ct-link ct-theme-dark  ct-link--active   ct-pagination__item__link"
           href="#2"
           title="Current page"
         >
-          
-
-    2  
+          2
         </a>
-        
-        
+                
       </li>
       
 
@@ -531,21 +418,14 @@ exports[`Pagination Component renders with optional attributes 1`] = `
       >
         
                                           
-
-
-  
-  
         <a
           class="ct-link ct-theme-dark     ct-pagination__item__link"
           href="#3"
           title="Go to page 3 of 3"
         >
-          
-
-    3  
+          3
         </a>
-        
-        
+                
       </li>
       
 
@@ -558,38 +438,17 @@ exports[`Pagination Component renders with optional attributes 1`] = `
         
                           
         
-
-
-  
-  
         <a
           class="ct-link ct-theme-dark   ct-link--disabled  ct-pagination__link"
           disabled=""
           href="#next"
           title="Go to next page"
         >
-          
-
-    
-              
-      
-                  
-                              
-          
-                    
-          
-                                
-          
-          
-          
            
           <span
             class="ct-text-icon__group"
           >
-            Next
-
-
-                                    
+            Next 
             <svg
               aria-hidden="true"
               class="ct-icon  ct-link__icon"
@@ -609,15 +468,9 @@ exports[`Pagination Component renders with optional attributes 1`] = `
             </svg>
             
 
-          
           </span>
-          
-                  
-      
-      
         </a>
-        
-      
+              
       </li>
       
 
@@ -628,38 +481,17 @@ exports[`Pagination Component renders with optional attributes 1`] = `
       >
         
           
-
-
-  
-  
         <a
           class="ct-link ct-theme-dark   ct-link--disabled  ct-pagination__link"
           disabled=""
           href="#last"
           title="Go to last page"
         >
-          
-
-    
-              
-      
-                  
-                              
-          
-                    
-          
-                                
-          
-          
-          
            
           <span
             class="ct-text-icon__group"
           >
-            Last
-
-
-                                    
+            Last 
             <svg
               aria-hidden="true"
               class="ct-icon  ct-link__icon"
@@ -679,15 +511,9 @@ exports[`Pagination Component renders with optional attributes 1`] = `
             </svg>
             
 
-          
           </span>
-          
-                  
-      
-      
         </a>
-        
-        
+                
       </li>
       
           
@@ -734,24 +560,11 @@ exports[`Pagination Component renders with required attributes 1`] = `
         
                           
         
-
-
-  
-  
         <a
           class="ct-link ct-theme-light     ct-pagination__link"
           href="#previous"
           title="Go to previous page - page 1"
         >
-          
-
-    
-              
-      
-        
-
-
-                                    
           <svg
             aria-hidden="true"
             class="ct-icon  ct-link__icon"
@@ -770,13 +583,9 @@ exports[`Pagination Component renders with required attributes 1`] = `
 
           </svg>
           
-
-          Previous
-      
-      
+Previous
         </a>
-        
-      
+              
       </li>
       
 
@@ -788,21 +597,14 @@ exports[`Pagination Component renders with required attributes 1`] = `
       >
         
                                           
-
-
-  
-  
         <a
           class="ct-link ct-theme-light     ct-pagination__item__link"
           href="#1"
           title="Go to page 1 of 3"
         >
-          
-
-    1  
+          1
         </a>
-        
-        
+                
       </li>
       
 
@@ -814,21 +616,14 @@ exports[`Pagination Component renders with required attributes 1`] = `
       >
         
                                           
-
-
-  
-  
         <a
           class="ct-link ct-theme-light  ct-link--active   ct-pagination__item__link"
           href="#2"
           title="Current page"
         >
-          
-
-    2  
+          2
         </a>
-        
-        
+                
       </li>
       
 
@@ -840,21 +635,14 @@ exports[`Pagination Component renders with required attributes 1`] = `
       >
         
                                           
-
-
-  
-  
         <a
           class="ct-link ct-theme-light     ct-pagination__item__link"
           href="#3"
           title="Go to page 3 of 3"
         >
-          
-
-    3  
+          3
         </a>
-        
-        
+                
       </li>
       
 
@@ -867,38 +655,17 @@ exports[`Pagination Component renders with required attributes 1`] = `
         
                           
         
-
-
-  
-  
         <a
           class="ct-link ct-theme-light   ct-link--disabled  ct-pagination__link"
           disabled=""
           href="#next"
           title="Go to next page"
         >
-          
-
-    
-              
-      
-                  
-                              
-          
-                    
-          
-                                
-          
-          
-          
            
           <span
             class="ct-text-icon__group"
           >
-            Next
-
-
-                                    
+            Next 
             <svg
               aria-hidden="true"
               class="ct-icon  ct-link__icon"
@@ -918,15 +685,9 @@ exports[`Pagination Component renders with required attributes 1`] = `
             </svg>
             
 
-          
           </span>
-          
-                  
-      
-      
         </a>
-        
-      
+              
       </li>
       
 

--- a/components/02-molecules/promo-card/__snapshots__/promo-card.test.js.snap
+++ b/components/02-molecules/promo-card/__snapshots__/promo-card.test.js.snap
@@ -35,20 +35,13 @@ exports[`Promo Card Component renders with link when provided 1`] = `
         class="ct-heading ct-theme-light ct-promo-card__title"
       >
                                       
-
-
-  
-  
         <a
           class="ct-link ct-theme-light     ct-promo-card__title__link"
           href="https://example.com"
         >
-          
-
-    Promo Card Title  
+          Promo Card Title
         </a>
-        
-                          
+                                  
       </h4>
       
                   
@@ -70,24 +63,12 @@ exports[`Promo Card Component renders with link when provided 1`] = `
         
               
                               
-
-
-  
-  
         <a
           aria-hidden="true"
           class="ct-link ct-theme-light    ct-link--only-icon ct-promo-card__tags__link"
           href="https://example.com"
           tabindex="-1"
         >
-          
-
-    
-              
-      
-
-
-                                    
           <svg
             aria-hidden="true"
             class="ct-icon  ct-link__icon"
@@ -107,11 +88,8 @@ exports[`Promo Card Component renders with link when provided 1`] = `
           </svg>
           
 
-          
-      
         </a>
-        
-                          
+                                  
       </div>
       
                   
@@ -244,26 +222,19 @@ exports[`Promo Card Component renders with optional attributes 1`] = `
         class="ct-heading ct-theme-dark ct-promo-card__title"
       >
                                       
-
-
-  
-  
         <a
           class="ct-link ct-theme-dark     ct-promo-card__title__link"
           href="https://example.com"
           target="_blank"
         >
-          
-
-    Promo Card Title  
+          Promo Card Title
           <span
             class="ct-visually-hidden"
           >
             (Opens in a new tab/window)
           </span>
         </a>
-        
-                          
+                                  
       </h4>
       
                   
@@ -352,10 +323,6 @@ exports[`Promo Card Component renders with optional attributes 1`] = `
         
               
                               
-
-
-  
-  
         <a
           aria-hidden="true"
           class="ct-link ct-theme-dark    ct-link--only-icon ct-promo-card__tags__link"
@@ -363,14 +330,6 @@ exports[`Promo Card Component renders with optional attributes 1`] = `
           tabindex="-1"
           target="_blank"
         >
-          
-
-    
-              
-      
-
-
-                                    
           <svg
             aria-hidden="true"
             class="ct-icon  ct-link__icon"
@@ -390,16 +349,13 @@ exports[`Promo Card Component renders with optional attributes 1`] = `
           </svg>
           
 
-          
-      
           <span
             class="ct-visually-hidden"
           >
             (Opens in a new tab/window)
           </span>
         </a>
-        
-                          
+                                  
       </div>
       
                   

--- a/components/02-molecules/publication-card/__snapshots__/publication-card.test.js.snap
+++ b/components/02-molecules/publication-card/__snapshots__/publication-card.test.js.snap
@@ -29,27 +29,19 @@ exports[`Publication Card Component renders file link with extension and size 1`
                     
                                 
         
-
-
-  
-  
       <a
         class="ct-link ct-theme-light     ct-publication-card__link"
         href="https://example.com/sample.pdf"
         title="Download Sample File"
       >
-        
-
-    Sample File 
+        Sample File 
         <span
           class="ct-publication-card__link__extension"
         >
           (PDF, 2MB)
         </span>
-          
       </a>
-      
-      
+            
                         
     </div>
     
@@ -120,32 +112,11 @@ exports[`Publication Card Component renders with optional attributes 1`] = `
         class="ct-heading ct-theme-dark ct-publication-card__title"
       >
                     
-
-
-  
-  
         <a
           class="ct-link ct-theme-dark     ct-publication-card__title__link"
           href="https://example.com/sample.pdf"
         >
-          
-
-    
-              
-      
-                  
-                              
-          
-                    
-          
-                                
-          
-          
-          
-          Publication Card Title
-
-
-                                    
+          Publication Card Title 
           <svg
             aria-hidden="true"
             class="ct-icon  ct-link__icon"
@@ -165,12 +136,8 @@ exports[`Publication Card Component renders with optional attributes 1`] = `
           </svg>
           
 
-                  
-      
-      
         </a>
-        
-          
+                  
       </h4>
       
               
@@ -194,27 +161,19 @@ exports[`Publication Card Component renders with optional attributes 1`] = `
                     
                                 
         
-
-
-  
-  
       <a
         class="ct-link ct-theme-dark     ct-publication-card__link"
         href="https://example.com/sample.pdf"
         title="Download Sample File"
       >
-        
-
-    Sample File 
+        Sample File 
         <span
           class="ct-publication-card__link__extension"
         >
           (PDF, 2MB)
         </span>
-          
       </a>
-      
-      
+            
                         
       <div
         class="ct-publication-card__content-bottom"
@@ -257,32 +216,11 @@ exports[`Publication Card Component renders with required attributes 1`] = `
         class="ct-heading ct-theme-light ct-publication-card__title"
       >
                     
-
-
-  
-  
         <a
           class="ct-link ct-theme-light     ct-publication-card__title__link"
           href="https://example.com/sample.pdf"
         >
-          
-
-    
-              
-      
-                  
-                              
-          
-                    
-          
-                                
-          
-          
-          
-          Publication Card Title
-
-
-                                    
+          Publication Card Title 
           <svg
             aria-hidden="true"
             class="ct-icon  ct-link__icon"
@@ -302,12 +240,8 @@ exports[`Publication Card Component renders with required attributes 1`] = `
           </svg>
           
 
-                  
-      
-      
         </a>
-        
-          
+                  
       </h4>
       
               
@@ -315,27 +249,19 @@ exports[`Publication Card Component renders with required attributes 1`] = `
                     
                                 
         
-
-
-  
-  
       <a
         class="ct-link ct-theme-light     ct-publication-card__link"
         href="https://example.com/sample.pdf"
         title="Download Sample File"
       >
-        
-
-    Sample File 
+        Sample File 
         <span
           class="ct-publication-card__link__extension"
         >
           (PDF, 2MB)
         </span>
-          
       </a>
-      
-      
+            
                         
     </div>
     
@@ -376,27 +302,19 @@ exports[`Publication Card Component renders with summary when provided 1`] = `
                     
                                 
         
-
-
-  
-  
       <a
         class="ct-link ct-theme-light     ct-publication-card__link"
         href="https://example.com/sample.pdf"
         title="Download Sample File"
       >
-        
-
-    Sample File 
+        Sample File 
         <span
           class="ct-publication-card__link__extension"
         >
           (PDF, 2MB)
         </span>
-          
       </a>
-      
-      
+            
                         
     </div>
     

--- a/components/02-molecules/search/__snapshots__/search.test.js.snap
+++ b/components/02-molecules/search/__snapshots__/search.test.js.snap
@@ -11,36 +11,15 @@ exports[`Search Component renders with URL only 1`] = `
   >
     
   
-
-
-  
-  
     <a
       class="ct-link ct-theme-light     ct-search__link"
       href="https://example.com/search"
     >
-      
-
-    
-              
-      
-                  
-                              
-          
-                    
-          
-                                
-          
-          
-          
-           
+       
       <span
         class="ct-text-icon__group"
       >
-        Search
-
-
-                                    
+        Search 
         <svg
           aria-hidden="true"
           class="ct-icon  ct-link__icon"
@@ -60,15 +39,8 @@ exports[`Search Component renders with URL only 1`] = `
         </svg>
         
 
-          
       </span>
-      
-                  
-      
-      
     </a>
-    
-
   </div>
   
 
@@ -87,36 +59,15 @@ exports[`Search Component renders with optional attributes 1`] = `
   >
     
   
-
-
-  
-  
     <a
       class="ct-link ct-theme-dark     ct-search__link"
       href="https://example.com/search"
     >
-      
-
-    
-              
-      
-                  
-                              
-          
-                    
-          
-                                
-          
-          
-          
-           
+       
       <span
         class="ct-text-icon__group"
       >
-        Search
-
-
-                                    
+        Search 
         <svg
           aria-hidden="true"
           class="ct-icon  ct-link__icon"
@@ -136,15 +87,8 @@ exports[`Search Component renders with optional attributes 1`] = `
         </svg>
         
 
-          
       </span>
-      
-                  
-      
-      
     </a>
-    
-
   </div>
   
 
@@ -162,36 +106,15 @@ exports[`Search Component renders with required attributes 1`] = `
   >
     
   
-
-
-  
-  
     <a
       class="ct-link ct-theme-light     ct-search__link"
       href="https://example.com/search"
     >
-      
-
-    
-              
-      
-                  
-                              
-          
-                    
-          
-                                
-          
-          
-          
-           
+       
       <span
         class="ct-text-icon__group"
       >
-        Search
-
-
-                                    
+        Search 
         <svg
           aria-hidden="true"
           class="ct-icon  ct-link__icon"
@@ -211,15 +134,8 @@ exports[`Search Component renders with required attributes 1`] = `
         </svg>
         
 
-          
       </span>
-      
-                  
-      
-      
     </a>
-    
-
   </div>
   
 

--- a/components/02-molecules/service-card/__snapshots__/service-card.test.js.snap
+++ b/components/02-molecules/service-card/__snapshots__/service-card.test.js.snap
@@ -53,20 +53,13 @@ exports[`Service Card Component renders with content slots 1`] = `
           class="ct-item-list__item"
         >
                           
-
-
-  
-  
           <a
             class="ct-link ct-theme-light"
             href="https://example.com/link1"
           >
-            
-
-    Link 1  
+            Link 1
           </a>
-          
-              
+                        
         </li>
         
                         
@@ -74,20 +67,13 @@ exports[`Service Card Component renders with content slots 1`] = `
           class="ct-item-list__item"
         >
                           
-
-
-  
-  
           <a
             class="ct-link ct-theme-light"
             href="https://example.com/link2"
           >
-            
-
-    Link 2  
+            Link 2
           </a>
-          
-              
+                        
         </li>
         
             
@@ -157,37 +143,16 @@ exports[`Service Card Component renders with optional attributes 1`] = `
           class="ct-item-list__item"
         >
                           
-
-
-  
-  
           <a
             class="ct-link ct-theme-dark ct-link--external"
             href="https://example.com/link1"
             target="_blank"
           >
-            
-
-    
-      
-      
-                  
-                              
-          
-                    
-          
-                                
-          
-                                            
-          
-          Link 
+            Link 
             <span
               class="ct-text-icon__group"
             >
-              1
-
-
-                                    
+              1  
               <svg
                 aria-hidden="true"
                 class="ct-icon  "
@@ -207,20 +172,14 @@ exports[`Service Card Component renders with optional attributes 1`] = `
               </svg>
               
 
-  
             </span>
-            
-                  
-      
-      
             <span
               class="ct-visually-hidden"
             >
               (Opens in a new tab/window)
             </span>
           </a>
-          
-              
+                        
         </li>
         
                         
@@ -228,20 +187,13 @@ exports[`Service Card Component renders with optional attributes 1`] = `
           class="ct-item-list__item"
         >
                           
-
-
-  
-  
           <a
             class="ct-link ct-theme-dark"
             href="https://example.com/link2"
           >
-            
-
-    Link 2  
+            Link 2
           </a>
-          
-              
+                        
         </li>
         
             
@@ -303,20 +255,13 @@ exports[`Service Card Component renders with required attributes 1`] = `
           class="ct-item-list__item"
         >
                           
-
-
-  
-  
           <a
             class="ct-link ct-theme-light"
             href="https://example.com/link1"
           >
-            
-
-    Link 1  
+            Link 1
           </a>
-          
-              
+                        
         </li>
         
                         
@@ -324,20 +269,13 @@ exports[`Service Card Component renders with required attributes 1`] = `
           class="ct-item-list__item"
         >
                           
-
-
-  
-  
           <a
             class="ct-link ct-theme-light"
             href="https://example.com/link2"
           >
-            
-
-    Link 2  
+            Link 2
           </a>
-          
-              
+                        
         </li>
         
             

--- a/components/02-molecules/single-filter/__snapshots__/single-filter.test.js.snap
+++ b/components/02-molecules/single-filter/__snapshots__/single-filter.test.js.snap
@@ -85,9 +85,6 @@ exports[`Single Filter Component renders with multiple selection enabled 1`] = `
                       type="checkbox"
                     />
                     Filter 1        
-
-
-                                    
                     <svg
                       aria-hidden="true"
                       class="ct-icon  ct-chip__dismiss"
@@ -106,8 +103,7 @@ exports[`Single Filter Component renders with multiple selection enabled 1`] = `
 
                     </svg>
                     
-
-            
+          
                   </label>
                   
   															
@@ -132,9 +128,6 @@ exports[`Single Filter Component renders with multiple selection enabled 1`] = `
                       type="checkbox"
                     />
                     Filter 2        
-
-
-                                    
                     <svg
                       aria-hidden="true"
                       class="ct-icon  ct-chip__dismiss"
@@ -153,8 +146,7 @@ exports[`Single Filter Component renders with multiple selection enabled 1`] = `
 
                     </svg>
                     
-
-            
+          
                   </label>
                   
   															
@@ -179,28 +171,11 @@ exports[`Single Filter Component renders with multiple selection enabled 1`] = `
                 data-component-name="button"
                 type="submit"
               >
-                
-
-    
-              
-      
-                  
-                              
-          
-                    
-          
-                                
-          
-          
-          
-          Apply 
+                Apply 
                 <span
                   class="ct-text-icon__group"
                 >
-                  filter
-
-
-                                    
+                  filter 
                   <svg
                     aria-hidden="true"
                     class="ct-icon  ct-button__icon"
@@ -220,12 +195,7 @@ exports[`Single Filter Component renders with multiple selection enabled 1`] = `
                   </svg>
                   
 
-          
                 </span>
-                
-                  
-      
-      
               </button>
               
 
@@ -386,28 +356,11 @@ exports[`Single Filter Component renders with optional attributes 1`] = `
                 data-component-name="button"
                 type="submit"
               >
-                
-
-    
-              
-      
-                  
-                              
-          
-                    
-          
-                                
-          
-          
-          
-          Apply 
+                Apply 
                 <span
                   class="ct-text-icon__group"
                 >
-                  filter
-
-
-                                    
+                  filter 
                   <svg
                     aria-hidden="true"
                     class="ct-icon  ct-button__icon"
@@ -427,12 +380,7 @@ exports[`Single Filter Component renders with optional attributes 1`] = `
                   </svg>
                   
 
-          
                 </span>
-                
-                  
-      
-      
               </button>
               
 
@@ -601,28 +549,11 @@ exports[`Single Filter Component renders with required attributes 1`] = `
                 data-component-name="button"
                 type="submit"
               >
-                
-
-    
-              
-      
-                  
-                              
-          
-                    
-          
-                                
-          
-          
-          
-          Apply 
+                Apply 
                 <span
                   class="ct-text-icon__group"
                 >
-                  filter
-
-
-                                    
+                  filter 
                   <svg
                     aria-hidden="true"
                     class="ct-icon  ct-button__icon"
@@ -642,12 +573,7 @@ exports[`Single Filter Component renders with required attributes 1`] = `
                   </svg>
                   
 
-          
                 </span>
-                
-                  
-      
-      
               </button>
               
 

--- a/components/02-molecules/snippet/__snapshots__/snippet.test.js.snap
+++ b/components/02-molecules/snippet/__snapshots__/snippet.test.js.snap
@@ -94,20 +94,13 @@ exports[`Snippet Component renders with link and tags 1`] = `
         class="ct-heading ct-theme-light ct-snippet__title"
       >
                                       
-
-
-  
-  
         <a
           class="ct-link ct-theme-light     ct-snippet__title__link"
           href="https://example.com/read-more"
         >
-          
-
-    Snippet Title  
+          Snippet Title
         </a>
-        
-                          
+                                  
       </h4>
       
                   
@@ -224,26 +217,19 @@ exports[`Snippet Component renders with optional attributes 1`] = `
         class="ct-heading ct-theme-dark ct-snippet__title"
       >
                                       
-
-
-  
-  
         <a
           class="ct-link ct-theme-dark     ct-snippet__title__link"
           href="https://example.com/read-more"
           target="_blank"
         >
-          
-
-    Snippet Title  
+          Snippet Title
           <span
             class="ct-visually-hidden"
           >
             (Opens in a new tab/window)
           </span>
         </a>
-        
-                          
+                                  
       </h4>
       
                   

--- a/components/02-molecules/social-links/__snapshots__/social-links.test.js.snap
+++ b/components/02-molecules/social-links/__snapshots__/social-links.test.js.snap
@@ -43,10 +43,6 @@ exports[`Social Links Component renders with icon HTML 1`] = `
         >
                     
           <svg />
-          
-
-
-
         </a>
         
         
@@ -69,10 +65,6 @@ exports[`Social Links Component renders with icon HTML 1`] = `
         >
                     
           <svg />
-          
-
-
-
         </a>
         
         
@@ -125,10 +117,6 @@ exports[`Social Links Component renders with optional attributes 1`] = `
         >
                     
           <svg />
-          
-
-
-
         </a>
         
         
@@ -151,10 +139,6 @@ exports[`Social Links Component renders with optional attributes 1`] = `
         >
                     
           <svg />
-          
-
-
-
         </a>
         
         
@@ -205,9 +189,6 @@ exports[`Social Links Component renders with required attributes 1`] = `
           title="Facebook"
         >
                     
-
-
-                                    
           <svg
             aria-hidden="true"
             class="ct-icon  ct-button__icon"
@@ -227,7 +208,6 @@ exports[`Social Links Component renders with required attributes 1`] = `
           </svg>
           
 
-  
         </a>
         
         
@@ -249,9 +229,6 @@ exports[`Social Links Component renders with required attributes 1`] = `
           title="Twitter"
         >
                     
-
-
-                                    
           <svg
             aria-hidden="true"
             class="ct-icon  ct-button__icon"
@@ -271,7 +248,6 @@ exports[`Social Links Component renders with required attributes 1`] = `
           </svg>
           
 
-  
         </a>
         
         

--- a/components/02-molecules/subject-card/__snapshots__/subject-card.test.js.snap
+++ b/components/02-molecules/subject-card/__snapshots__/subject-card.test.js.snap
@@ -97,20 +97,13 @@ exports[`Subject Card Component renders with link and image 1`] = `
         class="ct-heading ct-theme-light ct-subject-card__title"
       >
                                   
-
-
-  
-  
         <a
           class="ct-link ct-theme-light     ct-subject-card__title__link"
           href="https://example.com/read-more"
         >
-          
-
-    Subject Card Title  
+          Subject Card Title
         </a>
-        
-                      
+                              
       </h4>
       
                   
@@ -175,26 +168,19 @@ exports[`Subject Card Component renders with optional attributes 1`] = `
         class="ct-heading ct-theme-dark ct-subject-card__title"
       >
                                   
-
-
-  
-  
         <a
           class="ct-link ct-theme-dark     ct-subject-card__title__link"
           href="https://example.com/read-more"
           target="_blank"
         >
-          
-
-    Subject Card Title  
+          Subject Card Title
           <span
             class="ct-visually-hidden"
           >
             (Opens in a new tab/window)
           </span>
         </a>
-        
-                      
+                              
       </h4>
       
                   

--- a/components/02-molecules/tabs/__snapshots__/tabs.test.js.snap
+++ b/components/02-molecules/tabs/__snapshots__/tabs.test.js.snap
@@ -36,10 +36,6 @@ exports[`Tabs Component renders with generated links from panels 1`] = `
         class="ct-item-list__item"
       >
             
-
-
-  
-  
         <a
           aria-controls="tab1"
           class="ct-link ct-theme-light"
@@ -48,12 +44,9 @@ exports[`Tabs Component renders with generated links from panels 1`] = `
           id="tab1-tab"
           role="tab"
         >
-          
-
-    Tab 1  
+          Tab 1
         </a>
-        
-  
+          
       </li>
       
                         
@@ -61,10 +54,6 @@ exports[`Tabs Component renders with generated links from panels 1`] = `
         class="ct-item-list__item"
       >
             
-
-
-  
-  
         <a
           aria-controls="tab2"
           class="ct-link ct-theme-light"
@@ -73,12 +62,9 @@ exports[`Tabs Component renders with generated links from panels 1`] = `
           id="tab2-tab"
           role="tab"
         >
-          
-
-    Tab 2  
+          Tab 2
         </a>
-        
-  
+          
       </li>
       
             
@@ -152,10 +138,6 @@ exports[`Tabs Component renders with optional attributes 1`] = `
         class="ct-item-list__item"
       >
             
-
-
-  
-  
         <a
           aria-controls="tab1"
           class="ct-link ct-theme-dark"
@@ -164,12 +146,9 @@ exports[`Tabs Component renders with optional attributes 1`] = `
           id="tab1-tab"
           role="tab"
         >
-          
-
-    Tab 1  
+          Tab 1
         </a>
-        
-  
+          
       </li>
       
                         
@@ -177,10 +156,6 @@ exports[`Tabs Component renders with optional attributes 1`] = `
         class="ct-item-list__item"
       >
             
-
-
-  
-  
         <a
           aria-controls="tab2"
           class="ct-link ct-theme-dark"
@@ -189,12 +164,9 @@ exports[`Tabs Component renders with optional attributes 1`] = `
           id="tab2-tab"
           role="tab"
         >
-          
-
-    Tab 2  
+          Tab 2
         </a>
-        
-  
+          
       </li>
       
             
@@ -267,10 +239,6 @@ exports[`Tabs Component renders with required attributes 1`] = `
         class="ct-item-list__item"
       >
             
-
-
-  
-  
         <a
           aria-controls="tab1"
           class="ct-link ct-theme-light"
@@ -279,12 +247,9 @@ exports[`Tabs Component renders with required attributes 1`] = `
           id="tab1-tab"
           role="tab"
         >
-          
-
-    Tab 1  
+          Tab 1
         </a>
-        
-  
+          
       </li>
       
                         
@@ -292,10 +257,6 @@ exports[`Tabs Component renders with required attributes 1`] = `
         class="ct-item-list__item"
       >
             
-
-
-  
-  
         <a
           aria-controls="tab2"
           class="ct-link ct-theme-light"
@@ -304,12 +265,9 @@ exports[`Tabs Component renders with required attributes 1`] = `
           id="tab2-tab"
           role="tab"
         >
-          
-
-    Tab 2  
+          Tab 2
         </a>
-        
-  
+          
       </li>
       
             

--- a/components/02-molecules/tooltip/__snapshots__/tooltip.test.js.snap
+++ b/components/02-molecules/tooltip/__snapshots__/tooltip.test.js.snap
@@ -24,10 +24,6 @@ exports[`Tooltip Component renders with icon and icon size 1`] = `
       data-tooltip-button=""
       data-tooltip-position=""
     >
-      
-
-
-                                    
       <svg
         aria-hidden="true"
         class="ct-icon ct-icon--size-large "
@@ -47,7 +43,6 @@ exports[`Tooltip Component renders with icon and icon size 1`] = `
       </svg>
       
 
-  
     </button>
     
 
@@ -75,14 +70,6 @@ exports[`Tooltip Component renders with icon and icon size 1`] = `
           class="ct-button ct-theme-light ct-button--tertiary ct-button--button ct-button--regular   "
           data-component-name="button"
         >
-          
-
-    
-              
-      
-
-
-                                    
           <svg
             aria-hidden="true"
             class="ct-icon  ct-button__icon"
@@ -102,8 +89,6 @@ exports[`Tooltip Component renders with icon and icon size 1`] = `
           </svg>
           
 
-          
-      
         </button>
         
 
@@ -145,10 +130,6 @@ exports[`Tooltip Component renders with optional attributes 1`] = `
       data-tooltip-position=""
       title="Tooltip title"
     >
-      
-
-
-                                    
       <svg
         aria-hidden="true"
         class="ct-icon ct-icon--size-large "
@@ -168,7 +149,6 @@ exports[`Tooltip Component renders with optional attributes 1`] = `
       </svg>
       
 
-  
     </button>
     
 
@@ -196,14 +176,6 @@ exports[`Tooltip Component renders with optional attributes 1`] = `
           class="ct-button ct-theme-light ct-button--tertiary ct-button--button ct-button--regular   "
           data-component-name="button"
         >
-          
-
-    
-              
-      
-
-
-                                    
           <svg
             aria-hidden="true"
             class="ct-icon  ct-button__icon"
@@ -223,8 +195,6 @@ exports[`Tooltip Component renders with optional attributes 1`] = `
           </svg>
           
 
-          
-      
         </button>
         
 
@@ -263,10 +233,6 @@ exports[`Tooltip Component renders with required attributes 1`] = `
       data-tooltip-button=""
       data-tooltip-position=""
     >
-      
-
-
-                                    
       <svg
         aria-hidden="true"
         class="ct-icon ct-icon--size-large "
@@ -286,7 +252,6 @@ exports[`Tooltip Component renders with required attributes 1`] = `
       </svg>
       
 
-  
     </button>
     
 
@@ -314,14 +279,6 @@ exports[`Tooltip Component renders with required attributes 1`] = `
           class="ct-button ct-theme-light ct-button--tertiary ct-button--button ct-button--regular   "
           data-component-name="button"
         >
-          
-
-    
-              
-      
-
-
-                                    
           <svg
             aria-hidden="true"
             class="ct-icon  ct-button__icon"
@@ -341,8 +298,6 @@ exports[`Tooltip Component renders with required attributes 1`] = `
           </svg>
           
 
-          
-      
         </button>
         
 

--- a/components/02-molecules/video-player/__snapshots__/video-player.test.js.snap
+++ b/components/02-molecules/video-player/__snapshots__/video-player.test.js.snap
@@ -221,15 +221,6 @@ exports[`Video Component renders with transcript link 1`] = `
           role="button"
           target="_blank"
         >
-          
-
-    
-              
-      
-        
-
-
-                                    
           <svg
             aria-hidden="true"
             class="ct-icon  ct-button__icon"
@@ -248,10 +239,7 @@ exports[`Video Component renders with transcript link 1`] = `
 
           </svg>
           
-
-          View Transcript
-      
-      
+View Transcript
           <span
             class="ct-visually-hidden"
           >

--- a/components/03-organisms/alert/__snapshots__/alert.test.js.snap
+++ b/components/03-organisms/alert/__snapshots__/alert.test.js.snap
@@ -44,9 +44,6 @@ exports[`Alert Component renders with correct icon for alert type 1`] = `
           >
             
               
-
-
-                                    
             <svg
               aria-hidden="true"
               class="ct-icon ct-icon--size-regular "
@@ -65,8 +62,7 @@ exports[`Alert Component renders with correct icon for alert type 1`] = `
 
             </svg>
             
-
-              
+            
           </span>
           
                     
@@ -90,14 +86,6 @@ exports[`Alert Component renders with correct icon for alert type 1`] = `
             id="dismiss-alert-"
             title="close success alert"
           >
-            
-
-    
-              
-      
-
-
-                                    
             <svg
               aria-hidden="true"
               class="ct-icon  ct-button__icon"
@@ -117,8 +105,6 @@ exports[`Alert Component renders with correct icon for alert type 1`] = `
             </svg>
             
 
-          
-      
           </button>
           
         
@@ -173,9 +159,6 @@ exports[`Alert Component renders with optional attributes 1`] = `
           >
             
               
-
-
-                                    
             <svg
               aria-hidden="true"
               class="ct-icon ct-icon--size-regular "
@@ -194,8 +177,7 @@ exports[`Alert Component renders with optional attributes 1`] = `
 
             </svg>
             
-
-              
+            
           </span>
           
                     Warning Alert
@@ -219,14 +201,6 @@ exports[`Alert Component renders with optional attributes 1`] = `
             id="dismiss-alert-alert-1"
             title="close warning alert"
           >
-            
-
-    
-              
-      
-
-
-                                    
             <svg
               aria-hidden="true"
               class="ct-icon  ct-button__icon"
@@ -246,8 +220,6 @@ exports[`Alert Component renders with optional attributes 1`] = `
             </svg>
             
 
-          
-      
           </button>
           
         
@@ -301,9 +273,6 @@ exports[`Alert Component renders with required attributes 1`] = `
           >
             
               
-
-
-                                    
             <svg
               aria-hidden="true"
               class="ct-icon ct-icon--size-regular "
@@ -322,8 +291,7 @@ exports[`Alert Component renders with required attributes 1`] = `
 
             </svg>
             
-
-              
+            
           </span>
           
                     
@@ -347,14 +315,6 @@ exports[`Alert Component renders with required attributes 1`] = `
             id="dismiss-alert-"
             title="close information alert"
           >
-            
-
-    
-              
-      
-
-
-                                    
             <svg
               aria-hidden="true"
               class="ct-icon  ct-button__icon"
@@ -374,8 +334,6 @@ exports[`Alert Component renders with required attributes 1`] = `
             </svg>
             
 
-          
-      
           </button>
           
         

--- a/components/03-organisms/banner/__snapshots__/banner.test.js.snap
+++ b/components/03-organisms/banner/__snapshots__/banner.test.js.snap
@@ -89,9 +89,7 @@ exports[`Banner Component renders with all attributes provided 1`] = `
     
           
       
-                            
                               
-      
       
           
           
@@ -107,23 +105,10 @@ exports[`Banner Component renders with all attributes provided 1`] = `
                     class="ct-item-list__item"
                   >
                             
-
-
-  
-  
                     <a
-                      class="ct-link ct-theme-dark"
+                      class="ct-link ct-theme-dark     ct-breadcrumb__links__link"
                       href="/"
                     >
-                      
-
-    
-              
-      
-        
-
-
-                                    
                       <svg
                         aria-hidden="true"
                         class="ct-icon  ct-link__icon"
@@ -142,13 +127,9 @@ exports[`Banner Component renders with all attributes provided 1`] = `
 
                       </svg>
                       
-
-          Home
-      
-      
+Home
                     </a>
-                    
-      
+                          
                   </li>
                   
             
@@ -166,32 +147,12 @@ exports[`Banner Component renders with all attributes provided 1`] = `
                   <li
                     class="ct-item-list__item"
                   >
-                            
-                  
-
-
-  
-  
                     <a
                       class="ct-link ct-theme-dark     ct-breadcrumb__links__link"
                       href="/"
                     >
-                      
-
-    Home  
+                      Home
                     </a>
-                    
-              
-                  </li>
-                  
-                        
-                  <li
-                    class="ct-item-list__item"
-                  >
-                              
-
-
-                                    
                     <svg
                       aria-hidden="true"
                       class="ct-icon  ct-breadcrumb__links__separator"
@@ -211,30 +172,19 @@ exports[`Banner Component renders with all attributes provided 1`] = `
                     </svg>
                     
 
-          
                   </li>
                   
                         
                   <li
                     class="ct-item-list__item"
                   >
-                            
-                  
-
-
-  
-  
                     <a
                       aria-current="location"
                       class="ct-link ct-theme-dark  ct-link--active   ct-breadcrumb__links__link ct-breadcrumb__links__link--active"
                       href="/section"
                     >
-                      
-
-    Section  
+                      Section
                     </a>
-                    
-              
                   </li>
                   
             

--- a/components/03-organisms/campaign/__snapshots__/campaign.test.js.snap
+++ b/components/03-organisms/campaign/__snapshots__/campaign.test.js.snap
@@ -158,28 +158,11 @@ exports[`Campaign Component renders with attributes 1`] = `
                   role="button"
                   target="_blank"
                 >
-                  
-
-    
-      
-      
-                  
-                              
-          
-                    
-          
-                                
-          
-                                            
-          
-          Link 
+                  Link 
                   <span
                     class="ct-text-icon__group"
                   >
-                    1
-
-
-                                    
+                    1  
                     <svg
                       aria-hidden="true"
                       class="ct-icon  "
@@ -199,12 +182,7 @@ exports[`Campaign Component renders with attributes 1`] = `
                     </svg>
                     
 
-  
                   </span>
-                  
-                  
-      
-      
                   <span
                     class="ct-visually-hidden"
                   >
@@ -228,9 +206,7 @@ exports[`Campaign Component renders with attributes 1`] = `
                   href="http://example.com/2"
                   role="button"
                 >
-                  
-
-    Link 2  
+                  Link 2
                 </a>
                 
 									

--- a/components/03-organisms/list/__snapshots__/list.test.js.snap
+++ b/components/03-organisms/list/__snapshots__/list.test.js.snap
@@ -68,28 +68,11 @@ exports[`List Component renders with all attributes provided 1`] = `
                   href="https://example.com"
                   role="button"
                 >
-                  
-
-    
-              
-      
-                  
-                              
-          
-                    
-          
-                                
-          
-          
-          
-          Link 
+                  Link 
                   <span
                     class="ct-text-icon__group"
                   >
-                    Above
-
-
-                                    
+                    Above 
                     <svg
                       aria-hidden="true"
                       class="ct-icon  ct-button__icon"
@@ -109,12 +92,7 @@ exports[`List Component renders with all attributes provided 1`] = `
                     </svg>
                     
 
-          
                   </span>
-                  
-                  
-      
-      
                 </a>
                 
                     
@@ -276,28 +254,11 @@ exports[`List Component renders with all attributes provided 1`] = `
           href="https://example.com"
           role="button"
         >
-          
-
-    
-              
-      
-                  
-                              
-          
-                    
-          
-                                
-          
-          
-          
           Link 
           <span
             class="ct-text-icon__group"
           >
-            Below
-
-
-                                    
+            Below 
             <svg
               aria-hidden="true"
               class="ct-icon  ct-button__icon"
@@ -317,12 +278,7 @@ exports[`List Component renders with all attributes provided 1`] = `
             </svg>
             
 
-          
           </span>
-          
-                  
-      
-      
         </a>
         
         

--- a/components/03-organisms/message/__snapshots__/message.test.js.snap
+++ b/components/03-organisms/message/__snapshots__/message.test.js.snap
@@ -20,9 +20,6 @@ exports[`Message Component does not render when description and title are empty 
     >
       
       
-
-
-                                    
       <svg
         aria-hidden="true"
         class="ct-icon ct-icon--size-regular "
@@ -41,8 +38,7 @@ exports[`Message Component does not render when description and title are empty 
 
       </svg>
       
-
-      
+    
     </div>
     
   
@@ -82,9 +78,6 @@ exports[`Message Component renders with all attributes provided 1`] = `
     >
       
       
-
-
-                                    
       <svg
         aria-hidden="true"
         class="ct-icon ct-icon--size-regular "
@@ -103,8 +96,7 @@ exports[`Message Component renders with all attributes provided 1`] = `
 
       </svg>
       
-
-      
+    
     </div>
     
   
@@ -158,9 +150,6 @@ exports[`Message Component renders with default type and theme 1`] = `
     >
       
       
-
-
-                                    
       <svg
         aria-hidden="true"
         class="ct-icon ct-icon--size-regular "
@@ -179,8 +168,7 @@ exports[`Message Component renders with default type and theme 1`] = `
 
       </svg>
       
-
-      
+    
     </div>
     
   
@@ -227,9 +215,6 @@ exports[`Message Component renders without description 1`] = `
     >
       
       
-
-
-                                    
       <svg
         aria-hidden="true"
         class="ct-icon ct-icon--size-regular "
@@ -248,8 +233,7 @@ exports[`Message Component renders without description 1`] = `
 
       </svg>
       
-
-      
+    
     </div>
     
   

--- a/components/03-organisms/mobile-navigation/__snapshots__/mobile-navigation.test.js.snap
+++ b/components/03-organisms/mobile-navigation/__snapshots__/mobile-navigation.test.js.snap
@@ -35,28 +35,11 @@ exports[`Mobile Navigation Component does not render when all attributes are emp
           data-component-name="button"
           data-flyout-close-all-trigger=""
         >
-          
-
-    
-              
-      
-                  
-                              
-          
-                    
-          
-                                
-          
-          
-          
            
           <span
             class="ct-text-icon__group"
           >
-            Close
-
-
-                                    
+            Close 
             <svg
               aria-hidden="true"
               class="ct-icon  ct-button__icon"
@@ -76,12 +59,7 @@ exports[`Mobile Navigation Component does not render when all attributes are emp
             </svg>
             
 
-          
           </span>
-          
-                  
-      
-      
         </button>
         
 
@@ -136,28 +114,11 @@ exports[`Mobile Navigation Component renders correctly when only bottom menu is 
           data-component-name="button"
           data-flyout-close-all-trigger=""
         >
-          
-
-    
-              
-      
-                  
-                              
-          
-                    
-          
-                                
-          
-          
-          
            
           <span
             class="ct-text-icon__group"
           >
-            Close
-
-
-                                    
+            Close 
             <svg
               aria-hidden="true"
               class="ct-icon  ct-button__icon"
@@ -177,12 +138,7 @@ exports[`Mobile Navigation Component renders correctly when only bottom menu is 
             </svg>
             
 
-          
           </span>
-          
-                  
-      
-      
         </button>
         
 
@@ -219,21 +175,14 @@ exports[`Mobile Navigation Component renders correctly when only bottom menu is 
             
 
         
-
-
-  
-  
             <a
               class="ct-link ct-theme-light     ct-menu__item__link"
               href="/contact"
               title="Contact"
             >
-              
-
-    Contact  
+              Contact
             </a>
             
-
         
         
       
@@ -248,21 +197,14 @@ exports[`Mobile Navigation Component renders correctly when only bottom menu is 
             
 
         
-
-
-  
-  
             <a
               class="ct-link ct-theme-light     ct-menu__item__link"
               href="/help"
               title="Help"
             >
-              
-
-    Help  
+              Help
             </a>
             
-
         
         
       
@@ -322,28 +264,11 @@ exports[`Mobile Navigation Component renders correctly when only top menu is pro
           data-component-name="button"
           data-flyout-close-all-trigger=""
         >
-          
-
-    
-              
-      
-                  
-                              
-          
-                    
-          
-                                
-          
-          
-          
            
           <span
             class="ct-text-icon__group"
           >
-            Close
-
-
-                                    
+            Close 
             <svg
               aria-hidden="true"
               class="ct-icon  ct-button__icon"
@@ -363,12 +288,7 @@ exports[`Mobile Navigation Component renders correctly when only top menu is pro
             </svg>
             
 
-          
           </span>
-          
-                  
-      
-      
         </button>
         
 
@@ -404,21 +324,14 @@ exports[`Mobile Navigation Component renders correctly when only top menu is pro
             
 
         
-
-
-  
-  
             <a
               class="ct-link ct-theme-light     ct-menu__item__link"
               href="/"
               title="Home"
             >
-              
-
-    Home  
+              Home
             </a>
             
-
         
         
       
@@ -433,21 +346,14 @@ exports[`Mobile Navigation Component renders correctly when only top menu is pro
             
 
         
-
-
-  
-  
             <a
               class="ct-link ct-theme-light     ct-menu__item__link"
               href="/about"
               title="About"
             >
-              
-
-    About  
+              About
             </a>
             
-
         
         
       
@@ -508,28 +414,11 @@ exports[`Mobile Navigation Component renders with all attributes provided 1`] = 
           data-component-name="button"
           data-flyout-close-all-trigger=""
         >
-          
-
-    
-              
-      
-                  
-                              
-          
-                    
-          
-                                
-          
-          
-          
            
           <span
             class="ct-text-icon__group"
           >
-            Close
-
-
-                                    
+            Close 
             <svg
               aria-hidden="true"
               class="ct-icon  ct-button__icon"
@@ -549,12 +438,7 @@ exports[`Mobile Navigation Component renders with all attributes provided 1`] = 
             </svg>
             
 
-          
           </span>
-          
-                  
-      
-      
         </button>
         
 
@@ -599,21 +483,14 @@ exports[`Mobile Navigation Component renders with all attributes provided 1`] = 
             
 
         
-
-
-  
-  
             <a
               class="ct-link ct-theme-dark     ct-menu__item__link"
               href="/"
               title="Home"
             >
-              
-
-    Home  
+              Home
             </a>
             
-
         
         
       
@@ -628,21 +505,14 @@ exports[`Mobile Navigation Component renders with all attributes provided 1`] = 
             
 
         
-
-
-  
-  
             <a
               class="ct-link ct-theme-dark     ct-menu__item__link"
               href="/about"
               title="About"
             >
-              
-
-    About  
+              About
             </a>
             
-
         
         
       
@@ -685,21 +555,14 @@ exports[`Mobile Navigation Component renders with all attributes provided 1`] = 
             
 
         
-
-
-  
-  
             <a
               class="ct-link ct-theme-dark     ct-menu__item__link"
               href="/contact"
               title="Contact"
             >
-              
-
-    Contact  
+              Contact
             </a>
             
-
         
         
       
@@ -714,21 +577,14 @@ exports[`Mobile Navigation Component renders with all attributes provided 1`] = 
             
 
         
-
-
-  
-  
             <a
               class="ct-link ct-theme-dark     ct-menu__item__link"
               href="/help"
               title="Help"
             >
-              
-
-    Help  
+              Help
             </a>
             
-
         
         
       
@@ -797,28 +653,11 @@ exports[`Mobile Navigation Component renders with only required attributes 1`] =
           data-component-name="button"
           data-flyout-close-all-trigger=""
         >
-          
-
-    
-              
-      
-                  
-                              
-          
-                    
-          
-                                
-          
-          
-          
            
           <span
             class="ct-text-icon__group"
           >
-            Close
-
-
-                                    
+            Close 
             <svg
               aria-hidden="true"
               class="ct-icon  ct-button__icon"
@@ -838,12 +677,7 @@ exports[`Mobile Navigation Component renders with only required attributes 1`] =
             </svg>
             
 
-          
           </span>
-          
-                  
-      
-      
         </button>
         
 
@@ -879,21 +713,14 @@ exports[`Mobile Navigation Component renders with only required attributes 1`] =
             
 
         
-
-
-  
-  
             <a
               class="ct-link ct-theme-light     ct-menu__item__link"
               href="/"
               title="Home"
             >
-              
-
-    Home  
+              Home
             </a>
             
-
         
         
       
@@ -954,28 +781,11 @@ exports[`Mobile Navigation Component renders with some attributes missing 1`] = 
           data-component-name="button"
           data-flyout-close-all-trigger=""
         >
-          
-
-    
-              
-      
-                  
-                              
-          
-                    
-          
-                                
-          
-          
-          
            
           <span
             class="ct-text-icon__group"
           >
-            Close
-
-
-                                    
+            Close 
             <svg
               aria-hidden="true"
               class="ct-icon  ct-button__icon"
@@ -995,12 +805,7 @@ exports[`Mobile Navigation Component renders with some attributes missing 1`] = 
             </svg>
             
 
-          
           </span>
-          
-                  
-      
-      
         </button>
         
 

--- a/components/03-organisms/navigation/__snapshots__/navigation.test.js.snap
+++ b/components/03-organisms/navigation/__snapshots__/navigation.test.js.snap
@@ -62,21 +62,14 @@ exports[`Navigation Component renders correctly when items have submenus 1`] = `
           
 
         
-
-
-  
-  
           <a
             class="ct-link ct-theme-dark     ct-menu__item__link"
             href="/services"
             title="Services"
           >
-            
-
-    Services  
+            Services
           </a>
           
-
         
                             
           <div
@@ -101,21 +94,14 @@ exports[`Navigation Component renders correctly when items have submenus 1`] = `
                 
 
         
-
-
-  
-  
                 <a
                   class="ct-link ct-theme-dark     ct-menu__item__link"
                   href="/services/consulting"
                   title="Consulting"
                 >
-                  
-
-    Consulting  
+                  Consulting
                 </a>
                 
-
         
         
       
@@ -150,21 +136,14 @@ exports[`Navigation Component renders correctly when items have submenus 1`] = `
           
 
         
-
-
-  
-  
           <a
             class="ct-link ct-theme-dark     ct-menu__item__link"
             href="/contact"
             title="Contact"
           >
-            
-
-    Contact  
+            Contact
           </a>
           
-
         
                             
           <div
@@ -189,21 +168,14 @@ exports[`Navigation Component renders correctly when items have submenus 1`] = `
                 
 
         
-
-
-  
-  
                 <a
                   class="ct-link ct-theme-dark     ct-menu__item__link"
                   href="/contact/support"
                   title="Support"
                 >
-                  
-
-    Support  
+                  Support
                 </a>
                 
-
         
         
       
@@ -287,21 +259,14 @@ exports[`Navigation Component renders with all attributes provided 1`] = `
           
 
         
-
-
-  
-  
           <a
             class="ct-link ct-theme-dark     ct-menu__item__link"
             href="/"
             title="Home"
           >
-            
-
-    Home  
+            Home
           </a>
           
-
         
         
       
@@ -319,21 +284,14 @@ exports[`Navigation Component renders with all attributes provided 1`] = `
           
 
         
-
-
-  
-  
           <a
             class="ct-link ct-theme-dark     ct-menu__item__link"
             href="/about"
             title="About"
           >
-            
-
-    About  
+            About
           </a>
           
-
         
         
       
@@ -351,21 +309,14 @@ exports[`Navigation Component renders with all attributes provided 1`] = `
           
 
         
-
-
-  
-  
           <a
             class="ct-link ct-theme-dark     ct-menu__item__link"
             href="/services"
             title="Services"
           >
-            
-
-    Services  
+            Services
           </a>
           
-
         
         
       
@@ -383,21 +334,14 @@ exports[`Navigation Component renders with all attributes provided 1`] = `
           
 
         
-
-
-  
-  
           <a
             class="ct-link ct-theme-dark     ct-menu__item__link"
             href="/contact"
             title="Contact"
           >
-            
-
-    Contact  
+            Contact
           </a>
           
-
         
         
       
@@ -459,21 +403,14 @@ exports[`Navigation Component renders with only required attributes 1`] = `
           
 
         
-
-
-  
-  
           <a
             class="ct-link ct-theme-light     ct-menu__item__link"
             href="/"
             title="Home"
           >
-            
-
-    Home  
+            Home
           </a>
           
-
         
         
       
@@ -535,21 +472,14 @@ exports[`Navigation Component renders with some attributes missing 1`] = `
           
 
         
-
-
-  
-  
           <a
             class="ct-link ct-theme-light     ct-menu__item__link"
             href="/"
             title="Home"
           >
-            
-
-    Home  
+            Home
           </a>
           
-
         
         
       
@@ -567,21 +497,14 @@ exports[`Navigation Component renders with some attributes missing 1`] = `
           
 
         
-
-
-  
-  
           <a
             class="ct-link ct-theme-light     ct-menu__item__link"
             href="/about"
             title="About"
           >
-            
-
-    About  
+            About
           </a>
           
-
         
         
       

--- a/components/03-organisms/promo/__snapshots__/promo.test.js.snap
+++ b/components/03-organisms/promo/__snapshots__/promo.test.js.snap
@@ -94,28 +94,11 @@ exports[`Promo Component renders with all attributes provided 1`] = `
                 role="button"
                 target="_blank"
               >
-                
-
-    
-      
-      
-                  
-                              
-          
-                    
-          
-                                
-          
-                                            
-          
-          Learn 
+                Learn 
                 <span
                   class="ct-text-icon__group"
                 >
-                  More
-
-
-                                    
+                  More  
                   <svg
                     aria-hidden="true"
                     class="ct-icon  "
@@ -135,12 +118,7 @@ exports[`Promo Component renders with all attributes provided 1`] = `
                   </svg>
                   
 
-  
                 </span>
-                
-                  
-      
-      
                 <span
                   class="ct-visually-hidden"
                 >
@@ -408,9 +386,7 @@ exports[`Promo Component renders without content_top and content_bottom 1`] = `
           href="https://example.com"
           role="button"
         >
-          
-
-    Learn More  
+          Learn More
         </a>
         
                       

--- a/components/03-organisms/side-navigation/__snapshots__/side-navigation.test.js.snap
+++ b/components/03-organisms/side-navigation/__snapshots__/side-navigation.test.js.snap
@@ -27,22 +27,15 @@ exports[`Side Navigation Component renders with all attributes provided 1`] = `
     >
       
     
-
-
-  
-  
       <a
         class="ct-link ct-theme-dark     ct-skip-link__link ct-visually-hidden"
         data-platform=""
         href="#main-content"
         title="Skip to main content"
       >
-        
-
-    Skip to main content  
+        Skip to main content
       </a>
-      
-  
+        
     </div>
     
                   
@@ -80,21 +73,14 @@ exports[`Side Navigation Component renders with all attributes provided 1`] = `
         
 
         
-
-
-  
-  
         <a
           class="ct-link ct-theme-dark     ct-menu__item__link"
           href="/"
           title="Home"
         >
-          
-
-    Home  
+          Home
         </a>
         
-
         
         
       
@@ -112,21 +98,14 @@ exports[`Side Navigation Component renders with all attributes provided 1`] = `
         
 
         
-
-
-  
-  
         <a
           class="ct-link ct-theme-dark     ct-menu__item__link"
           href="/about"
           title="About"
         >
-          
-
-    About  
+          About
         </a>
         
-
         
         
       
@@ -144,21 +123,14 @@ exports[`Side Navigation Component renders with all attributes provided 1`] = `
         
 
         
-
-
-  
-  
         <a
           class="ct-link ct-theme-dark     ct-menu__item__link"
           href="/services"
           title="Services"
         >
-          
-
-    Services  
+          Services
         </a>
         
-
         
         
       
@@ -176,21 +148,14 @@ exports[`Side Navigation Component renders with all attributes provided 1`] = `
         
 
         
-
-
-  
-  
         <a
           class="ct-link ct-theme-dark     ct-menu__item__link"
           href="/contact"
           title="Contact"
         >
-          
-
-    Contact  
+          Contact
         </a>
         
-
         
         
       
@@ -226,22 +191,15 @@ exports[`Side Navigation Component renders with only required attributes 1`] = `
     >
       
     
-
-
-  
-  
       <a
         class="ct-link ct-theme-light     ct-skip-link__link ct-visually-hidden"
         data-platform=""
         href="#main-content"
         title="Skip to main content"
       >
-        
-
-    Skip to main content  
+        Skip to main content
       </a>
-      
-  
+        
     </div>
     
         
@@ -269,21 +227,14 @@ exports[`Side Navigation Component renders with only required attributes 1`] = `
         
 
         
-
-
-  
-  
         <a
           class="ct-link ct-theme-light     ct-menu__item__link"
           href="/"
           title="Home"
         >
-          
-
-    Home  
+          Home
         </a>
         
-
         
         
       
@@ -319,22 +270,15 @@ exports[`Side Navigation Component renders with some attributes missing 1`] = `
     >
       
     
-
-
-  
-  
       <a
         class="ct-link ct-theme-light     ct-skip-link__link ct-visually-hidden"
         data-platform=""
         href="#main-content"
         title="Skip to main content"
       >
-        
-
-    Skip to main content  
+        Skip to main content
       </a>
-      
-  
+        
     </div>
     
         
@@ -362,21 +306,14 @@ exports[`Side Navigation Component renders with some attributes missing 1`] = `
         
 
         
-
-
-  
-  
         <a
           class="ct-link ct-theme-light     ct-menu__item__link"
           href="/"
           title="Home"
         >
-          
-
-    Home  
+          Home
         </a>
         
-
         
         
       
@@ -394,21 +331,14 @@ exports[`Side Navigation Component renders with some attributes missing 1`] = `
         
 
         
-
-
-  
-  
         <a
           class="ct-link ct-theme-light     ct-menu__item__link"
           href="/about"
           title="About"
         >
-          
-
-    About  
+          About
         </a>
         
-
         
         
       

--- a/components/03-organisms/skip-link/__snapshots__/skip-link.test.js.snap
+++ b/components/03-organisms/skip-link/__snapshots__/skip-link.test.js.snap
@@ -11,22 +11,15 @@ exports[`Skip Link Component renders with all attributes provided 1`] = `
   >
     
     
-
-
-  
-  
     <a
       class="ct-link ct-theme-dark     ct-skip-link__link ct-visually-hidden"
       data-platform=""
       href="#main-content"
       title="Go to main content"
     >
-      
-
-    Go to main content  
+      Go to main content
     </a>
-    
-  
+      
   </div>
   
 
@@ -44,22 +37,15 @@ exports[`Skip Link Component renders with default text when text is empty 1`] = 
   >
     
     
-
-
-  
-  
     <a
       class="ct-link ct-theme-light     ct-skip-link__link ct-visually-hidden"
       data-platform=""
       href="#main-content"
       title="Skip to main content"
     >
-      
-
-    Skip to main content  
+      Skip to main content
     </a>
-    
-  
+      
   </div>
   
 
@@ -77,22 +63,15 @@ exports[`Skip Link Component renders with only required attributes 1`] = `
   >
     
     
-
-
-  
-  
     <a
       class="ct-link ct-theme-light     ct-skip-link__link ct-visually-hidden"
       data-platform=""
       href="#main-content"
       title="Skip to main content"
     >
-      
-
-    Skip to main content  
+      Skip to main content
     </a>
-    
-  
+      
   </div>
   
 

--- a/components/03-organisms/slider/__snapshots__/slider.test.js.snap
+++ b/components/03-organisms/slider/__snapshots__/slider.test.js.snap
@@ -103,15 +103,6 @@ exports[`Slider Component renders with all attributes provided 1`] = `
                   data-component-name="button"
                   data-slider-previous=""
                 >
-                  
-
-    
-              
-      
-        
-
-
-                                    
                   <svg
                     aria-hidden="true"
                     class="ct-icon  ct-button__icon"
@@ -130,10 +121,7 @@ exports[`Slider Component renders with all attributes provided 1`] = `
 
                   </svg>
                   
-
-          Previous Slide
-      
-      
+Previous Slide
                 </button>
                 
                   
@@ -144,28 +132,11 @@ exports[`Slider Component renders with all attributes provided 1`] = `
                   data-component-name="button"
                   data-slider-next=""
                 >
-                  
-
-    
-              
-      
-                  
-                              
-          
-                    
-          
-                                
-          
-          
-          
-          Next 
+                  Next 
                   <span
                     class="ct-text-icon__group"
                   >
-                    Slide
-
-
-                                    
+                    Slide 
                     <svg
                       aria-hidden="true"
                       class="ct-icon  ct-button__icon"
@@ -185,12 +156,7 @@ exports[`Slider Component renders with all attributes provided 1`] = `
                     </svg>
                     
 
-          
                   </span>
-                  
-                  
-      
-      
                 </button>
                 
                 
@@ -314,15 +280,6 @@ exports[`Slider Component renders with only required attributes 1`] = `
                   data-component-name="button"
                   data-slider-previous=""
                 >
-                  
-
-    
-              
-      
-        
-
-
-                                    
                   <svg
                     aria-hidden="true"
                     class="ct-icon  ct-button__icon"
@@ -341,10 +298,7 @@ exports[`Slider Component renders with only required attributes 1`] = `
 
                   </svg>
                   
-
-          Previous
-      
-      
+Previous
                 </button>
                 
                   
@@ -355,28 +309,11 @@ exports[`Slider Component renders with only required attributes 1`] = `
                   data-component-name="button"
                   data-slider-next=""
                 >
-                  
-
-    
-              
-      
-                  
-                              
-          
-                    
-          
-                                
-          
-          
-          
-           
+                   
                   <span
                     class="ct-text-icon__group"
                   >
-                    Next
-
-
-                                    
+                    Next 
                     <svg
                       aria-hidden="true"
                       class="ct-icon  ct-button__icon"
@@ -396,12 +333,7 @@ exports[`Slider Component renders with only required attributes 1`] = `
                     </svg>
                     
 
-          
                   </span>
-                  
-                  
-      
-      
                 </button>
                 
                 
@@ -535,15 +467,6 @@ exports[`Slider Component renders without some attributes 1`] = `
                   data-component-name="button"
                   data-slider-previous=""
                 >
-                  
-
-    
-              
-      
-        
-
-
-                                    
                   <svg
                     aria-hidden="true"
                     class="ct-icon  ct-button__icon"
@@ -562,10 +485,7 @@ exports[`Slider Component renders without some attributes 1`] = `
 
                   </svg>
                   
-
-          Previous Slide
-      
-      
+Previous Slide
                 </button>
                 
                   
@@ -576,28 +496,11 @@ exports[`Slider Component renders without some attributes 1`] = `
                   data-component-name="button"
                   data-slider-next=""
                 >
-                  
-
-    
-              
-      
-                  
-                              
-          
-                    
-          
-                                
-          
-          
-          
-          Next 
+                  Next 
                   <span
                     class="ct-text-icon__group"
                   >
-                    Slide
-
-
-                                    
+                    Slide 
                     <svg
                       aria-hidden="true"
                       class="ct-icon  ct-button__icon"
@@ -617,12 +520,7 @@ exports[`Slider Component renders without some attributes 1`] = `
                     </svg>
                     
 
-          
                   </span>
-                  
-                  
-      
-      
                 </button>
                 
                 

--- a/components/04-templates/page/__snapshots__/page.test.js.snap
+++ b/components/04-templates/page/__snapshots__/page.test.js.snap
@@ -595,10 +595,6 @@ exports[`Page Component renders all blocks with complex attributes and classes 1
         >
           Return focus to the top of the page
         </span>
-        
-
-
-                                    
         <svg
           aria-hidden="true"
           class="ct-icon  ct-button__icon"
@@ -618,7 +614,6 @@ exports[`Page Component renders all blocks with complex attributes and classes 1
         </svg>
         
 
-  
       </a>
       
 
@@ -770,10 +765,6 @@ exports[`Page Component renders content block with permutations: {
         >
           Return focus to the top of the page
         </span>
-        
-
-
-                                    
         <svg
           aria-hidden="true"
           class="ct-icon  ct-button__icon"
@@ -793,7 +784,6 @@ exports[`Page Component renders content block with permutations: {
         </svg>
         
 
-  
       </a>
       
 
@@ -931,10 +921,6 @@ exports[`Page Component renders content block with permutations: {
         >
           Return focus to the top of the page
         </span>
-        
-
-
-                                    
         <svg
           aria-hidden="true"
           class="ct-icon  ct-button__icon"
@@ -954,7 +940,6 @@ exports[`Page Component renders content block with permutations: {
         </svg>
         
 
-  
       </a>
       
 
@@ -1092,10 +1077,6 @@ exports[`Page Component renders content block with permutations: {
         >
           Return focus to the top of the page
         </span>
-        
-
-
-                                    
         <svg
           aria-hidden="true"
           class="ct-icon  ct-button__icon"
@@ -1115,7 +1096,6 @@ exports[`Page Component renders content block with permutations: {
         </svg>
         
 
-  
       </a>
       
 
@@ -1239,10 +1219,6 @@ exports[`Page Component renders content block with permutations: {
         >
           Return focus to the top of the page
         </span>
-        
-
-
-                                    
         <svg
           aria-hidden="true"
           class="ct-icon  ct-button__icon"
@@ -1262,7 +1238,6 @@ exports[`Page Component renders content block with permutations: {
         </svg>
         
 
-  
       </a>
       
 
@@ -1349,10 +1324,6 @@ exports[`Page Component renders with custom theme and attributes 1`] = `
         >
           Return focus to the top of the page
         </span>
-        
-
-
-                                    
         <svg
           aria-hidden="true"
           class="ct-icon  ct-button__icon"
@@ -1372,7 +1343,6 @@ exports[`Page Component renders with custom theme and attributes 1`] = `
         </svg>
         
 
-  
       </a>
       
 
@@ -1458,10 +1428,6 @@ exports[`Page Component renders with default values 1`] = `
         >
           Return focus to the top of the page
         </span>
-        
-
-
-                                    
         <svg
           aria-hidden="true"
           class="ct-icon  ct-button__icon"
@@ -1481,7 +1447,6 @@ exports[`Page Component renders with default values 1`] = `
         </svg>
         
 
-  
       </a>
       
 
@@ -1568,10 +1533,6 @@ exports[`Page Component strips HTML tags from attributes 1`] = `
         >
           Return focus to the top of the page
         </span>
-        
-
-
-                                    
         <svg
           aria-hidden="true"
           class="ct-icon  ct-button__icon"
@@ -1591,7 +1552,6 @@ exports[`Page Component strips HTML tags from attributes 1`] = `
         </svg>
         
 
-  
       </a>
       
 


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have formatted the subject to include the issue number
  as `[#123] Verb in past tense with a period at the end.`
- [x] I have provided information in the `Changed` section about WHY something was
  done if this was a bespoke implementation.
- [x] I have performed a self-review of my code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have run new and existing relevant tests locally with my changes,
  and they have passed.
- [x] I have provided screenshots, where applicable.

## Changed

- Moved breadcrumb arrow into the list item, rather than having a separate list item just for the arrow.
- Reduced unwanted spacing in text-icon, icon, and link. This is required to avoid a browser quirk which adds a space between the link and the icon, and the link text and the end of the `</a>` tag.
- Ensure a space _is_ included when doing last word and icon - this inline spacing is needed.
- Removed use of spaceless in text-icon - it's being deprecated in twig.

## Screenshots
![Screenshot 2025-02-14 at 5 21 34 pm](https://github.com/user-attachments/assets/a18faeec-7e65-471e-8711-0f0d9465e6d7)

![Screenshot 2025-02-14 at 5 25 14 pm](https://github.com/user-attachments/assets/d71a68cd-b584-4cb9-bbc5-5e3894e538a8)

The changes to spacing in this ticket prevent that second screenshot with extra space from occurring.