### PR TITLE
Fixed GHA to skip netlify deployment comments on `main` branch.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -123,6 +123,7 @@ jobs:
           NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
         timeout-minutes: 1
+
       - name: Deploy SDC Components Storybook to Netlify
         id: netlify-sdc
         if: matrix.node-version == 22
@@ -140,20 +141,24 @@ jobs:
           NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
         timeout-minutes: 1
-      - name: Find ID of existing deployment message
+
+      - name: Find ID of existing deployment message for a PR
         uses: 'peter-evans/find-comment@14614d7a55fa5b53e634f9e6c068317a3f7b6ab1'
         id: netlify-deploy-message
+        if: github.event_name == 'pull_request'
         with:
           issue-number: ${{ github.event.pull_request.number }}
           comment-author: 'github-actions[bot]'
           body-includes: 'CivicTheme UI Kit Deployments'
-      - name: Create or update deployment message
+
+      - name: Create or update deployment message on a PR
         uses: 'peter-evans/create-or-update-comment@70cab5820c914a684c6c1db2c5537c3279e31860'
+        if: github.event_name == 'pull_request'
         with:
           comment-id: ${{ steps.netlify-deploy-message.outputs.comment-id }}
           issue-number: ${{ github.event.pull_request.number }}
           body: |
             🎨 CivicTheme UI Kit Deployments:
             - 📦 [twig](${{ steps.netlify-twig.outputs.deploy-url }})
-            - :📦 [sdc](${{ steps.netlify-sdc.outputs.deploy-url }})
+            - 📦 [sdc](${{ steps.netlify-sdc.outputs.deploy-url }})
           edit-mode: replace

--- a/.github/workflows/visual-regression.yml
+++ b/.github/workflows/visual-regression.yml
@@ -12,8 +12,6 @@ on:
       - 'project/**'
       - 'feature/**'
 
-
-
 jobs:
   visual-regression:
     runs-on: ubuntu-latest
@@ -81,7 +79,8 @@ jobs:
           NETLIFY_SITE_ID: ${{ secrets.NETLIFY_VISUAL_REGRESSION_SITE_ID }}
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
         timeout-minutes: 1
-      - name: Generate the visual regression message.
+
+      - name: Generate the visual regression message
         id: visual-regression-message
         uses: actions/github-script@v7
         with:
@@ -90,14 +89,16 @@ jobs:
             const { default: createVisualRegressionPrComments } = await import('${{ github.workspace }}/.github/action-scripts/create-visual-regression-pr-comments.js')
             const deploymentUrl = ${{ steps.netlify-deploy-message.outputs.comment-id }}
             createVisualRegressionPrComments({require, core})
-      - name: Find ID of existing deployment message
+
+      - name: Find ID of existing deployment message on a PR
         uses: 'peter-evans/find-comment@14614d7a55fa5b53e634f9e6c068317a3f7b6ab1'
         id: netlify-visual-regression-message
         with:
           issue-number: ${{ github.event.pull_request.number }}
           comment-author: 'github-actions[bot]'
           body-includes: 'CivicTheme UI Kit Deployments'
-      - name: Create or update deployment message
+
+      - name: Create or update deployment message on a PR
         uses: 'peter-evans/create-or-update-comment@70cab5820c914a684c6c1db2c5537c3279e31860'
         with:
           comment-id: ${{ steps.netlify-visual-regression-message.outputs.comment-id }}
@@ -107,7 +108,3 @@ jobs:
 
             ${{ steps.visual-regression-message.outputs.comment }}
           edit-mode: replace
-
-
-
-


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated GitHub Actions workflows to run certain deployment and messaging steps only for pull request events.
  - Clarified step names and fixed minor formatting issues in deployment messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->