### PR TITLE
Issue #3529956: Basic Content tables on mobile render incorrectly

### DIFF
--- a/packages/sdc/components/02-molecules/basic-content/basic-content.component.yml
+++ b/packages/sdc/components/02-molecules/basic-content/basic-content.component.yml
@@ -41,3 +41,6 @@ slots:
   content:
     title: Content
     description: HTML content.
+libraryOverrides:
+  dependencies:
+    - core/components.civictheme--table


### PR DESCRIPTION
https://www.drupal.org/project/civictheme/issues/3529956

## Checklist before requesting a review

- [x] I have formatted the subject to include the issue number
  as `[#123] Verb in past tense with a period at the end.`
- [x] I have provided information in the `Changed` section about WHY something was
  done if this was a bespoke implementation.
- [x] I have performed a self-review of my code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have run new and existing relevant tests locally with my changes,
  and they have passed.
- [ ] I have provided screenshots, where applicable.

## Changed

1. Options to solve this were either split the JS implementation so table JS is a base utility that can be applied in any component, or implement a dependency on table for basic-content so that any time basic-content is used it will include table libraries.
2. Implementing the JS split (given the current structure of civictheme) would likely require adding a `[data-table]` attribute to any div that is, or may contain a table. This attribute could be added to both atom/table and molecule/basic-content and anywhere else a table may be used (this could also include paragraph components as they too use basic-content styling).
3. The benefit on tables in base is the dependencies within components are simplified, but the drawback is that more styles and JS exist within the base library whether they are used or not.
4. This implementation has a drawback of needing to use the drupal theme machine name `core/components.civictheme--table` within the SDC. Up until now the drupal theme name is not assumed to be `civictheme` and could change without affecting the UI Kit, however as SDC is a drupal concept and dependencies rely on providing the theme name, this is likely to get murkier the more we include drupalisms in UI Kit.

## Screenshots
