### PR TITLE
[#366] Removed disable carousel controls.

### DIFF
--- a/packages/sdc/components/03-organisms/slider/slider.js
+++ b/packages/sdc/components/03-organisms/slider/slider.js
@@ -25,7 +25,6 @@ function CivicThemeSlider(el) {
   this.animationTimeout = null;
 
   this.updateProgress();
-  this.updateControlsState();
   this.hideAllSlidesExceptCurrent();
 
   this.refresh();
@@ -120,36 +119,28 @@ CivicThemeSlider.prototype.updateDisplaySlide = function () {
   }, duration);
 };
 
-CivicThemeSlider.prototype.updateControlsState = function () {
-  this.prev.disabled = (this.currentSlide === 0);
-  if (this.prev.disabled) {
-    this.prev.classList.remove('focus');
-    this.prev.blur();
-  }
-  this.next.disabled = (this.currentSlide === (this.totalSlides - 1));
-  if (this.next.disabled) {
-    this.next.classList.remove('focus');
-    this.next.blur();
-  }
-};
-
 CivicThemeSlider.prototype.previousClick = function () {
-  this.currentSlide--;
-  this.currentSlide = this.currentSlide < 0 ? 0 : this.currentSlide;
+  // Go to last slide if current slide is the first slide.
+  if (this.currentSlide === 0) {
+    this.currentSlide = this.totalSlides - 1;
+  } else {
+    this.currentSlide--;
+  }
   this.rail.style.left = `${this.currentSlide * -100}%`;
   this.updateProgress();
   this.updateDisplaySlide();
-  this.updateControlsState();
 };
 
 CivicThemeSlider.prototype.nextClick = function () {
-  this.currentSlide++;
-  const total = this.totalSlides - 1;
-  this.currentSlide = this.currentSlide > total ? total : this.currentSlide;
+  // Go to first slide if current slide is the last slide.
+  if (this.currentSlide === (this.totalSlides - 1)) {
+    this.currentSlide = 0;
+  } else {
+    this.currentSlide++;
+  }
   this.rail.style.left = `${this.currentSlide * -100}%`;
   this.updateProgress();
   this.updateDisplaySlide();
-  this.updateControlsState();
 };
 
 CivicThemeSlider.prototype.updateProgress = function () {

--- a/packages/twig/components/03-organisms/slider/slider.js
+++ b/packages/twig/components/03-organisms/slider/slider.js
@@ -25,7 +25,6 @@ function CivicThemeSlider(el) {
   this.animationTimeout = null;
 
   this.updateProgress();
-  this.updateControlsState();
   this.hideAllSlidesExceptCurrent();
 
   this.refresh();
@@ -120,36 +119,28 @@ CivicThemeSlider.prototype.updateDisplaySlide = function () {
   }, duration);
 };
 
-CivicThemeSlider.prototype.updateControlsState = function () {
-  this.prev.disabled = (this.currentSlide === 0);
-  if (this.prev.disabled) {
-    this.prev.classList.remove('focus');
-    this.prev.blur();
-  }
-  this.next.disabled = (this.currentSlide === (this.totalSlides - 1));
-  if (this.next.disabled) {
-    this.next.classList.remove('focus');
-    this.next.blur();
-  }
-};
-
 CivicThemeSlider.prototype.previousClick = function () {
-  this.currentSlide--;
-  this.currentSlide = this.currentSlide < 0 ? 0 : this.currentSlide;
+  // Go to last slide if current slide is the first slide.
+  if (this.currentSlide === 0) {
+    this.currentSlide = this.totalSlides - 1;
+  } else {
+    this.currentSlide--;
+  }
   this.rail.style.left = `${this.currentSlide * -100}%`;
   this.updateProgress();
   this.updateDisplaySlide();
-  this.updateControlsState();
 };
 
 CivicThemeSlider.prototype.nextClick = function () {
-  this.currentSlide++;
-  const total = this.totalSlides - 1;
-  this.currentSlide = this.currentSlide > total ? total : this.currentSlide;
+  // Go to first slide if current slide is the last slide.
+  if (this.currentSlide === (this.totalSlides - 1)) {
+    this.currentSlide = 0;
+  } else {
+    this.currentSlide++;
+  }
   this.rail.style.left = `${this.currentSlide * -100}%`;
   this.updateProgress();
   this.updateDisplaySlide();
-  this.updateControlsState();
 };
 
 CivicThemeSlider.prototype.updateProgress = function () {


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have formatted the subject to include the issue number
  as `[#123] Verb in past tense with a period at the end.`
- [x] I have provided information in the `Changed` section about WHY something was
  done if this was a bespoke implementation.
- [x] I have performed a self-review of my code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have run new and existing relevant tests locally with my changes,
  and they have passed.
- [x] I have provided screenshots, where applicable.

## Ticket:
- Jira: https://salsadigital.atlassian.net/browse/CIVIC-2060
- Github: https://github.com/civictheme/uikit/issues/366

## Changed

1. Removed disabled attribute of carousel control buttons.
2. Removed tab-index of carousel indicator.

## Screenshots
![Screenshot 2025-03-04 at 9 03 14 pm](https://github.com/user-attachments/assets/46a5f1b3-f0ce-4529-9b61-44ecd47a6b78)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Slider navigation now wraps around cyclically, allowing continuous scrolling from the last slide to the first and vice versa.
- **Refactor**
	- Navigation buttons are always enabled, providing uninterrupted access to previous and next slides.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->