### PR TITLE
[#626] Fixed Image alt text.

### DIFF
--- a/packages/sdc/components/00-base/icon/__snapshots__/icon.test.js.snap
+++ b/packages/sdc/components/00-base/icon/__snapshots__/icon.test.js.snap
@@ -30,7 +30,6 @@ exports[`Icon Component renders with additional attributes and classes 1`] = `
 exports[`Icon Component renders with custom size 1`] = `
 <div>
   <svg
-    alt="Test Icon"
     aria-hidden="true"
     class="ct-icon ct-icon--size-large "
     height="24"

--- a/packages/sdc/components/00-base/icon/icon.component.yml
+++ b/packages/sdc/components/00-base/icon/icon.component.yml
@@ -13,10 +13,6 @@ props:
       type: string
       title: Size
       description: Icon size.
-    alt:
-      type: string
-      title: Alt text
-      description: Icon alt text.
     attributes:
       type: string
       title: Attributes

--- a/packages/sdc/components/00-base/icon/icon.test.js
+++ b/packages/sdc/components/00-base/icon/icon.test.js
@@ -17,13 +17,11 @@ describe('Icon Component', () => {
     const c = await dom(template, {
       symbol: 'close',
       size: 'large',
-      alt: 'Test Icon',
     });
 
     expect(c.querySelectorAll('.ct-icon.ct-icon--size-large')).toHaveLength(1);
     expect(c.querySelectorAll('.ct-icon[aria-hidden="true"]')).toHaveLength(1);
     expect(c.querySelectorAll('.ct-icon[role="img"]')).toHaveLength(1);
-    expect(c.querySelectorAll('.ct-icon[alt="Test Icon"]')).toHaveLength(1);
 
     assertUniqueCssClasses(c);
   });

--- a/packages/sdc/components/00-base/icon/icon.twig
+++ b/packages/sdc/components/00-base/icon/icon.twig
@@ -6,7 +6,6 @@
  * Props:
  * - symbol: [string] Icon name (required).
  * - size: [string] Icon size.
- * - alt: [string] Icon alt text.
  * - attributes: [string] Additional HTML attributes.
  * - modifier_class: [string] Additional CSS classes.
  * - assets_dir: [string] Directory containing icon assets.

--- a/packages/sdc/components/00-base/icon/icon.twig
+++ b/packages/sdc/components/00-base/icon/icon.twig
@@ -22,9 +22,8 @@
     {%- set base_class = 'ct-icon ' ~ size_class -%}
     {%- set modifier = modifier_class|default('') -%}
     {%- set aria_attributes = 'aria-hidden="true" role="img"' -%}
-    {%- set alt_attribute = alt is defined ? 'alt="' ~ alt ~ '"' : '' -%}
     {%- set additional_attributes = attributes|default('') -%}
-    {%- set attributes = 'class="' ~ base_class ~ ' ' ~ modifier ~ '" ' ~ aria_attributes ~ ' ' ~ alt_attribute ~ ' ' ~ additional_attributes -%}
+    {%- set attributes = 'class="' ~ base_class ~ ' ' ~ modifier ~ '" ' ~ aria_attributes ~ ' ' ~ additional_attributes -%}
     {{- source|replace({'<svg ': '<svg ' ~ attributes ~ ' '})|raw -}}
   {%- endif -%}
 {%- endif -%}

--- a/packages/sdc/components/01-atoms/image/image.twig
+++ b/packages/sdc/components/01-atoms/image/image.twig
@@ -16,12 +16,13 @@
 
 {% set theme_class = 'ct-theme-%s'|format(theme|default('light')) %}
 {% set modifier_class = '%s %s'|format(theme_class, modifier_class|default('')) %}
+{% set alt = (alt == '""') ? '' : alt|default('') %}
 
 {% if url is not empty %}
   <img
     class="ct-image {{ modifier_class -}}"
     src="{{ url }}"
-    {% if alt is not null %}alt="{{ alt }}"{% endif %}
+    alt="{{ alt }}"
     {% if width is not empty %}width="{{ width }}"{% endif %}
     {% if height is not empty %}height="{{ height }}"{% endif %}
     {% if attributes is not empty %}{{- attributes|raw -}}{% endif %}

--- a/packages/sdc/components/02-molecules/figure/figure.component.yml
+++ b/packages/sdc/components/02-molecules/figure/figure.component.yml
@@ -21,15 +21,19 @@ props:
       title: Modifier classes
       description: Additional CSS classes.
     url:
+      type: string
       title: URL
       description: Image URL.
     alt:
+      type: string
       title: Alt text
       description: Image alt text.
     width:
+      type: string
       title: Width
       description: Image width.
     height:
+      type: string
       title: Height
       description: Image height.
 slots:

--- a/packages/twig/components/00-base/icon/__snapshots__/icon.test.js.snap
+++ b/packages/twig/components/00-base/icon/__snapshots__/icon.test.js.snap
@@ -30,7 +30,6 @@ exports[`Icon Component renders with additional attributes and classes 1`] = `
 exports[`Icon Component renders with custom size 1`] = `
 <div>
   <svg
-    alt="Test Icon"
     aria-hidden="true"
     class="ct-icon ct-icon--size-large "
     height="24"

--- a/packages/twig/components/00-base/icon/icon.test.js
+++ b/packages/twig/components/00-base/icon/icon.test.js
@@ -17,13 +17,11 @@ describe('Icon Component', () => {
     const c = await dom(template, {
       symbol: 'close',
       size: 'large',
-      alt: 'Test Icon',
     });
 
     expect(c.querySelectorAll('.ct-icon.ct-icon--size-large')).toHaveLength(1);
     expect(c.querySelectorAll('.ct-icon[aria-hidden="true"]')).toHaveLength(1);
     expect(c.querySelectorAll('.ct-icon[role="img"]')).toHaveLength(1);
-    expect(c.querySelectorAll('.ct-icon[alt="Test Icon"]')).toHaveLength(1);
 
     assertUniqueCssClasses(c);
   });

--- a/packages/twig/components/00-base/icon/icon.twig
+++ b/packages/twig/components/00-base/icon/icon.twig
@@ -6,7 +6,6 @@
  * Props:
  * - symbol: [string] Icon name (required).
  * - size: [string] Icon size.
- * - alt: [string] Icon alt text.
  * - attributes: [string] Additional HTML attributes.
  * - modifier_class: [string] Additional CSS classes.
  * - assets_dir: [string] Directory containing icon assets.

--- a/packages/twig/components/00-base/icon/icon.twig
+++ b/packages/twig/components/00-base/icon/icon.twig
@@ -22,9 +22,8 @@
     {%- set base_class = 'ct-icon ' ~ size_class -%}
     {%- set modifier = modifier_class|default('') -%}
     {%- set aria_attributes = 'aria-hidden="true" role="img"' -%}
-    {%- set alt_attribute = alt is defined ? 'alt="' ~ alt ~ '"' : '' -%}
     {%- set additional_attributes = attributes|default('') -%}
-    {%- set attributes = 'class="' ~ base_class ~ ' ' ~ modifier ~ '" ' ~ aria_attributes ~ ' ' ~ alt_attribute ~ ' ' ~ additional_attributes -%}
+    {%- set attributes = 'class="' ~ base_class ~ ' ' ~ modifier ~ '" ' ~ aria_attributes ~ ' ' ~ additional_attributes -%}
     {{- source|replace({'<svg ': '<svg ' ~ attributes ~ ' '})|raw -}}
   {%- endif -%}
 {%- endif -%}

--- a/packages/twig/components/01-atoms/image/image.twig
+++ b/packages/twig/components/01-atoms/image/image.twig
@@ -16,12 +16,13 @@
 
 {% set theme_class = 'ct-theme-%s'|format(theme|default('light')) %}
 {% set modifier_class = '%s %s'|format(theme_class, modifier_class|default('')) %}
+{% set alt = (alt == '""') ? '' : alt|default('') %}
 
 {% if url is not empty %}
   <img
     class="ct-image {{ modifier_class -}}"
     src="{{ url }}"
-    {% if alt is not null %}alt="{{ alt }}"{% endif %}
+    alt="{{ alt }}"
     {% if width is not empty %}width="{{ width }}"{% endif %}
     {% if height is not empty %}height="{{ height }}"{% endif %}
     {% if attributes is not empty %}{{- attributes|raw -}}{% endif %}


### PR DESCRIPTION
## Checklist before requesting a review

- [ ] I have formatted the subject to include the issue number
  as `[#123] Verb in past tense with a period at the end.`
- [ ] I have provided information in the `Changed` section about WHY something was
  done if this was a bespoke implementation.
- [ ] I have performed a self-review of my code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have run new and existing relevant tests locally with my changes,
  and they have passed.
- [ ] I have provided screenshots, where applicable.

## Ticket:
- Drupal: https://www.drupal.org/project/civictheme/issues/3471946
- Jira: https://salsadigital.atlassian.net/browse/CIVIC-1912

## Changed

1. Treats `""` alt image text as blank.
2. Removed `alt_attribute` from `icon.twig` file.

## Screenshots
![Screenshot 2025-02-28 at 2 35 28 pm](https://github.com/user-attachments/assets/d35887b6-dbeb-462f-af9a-69b3c4240c98)
![Screenshot 2025-02-28 at 2 21 27 pm](https://github.com/user-attachments/assets/c0f316cf-b5cc-40e8-869c-00584ff3aa4f)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved handling of the `alt` attribute in image components to ensure it is always present and correctly formatted.
- **Refactor**
	- Removed support for the `alt` attribute in icon components, so icons no longer include or accept an `alt` property.
	- Updated documentation to reflect the removal of the `alt` attribute from icon components.
	- Explicitly defined property types for image-related properties in figure components for better consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->