### PR TITLE
[#355] Updated skip link to use id on the main, or banner element.

### DIFF
--- a/components/03-organisms/banner/__snapshots__/banner.test.js.snap
+++ b/components/03-organisms/banner/__snapshots__/banner.test.js.snap
@@ -16,6 +16,8 @@ exports[`Banner Component renders with all attributes provided 1`] = `
   <div
     class="ct-banner ct-theme-dark ct-banner--decorative additional-class"
     data-test="true"
+    id="main-content"
+    tabindex="-1"
   >
     
     
@@ -239,14 +241,6 @@ Home
           </div>
           
           
-          
-          <a
-            aria-hidden="true"
-            id="main-content"
-            tabindex="-1"
-          />
-          
-
                       
           <div
             class="row"
@@ -448,6 +442,8 @@ exports[`Banner Component renders with only required attributes 1`] = `
   
   <div
     class="ct-banner ct-theme-light  "
+    id="main-content"
+    tabindex="-1"
   >
     
     
@@ -470,14 +466,6 @@ exports[`Banner Component renders with only required attributes 1`] = `
           
           
           
-          
-          <a
-            aria-hidden="true"
-            id="main-content"
-            tabindex="-1"
-          />
-          
-
           
                       
           <div
@@ -533,6 +521,8 @@ exports[`Banner Component renders without additional attributes and classes 1`] 
   
   <div
     class="ct-banner ct-theme-light  "
+    id="main-content"
+    tabindex="-1"
   >
     
     
@@ -555,14 +545,6 @@ exports[`Banner Component renders without additional attributes and classes 1`] 
           
           
           
-          
-          <a
-            aria-hidden="true"
-            id="main-content"
-            tabindex="-1"
-          />
-          
-
           
                       
           <div

--- a/components/03-organisms/banner/banner.twig
+++ b/components/03-organisms/banner/banner.twig
@@ -33,7 +33,7 @@
 {% set modifier_class = '%s %s %s'|format(theme_class, is_decorative_class, modifier_class|default('')) %}
 
 {% if content_top1 is not empty or content_top2 is not empty or content_top3 is not empty or site_section is not empty or title is not empty or content_middle is not empty or content is not empty or content_below is not empty or content_bottom is not empty %}
-  <div class="ct-banner {{ modifier_class -}}" {% if attributes is not empty %}{{- attributes|raw -}}{% endif %}>
+  <div class="ct-banner {{ modifier_class -}}" id="main-content" tabindex="-1" {% if attributes is not empty %}{{- attributes|raw -}}{% endif %}>
     <div class="ct-banner__wrapper">
       <div
         class="ct-banner__inner {% if background_image_blend_mode %}ct-background--{{ background_image_blend_mode|default('normal') }}{% endif %}"
@@ -95,8 +95,6 @@
               {% endblock -%}
             </div>
           {% endif %}
-
-          <a id="main-content" tabindex="-1" aria-hidden="true"></a>
 
           {% if site_section is not empty %}
             <div class="row">

--- a/components/04-templates/page/__snapshots__/page.test.js.snap
+++ b/components/04-templates/page/__snapshots__/page.test.js.snap
@@ -259,12 +259,6 @@ exports[`Page Component renders all blocks with complex attributes and classes 1
     </header>
     
   
-  
-    <a
-      id="banner"
-    />
-    
-
             
     <strong>
       Banner Content
@@ -656,20 +650,7 @@ exports[`Page Component renders content block with permutations: {
 
 
   
-  
-    <a
-      id="banner"
-    />
-    
-
-            
-    <a
-      aria-hidden="true"
-      id="main-content"
-      tabindex="-1"
-    />
-    
-      
+        
   
       
 
@@ -680,7 +661,9 @@ exports[`Page Component renders content block with permutations: {
 	
     <main
       class="ct-layout ct-vertical-spacing--top"
+      id="main-content"
       role="main"
+      tabindex="-1"
     >
       
 							
@@ -826,20 +809,7 @@ exports[`Page Component renders content block with permutations: {
 
 
   
-  
-    <a
-      id="banner"
-    />
-    
-
-            
-    <a
-      aria-hidden="true"
-      id="main-content"
-      tabindex="-1"
-    />
-    
-      
+        
   
       
 
@@ -850,7 +820,9 @@ exports[`Page Component renders content block with permutations: {
 	
     <main
       class="ct-layout ct-layout--no-sidebar-right  ct-layout--no-top-right  ct-layout--no-bottom-right ct-vertical-spacing--top"
+      id="main-content"
       role="main"
+      tabindex="-1"
     >
       
 							
@@ -982,20 +954,7 @@ exports[`Page Component renders content block with permutations: {
 
 
   
-  
-    <a
-      id="banner"
-    />
-    
-
-            
-    <a
-      aria-hidden="true"
-      id="main-content"
-      tabindex="-1"
-    />
-    
-      
+        
   
       
 
@@ -1006,7 +965,9 @@ exports[`Page Component renders content block with permutations: {
 	
     <main
       class="ct-layout ct-layout--no-sidebar-left  ct-layout--no-top-left  ct-layout--no-bottom-left  ct-vertical-spacing--top"
+      id="main-content"
       role="main"
+      tabindex="-1"
     >
       
 							
@@ -1138,20 +1099,7 @@ exports[`Page Component renders content block with permutations: {
 
 
   
-  
-    <a
-      id="banner"
-    />
-    
-
-            
-    <a
-      aria-hidden="true"
-      id="main-content"
-      tabindex="-1"
-    />
-    
-      
+        
   
       
 
@@ -1162,7 +1110,9 @@ exports[`Page Component renders content block with permutations: {
 	
     <main
       class="ct-layout ct-layout--no-sidebar-left ct-layout--no-sidebar-right ct-layout--no-top-left ct-layout--no-top-right ct-layout--no-bottom-left ct-layout--no-bottom-right"
+      id="main-content"
       role="main"
+      tabindex="-1"
     >
       
 							
@@ -1273,20 +1223,7 @@ exports[`Page Component renders with custom theme and attributes 1`] = `
 
 
   
-  
-    <a
-      id="banner"
-    />
-    
-
-            
-    <a
-      aria-hidden="true"
-      id="main-content"
-      tabindex="-1"
-    />
-    
-      
+        
   
       
 
@@ -1377,20 +1314,7 @@ exports[`Page Component renders with default values 1`] = `
 
 
   
-  
-    <a
-      id="banner"
-    />
-    
-
-            
-    <a
-      aria-hidden="true"
-      id="main-content"
-      tabindex="-1"
-    />
-    
-      
+        
   
       
 
@@ -1482,20 +1406,7 @@ exports[`Page Component strips HTML tags from attributes 1`] = `
 
 
   
-  
-    <a
-      id="banner"
-    />
-    
-
-            
-    <a
-      aria-hidden="true"
-      id="main-content"
-      tabindex="-1"
-    />
-    
-      
+        
   
       
 

--- a/components/04-templates/page/page.test.js
+++ b/components/04-templates/page/page.test.js
@@ -10,7 +10,6 @@ describe('Page Component', () => {
 
     expect(c.querySelectorAll('.ct-page.ct-theme-light')).toHaveLength(1);
     expect(c.querySelector('#top')).toBeTruthy();
-    expect(c.querySelector('#banner')).toBeTruthy();
 
     assertUniqueCssClasses(c);
   });

--- a/components/04-templates/page/page.twig
+++ b/components/04-templates/page/page.twig
@@ -31,13 +31,9 @@
     } only %}
   {% endblock %}
 
-  <a id="banner"></a>
-
   {% block banner %}
     {% if banner is not empty %}
       {{ banner|raw }}
-    {% else %}
-      <a id="main-content" tabindex="-1" aria-hidden="true"></a>
     {% endif %}
   {% endblock %}
 
@@ -71,6 +67,7 @@
       is_contained: content_contained,
       content_bottom: content_bottom,
       vertical_spacing: vertical_spacing,
+      attributes: (banner is empty) ? 'id="main-content" tabindex="-1"' : '',
     } only %}
   {% endblock %}
 


### PR DESCRIPTION
https://github.com/civictheme/uikit/issues/355

## Checklist before requesting a review

- [x] I have formatted the subject to include the issue number
  as `[#123] Verb in past tense with a period at the end.`
- [x] I have provided information in the `Changed` section about WHY something was
  done if this was a bespoke implementation.
- [x] I have performed a self-review of my code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have run new and existing relevant tests locally with my changes,
  and they have passed.
- [x] I have provided screenshots, where applicable.

## Changed

1. Removed empty `<a>` for skipping to main-content.
2. Added main-content id to banner root element (if available) or main if no banner available. Banner already has id set from drupal, so PR to remove the second id is [here](https://github.com/civictheme/monorepo-drupal/pull/1354).
3. Removed empty `<a>` for banner - this looks like a remnant of an old implementation. See notes below.

**Note on banner skip link removal:**

Looking into why this empty anchor existed when it didn't seem to be used, I found the following:

It was originally part of an accessibility fix where skip link would point to the banner element, then reverted back to main-content some time later. Links below for context:


GH:     https://github.com/civictheme/monorepo-drupal/pull/335/files

Banner id was originally used.

GH:     https://github.com/civictheme/monorepo-drupal/pull/423/files

Banner changed back to main-content, but banner id never removed.

## Screenshots

<img width="1443" alt="Screenshot 2025-03-07 at 10 24 32 pm" src="https://github.com/user-attachments/assets/9e7c2e81-a210-447d-93c2-0e7f221dc4b1" />
<img width="1007" alt="Screenshot 2025-03-07 at 10 24 07 pm" src="https://github.com/user-attachments/assets/793ae67c-36c1-497f-ac82-f6c91281e508" />
