### PR TITLE
[#352] Added Cacrousel region attributes.

### DIFF
--- a/components/03-organisms/slider/__snapshots__/slider.test.js.snap
+++ b/components/03-organisms/slider/__snapshots__/slider.test.js.snap
@@ -14,8 +14,11 @@ exports[`Slider Component renders with all attributes provided 1`] = `
 
   
   <div
+    aria-carousel="Slider"
+    aria-label="Slider Title"
     class="ct-slider ct-theme-dark ct-slider--with-background ct-vertical-spacing-inset--both additional-class"
     data-test="true"
+    role="region"
   >
     
     
@@ -214,7 +217,10 @@ exports[`Slider Component renders with only required attributes 1`] = `
 
   
   <div
+    aria-carousel="Slider"
+    aria-label="Slider"
     class="ct-slider ct-theme-light   "
+    role="region"
   >
     
     
@@ -384,7 +390,10 @@ exports[`Slider Component renders without some attributes 1`] = `
 
   
   <div
+    aria-carousel="Slider"
+    aria-label="Slider Title"
     class="ct-slider ct-theme-light   "
+    role="region"
   >
     
     

--- a/components/03-organisms/slider/slide.twig
+++ b/components/03-organisms/slider/slide.twig
@@ -31,7 +31,7 @@
 {% set theme_class = 'ct-theme-%s'|format(theme|default('light')) %}
 {% set modifier_class = '%s %s'|format(theme_class, modifier_class|default('')) %}
 
-<div class="ct-slide {{ modifier_class -}}" data-slider-slide {% if attributes is not empty %}{{ attributes|raw -}}{% endif %}>
+<div class="ct-slide {{ modifier_class -}}" role="group" aria-roledescription="slide" data-slider-slide {% if attributes is not empty %}{{ attributes|raw -}}{% endif %}>
 	<div class="row ct-slide__row">
     {% block image %}
       {% if image is not empty %}

--- a/components/03-organisms/slider/slider.js
+++ b/components/03-organisms/slider/slider.js
@@ -25,6 +25,7 @@ function CivicThemeSlider(el) {
   this.animationTimeout = null;
 
   this.updateProgress();
+  this.addSlideAriaAttributes();
   this.updateControlsState();
   this.hideAllSlidesExceptCurrent();
 
@@ -85,6 +86,12 @@ CivicThemeSlider.prototype.refresh = function () {
 CivicThemeSlider.prototype.enableSlideInteraction = function () {
   this.rail.querySelectorAll('a, button').forEach((link) => {
     link.removeAttribute('tabindex');
+  });
+};
+
+CivicThemeSlider.prototype.addSlideAriaAttributes = function () {
+  this.slides.forEach((slide, idx) => {
+    slide.setAttribute('aria-label', `Slide ${idx + 1} of ${this.totalSlides}`);
   });
 };
 

--- a/components/03-organisms/slider/slider.twig
+++ b/components/03-organisms/slider/slider.twig
@@ -24,7 +24,15 @@
 {% set modifier_class = '%s %s %s %s'|format(theme_class, with_background_class, vertical_spacing_class, modifier_class|default('')) %}
 
 {% if slides is not empty %}
-  <div class="ct-slider {{ modifier_class -}}" {% if attributes is not empty %}{{- attributes|raw -}}{% endif %}>
+  <div
+    role="region"
+    {% if title is not empty %}
+      aria-label="{{ title }}"
+    {% else %}
+      aria-label="Slider"
+    {% endif %}
+    aria-carousel="Slider"
+    class="ct-slider {{ modifier_class -}}" {% if attributes is not empty %}{{- attributes|raw -}}{% endif %}>
     <div class="container">
       <div class="row">
         <div class="col-xxs-12">


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have formatted the subject to include the issue number
  as `[#123] Verb in past tense with a period at the end.`
- [x] I have provided information in the `Changed` section about WHY something was
  done if this was a bespoke implementation.
- [x] I have performed a self-review of my code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have run new and existing relevant tests locally with my changes,
  and they have passed.
- [x] I have provided screenshots, where applicable.

## Changed

```
Wrap the carousel in a element with the role="region"
Provide an accessible name for the region via the aria-labelledby attribute, referencing the "Featured initiatives" heading that precedes the carousel.
Add the aria-roledescription="carousel" to the
element so that assistive technologies identify the region as a carousel.

Each slide should be in a element with role="group"
Provide an accessible name for each slide group via the aria-label attribute. The value should describe the position of the slide within the group, for example "1 of 2".
Add the aria-roledescription="slide" to the element so that assistive technologies identify the group as a slide.

```

## Screenshots
![Screenshot 2025-03-04 at 4 56 58 pm](https://github.com/user-attachments/assets/620d710b-30f5-44a4-9b60-413c33786e96)

