### PR TITLE
[#520] Grouped related fields and placed aria-invalid on correct input element.

### DIFF
--- a/components/01-atoms/checkbox/checkbox.twig
+++ b/components/01-atoms/checkbox/checkbox.twig
@@ -32,6 +32,7 @@
     {% if is_checked %}checked{% endif %}
     {% if is_required %}required{% endif %}
     {% if is_disabled %}disabled{% endif %}
+    {% if is_invalid %}aria-invalid="true"{% endif %}
     {% if attributes is not empty %}{{- attributes|raw -}}{% endif %}
   />
   {% if label is not empty %}

--- a/components/01-atoms/input/input.twig
+++ b/components/01-atoms/input/input.twig
@@ -29,6 +29,7 @@
 		{% if id %}id="{{ id }}"{% endif %}
 		{% if is_disabled %}disabled{% endif %}
 		{% if is_required %}required{% endif %}
+		{% if is_invalid %}aria-invalid="true"{% endif %}
 		{% if placeholder %}placeholder="{{ placeholder }}"{% endif %}
 		{% if attributes is not empty %}{{- attributes|raw -}}{% endif %}
 	/>

--- a/components/01-atoms/radio/radio.twig
+++ b/components/01-atoms/radio/radio.twig
@@ -32,6 +32,7 @@
     {% if is_checked %}checked{% endif %}
     {% if is_required %}required{% endif %}
     {% if is_disabled %}disabled{% endif %}
+    {% if is_invalid %}aria-invalid="true"{% endif %}
     {% if attributes is not empty %}{{- attributes|raw -}}{% endif %}
   />
   {% if label is not empty %}

--- a/components/01-atoms/select/select.twig
+++ b/components/01-atoms/select/select.twig
@@ -36,6 +36,7 @@
 		{% if is_multiple %}multiple{% endif %}
 		{% if is_disabled %}disabled{% endif %}
 		{% if is_required %}required{% endif %}
+		{% if is_invalid %}aria-invalid="true"{% endif %}
 		{% if attributes is not empty %}{{- attributes|raw -}}{% endif %}
 	>
 		{% for option in options %}

--- a/components/01-atoms/textarea/textarea.twig
+++ b/components/01-atoms/textarea/textarea.twig
@@ -29,6 +29,7 @@
     {% if id %}id="{{ id }}"{% endif %}
     {% if is_disabled %}disabled{% endif %}
     {% if is_required %}required{% endif %}
+    {% if is_invalid %}aria-invalid="true"{% endif %}
     {% if placeholder %}placeholder="{{ placeholder }}"{% endif %}
     {% if attributes is not empty %}{{- attributes|raw -}}{% endif %}
   />{{ value|default('') }}</textarea>

--- a/components/01-atoms/textfield/textfield.twig
+++ b/components/01-atoms/textfield/textfield.twig
@@ -29,6 +29,7 @@
 		{% if id %}id="{{ id }}"{% endif %}
 		{% if is_disabled %}disabled{% endif %}
 		{% if is_required %}required{% endif %}
+		{% if is_invalid %}aria-invalid="true"{% endif %}
 		{% if placeholder %}placeholder="{{ placeholder }}"{% endif %}
 		{% if attributes is not empty %}{{- attributes|raw -}}{% endif %}
 	/>

--- a/components/02-molecules/field/field.scss
+++ b/components/02-molecules/field/field.scss
@@ -17,6 +17,15 @@
     margin-bottom: ct-spacing(2);
   }
 
+  &#{$root}--radio,
+  &#{$root}--checkbox {
+    #{$root}__wrapper {
+      border: none;
+      padding: 0;
+      margin: 0;
+    }
+  }
+
   & > *:not(:last-child),
   &__wrapper > *:not(:last-child) {
     margin-bottom: ct-spacing();

--- a/components/02-molecules/field/field.twig
+++ b/components/02-molecules/field/field.twig
@@ -83,7 +83,7 @@
 		placeholder: placeholder is defined ? placeholder : '',
 		is_required: c.is_required is defined ? c.is_required : is_required,
 		required_text: c.required_text ? c.required_text : required_text,
-		is_invalid: is_invalid,
+		is_invalid: c.is_invalid is defined ? c.is_invalid : is_invalid,
 		is_disabled: c.is_disabled is defined ? c.is_disabled : is_disabled,
 		is_checked: c.is_checked is defined ? c.is_checked : false,
 		attributes: c.attributes is defined ? c.attributes : '',
@@ -92,10 +92,14 @@
 	{% set _controls = _controls|merge([c]) %}
 {% endfor %}
 {% set control = _controls %}
+{% set field_wrapper = type in ['checkbox', 'radio'] ? 'fieldset' : 'div' %}
 
 {% if control[0].name is defined %}
+	{% if attributes is not empty %}
+		{% set attributes = attributes|without('aria-invalid') %}
+	{% endif %}
 	<div class="ct-field {{ modifier_class -}}" {% if attributes %}{{- attributes|raw -}}{% endif %}>
-		{% if title is not empty and title_display != 'hidden' and type != 'hidden' %}
+		{% if title is not empty and title_display != 'hidden' and type not in ['hidden', 'checkbox', 'radio'] %}
 			{% include '@atoms/label/label.twig' with {
 				theme: theme,
 				content: label is not empty ? label : title,
@@ -106,7 +110,18 @@
 			} only %}
 		{% endif %}
 
-		<div class="ct-field__wrapper">
+		<{{ field_wrapper }} class="ct-field__wrapper">
+			{% if title is not empty and title_display != 'hidden' and type in ['checkbox', 'radio'] %}
+				{% include '@atoms/label/label.twig' with {
+					theme: theme,
+					tag: 'legend',
+					content: title,
+					is_required: is_required,
+					for: control[0].id and type not in ['radio', 'checkbox'] ? control[0].id : null,
+					modifier_class: 'ct-field__title' ~ (title_display == 'invisible' ? ' ct-visually-hidden' : ''),
+				} only %}
+			{% endif %}
+
 			{% if (description) and type != 'hidden' %}
 				{% include '@atoms/field-description/field-description.twig' with {
 					theme: theme,
@@ -167,6 +182,6 @@
 					attributes: message.attributes|default('')
 				} only %}
 			{% endif %}
-		</div>
+		</{{ field_wrapper }}>
 	</div>
 {% endif %}


### PR DESCRIPTION
## Checklist before requesting a review

- [ ] I have formatted the subject to include the issue number
  as `[#123] Verb in past tense with a period at the end.`
- [ ] I have provided information in the `Changed` section about WHY something was
  done if this was a bespoke implementation.
- [ ] I have performed a self-review of my code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have run new and existing relevant tests locally with my changes,
  and they have passed.
- [ ] I have provided screenshots, where applicable.

## Changed

1.

## Screenshots
<img width="1687" alt="Screenshot 2025-04-08 at 4 23 55 pm" src="https://github.com/user-attachments/assets/500968e1-51b8-48d5-9cab-98ed6646db64" />

<img width="479" alt="Screenshot 2025-04-08 at 4 23 31 pm" src="https://github.com/user-attachments/assets/3e9a7587-c9ca-4182-a29f-fdd6f6dd17ca" />

<img width="510" alt="Screenshot 2025-04-08 at 4 23 28 pm" src="https://github.com/user-attachments/assets/fafff71c-7c66-4e18-a158-5158e4133ebb" />

