### PR TITLE
[#228] Fixed unwanted cascading styles when toggling collapsible.

### DIFF
--- a/components/00-base/collapsible/collapsible.js
+++ b/components/00-base/collapsible/collapsible.js
@@ -262,6 +262,7 @@ CivicThemeCollapsible.prototype.setCollapsedState = function () {
   this.panel.style.overflow = 'hidden';
   this.panel.style.display = 'none';
   this.el.setAttribute('data-collapsible-collapsed', '');
+  this.trigger.setAttribute('data-collapsible-trigger-collapsed', '');
   this.panel.setAttribute('aria-hidden', true);
   this.trigger.setAttribute('aria-expanded', false);
   this.collapsed = true;
@@ -296,6 +297,7 @@ CivicThemeCollapsible.prototype.collapse = function (animate, evt) {
     t.panel.removeEventListener('transitionend', onTransitionEnd);
     // Remove progress state.
     t.el.removeAttribute('data-collapsible-collapsing');
+    t.trigger.removeAttribute('data-collapsible-trigger-collapsing');
     // Set all required attributes.
     t.setCollapsedState.call(t);
   };
@@ -314,6 +316,7 @@ CivicThemeCollapsible.prototype.collapse = function (animate, evt) {
       t.panel.style.height = `${h}px`;
       // Set progress state.
       t.el.setAttribute('data-collapsible-collapsing', '');
+      t.trigger.setAttribute('data-collapsible-trigger-collapsing', '');
       requestAnimationFrame(() => {
         // Register an event listener to fire at the end of the transition.
         t.panel.addEventListener('transitionend', onTransitionEnd);
@@ -341,6 +344,7 @@ CivicThemeCollapsible.prototype.setExpandedState = function () {
   this.panel.setAttribute('aria-hidden', false);
   this.trigger.setAttribute('aria-expanded', true);
   this.el.removeAttribute('data-collapsible-collapsed');
+  this.trigger.removeAttribute('data-collapsible-trigger-collapsed');
   this.collapsed = false;
 };
 
@@ -365,6 +369,7 @@ CivicThemeCollapsible.prototype.expand = function (animate) {
     t.setExpandedState.call(t);
     // Remove progress state.
     t.el.removeAttribute('data-collapsible-collapsing');
+    t.trigger.removeAttribute('data-collapsible-trigger-collapsing');
   };
 
   if (animate && t.duration > 0) {
@@ -375,6 +380,7 @@ CivicThemeCollapsible.prototype.expand = function (animate) {
 
     // Set progress state.
     t.el.setAttribute('data-collapsible-collapsing', '');
+    t.trigger.setAttribute('data-collapsible-trigger-collapsing', '');
     t.panel.style.height = '0px';
     requestAnimationFrame(() => {
       // Prepare for animation by setting initial values.

--- a/components/00-base/collapsible/collapsible.scss
+++ b/components/00-base/collapsible/collapsible.scss
@@ -2,27 +2,41 @@
 // Collapsible component.
 //
 
-@use 'sass:list';
-@use 'sass:map';
-
 [data-collapsible] {
   [data-collapsible-trigger] {
     cursor: pointer;
-  }
+    position: relative;
 
-  .ct-collapsible__icon {
-    @include ct-icon-size();
-  }
+    .ct-collapsible__icon {
+      @include ct-icon-size();
 
-  &:not([data-collapsible-trigger-no-icon]) {
-    [data-collapsible-trigger] {
-      position: relative;
+      transform: rotate(-180deg);
 
-      .ct-collapsible__icon {
-        transform: rotate(-180deg);
+      @include ct-print() {
+        transform: rotate(-180deg) !important;
       }
     }
 
+    &[data-collapsible-trigger-collapsing] {
+      .ct-collapsible__icon {
+        transform: rotate(0deg);
+      }
+
+      &[data-collapsible-trigger-collapsed] {
+        .ct-collapsible__icon {
+          transform: rotate(-180deg);
+        }
+      }
+    }
+
+    &[data-collapsible-trigger-collapsed] {
+      .ct-collapsible__icon {
+        transform: rotate(0deg);
+      }
+    }
+  }
+
+  &:not([data-collapsible-trigger-no-icon]) {
     &[data-collapsible-trigger-wide] {
       [data-collapsible-trigger] {
         display: flex;
@@ -42,36 +56,12 @@
     }
   }
 
-  &[data-collapsible-collapsing] {
-    [data-collapsible-trigger] {
-      .ct-collapsible__icon {
-        transform: rotate(0deg);
-      }
-    }
-
-    &[data-collapsible-collapsed] {
-      [data-collapsible-trigger] {
-        .ct-collapsible__icon {
-          transform: rotate(-180deg);
-        }
-      }
-    }
-  }
-
   &[data-collapsible-collapsed] {
-    [data-collapsible-trigger] {
-      .ct-collapsible__icon {
-        transform: rotate(0deg);
-      }
-    }
-
     [data-collapsible-panel] {
-      height: 0;
-      overflow: hidden;
-
       @include ct-print() {
-        height: auto;
-        visibility: visible;
+        display: block !important;
+        height: auto !important;
+        overflow: auto !important;
       }
     }
   }
@@ -81,8 +71,9 @@
   [data-collapsible] {
     &[data-collapsible-collapsed] {
       [data-collapsible-panel] {
-        height: auto;
-        overflow: auto;
+        display: block !important;
+        height: auto !important;
+        overflow: auto !important;
       }
     }
   }


### PR DESCRIPTION
https://salsadigital.atlassian.net/browse/CIVIC-1820
https://github.com/civictheme/uikit/issues/228

## Checklist before requesting a review

- [x] I have formatted the subject to include the issue number
  as `[#123] Verb in past tense with a period at the end.`
- [x] I have provided information in the `Changed` section about WHY something was
  done if this was a bespoke implementation.
- [x] I have performed a self-review of my code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have run new and existing relevant tests locally with my changes,
  and they have passed.
- [x] I have provided screenshots, where applicable.

## Changed

1. Collapsible now applies styles directly to active trigger, allowing only the opening trigger to animate.
2. Removed unnecessary use statements from collapsible styles.
3. Restructured trigger styles to (mostly) share the same trigger selector.
4. Fixed collapsed panels not opening when in print styles.

## Screenshots

https://github.com/user-attachments/assets/94fd2749-3af4-4a8a-82e7-1ba6dae7f424

