### PR TITLE
Removed legacy @font-face `src` attribute used in IE <10.

### DIFF
--- a/components/00-base/mixins/_font.scss
+++ b/components/00-base/mixins/_font.scss
@@ -88,7 +88,6 @@
       }
 
       $local-src-list: ();
-      $extra-src: null;
 
       @each $path in $uri {
         @if string.index($path, 'http') == 1 {
@@ -99,8 +98,6 @@
 
           // Handle special case for EOT and IE.
           @if $format == 'eot' {
-            $extra-src: url('#{$path}');
-            $path: '#{$path}?#iefix';
             $format: 'embedded-opentype';
           }
 
@@ -124,10 +121,6 @@
 
         @font-face {
           font-family: $font-family;
-
-          @if $extra-src {
-            src: $extra-src;
-          }
 
           src: $local-src-list;
 


### PR DESCRIPTION
This was added in 2021 when IE <10 was still relevant in government orgs. This is [no longer the case](https://en.wikipedia.org/wiki/Usage_share_of_web_browsers) and this IE hack can be safely removed.

## Changed

1. Removed an additional `src` attribute added for `eot` fonts used to account for IE <10.

[Spec of @font-face`](https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face#syntax)