### PR TITLE
Fixed Chip events and removed button state management from the Single filter.

### DIFF
--- a/packages/sdc/components/01-atoms/chip/__snapshots__/chip.test.js.snap
+++ b/packages/sdc/components/01-atoms/chip/__snapshots__/chip.test.js.snap
@@ -16,6 +16,7 @@ exports[`Chip Component renders with optional attributes 1`] = `
   <label
     class="ct-chip ct-theme-dark ct-chip--input ct-chip--large active ct-chip--multiple custom-class"
     data-chip-dismiss=""
+    data-chip-group-parent="test-group"
     data-component-name="chip"
   >
     

--- a/packages/sdc/components/01-atoms/chip/chip.component.yml
+++ b/packages/sdc/components/01-atoms/chip/chip.component.yml
@@ -49,3 +49,8 @@ props:
       type: string
       title: Modifier classes
       description: Additional CSS classes.
+    group_parent:
+      type: string
+      title: Group parent
+      description: Additional parent selector for radio group.
+

--- a/packages/sdc/components/01-atoms/chip/chip.component.yml
+++ b/packages/sdc/components/01-atoms/chip/chip.component.yml
@@ -41,6 +41,10 @@ props:
       type: boolean
       title: Multiple
       description: Whether multiple selection is allowed.
+    group_parent:
+      type: string
+      title: Group parent
+      description: Additional parent selector for radio group.
     attributes:
       type: string
       title: Attributes
@@ -49,8 +53,4 @@ props:
       type: string
       title: Modifier classes
       description: Additional CSS classes.
-    group_parent:
-      type: string
-      title: Group parent
-      description: Additional parent selector for radio group.
 

--- a/packages/sdc/components/01-atoms/chip/chip.js
+++ b/packages/sdc/components/01-atoms/chip/chip.js
@@ -75,13 +75,20 @@ CivicThemeChip.prototype.changeEvent = function (e) {
   // For radios, check current and uncheck others in this group.
   if (input.getAttribute('type') === 'radio') {
     const name = input.getAttribute('name');
-    const radios = document.querySelectorAll(`input[type=radio][name="${name}"]`);
+    // Find the closest chip group container (ct-chip)
+    const chipGroup = chip.closest('.ct-chip');
+    let radios;
+    if (chipGroup) {
+      radios = chipGroup.querySelectorAll(`input[type=radio][name="${name}"]`);
+    } else {
+      // Fallback to just the current input if no group found
+      radios = [input];
+    }
     for (const i in radios) {
       if (Object.prototype.hasOwnProperty.call(radios, i) && radios[i] !== input) {
         this.setChecked(radios[i], false);
       }
     }
-
     this.setChecked(input, true);
   } else {
     this.setChecked(input, input.checked);

--- a/packages/sdc/components/01-atoms/chip/chip.js
+++ b/packages/sdc/components/01-atoms/chip/chip.js
@@ -8,6 +8,7 @@ function CivicThemeChip(el) {
   }
 
   this.el = el;
+  this.groupParentSelector = el.getAttribute('data-chip-group-parent') || null;
 
   this.el.addEventListener('change', this.changeEvent.bind(this));
   this.el.addEventListener('focusin', this.focusinEvent.bind(this));
@@ -75,14 +76,12 @@ CivicThemeChip.prototype.changeEvent = function (e) {
   // For radios, check current and uncheck others in this group.
   if (input.getAttribute('type') === 'radio') {
     const name = input.getAttribute('name');
-    // Find the closest chip group container (ct-chip)
-    const chipGroup = chip.closest('.ct-chip');
     let radios;
-    if (chipGroup) {
-      radios = chipGroup.querySelectorAll(`input[type=radio][name="${name}"]`);
+    if (this.groupParentSelector) {
+      const chipGroup = chip.closest(this.groupParentSelector);
+      radios = chipGroup ? chipGroup.querySelectorAll(`input[type=radio][name="${name}"]`) : document.querySelectorAll(`input[type=radio][name="${name}"]`);
     } else {
-      // Fallback to just the current input if no group found
-      radios = [input];
+      radios = document.querySelectorAll(`input[type=radio][name="${name}"]`);
     }
     for (const i in radios) {
       if (Object.prototype.hasOwnProperty.call(radios, i) && radios[i] !== input) {

--- a/packages/sdc/components/01-atoms/chip/chip.js
+++ b/packages/sdc/components/01-atoms/chip/chip.js
@@ -76,18 +76,13 @@ CivicThemeChip.prototype.changeEvent = function (e) {
   // For radios, check current and uncheck others in this group.
   if (input.getAttribute('type') === 'radio') {
     const name = input.getAttribute('name');
-    let radios;
-    if (this.groupParentSelector) {
-      const chipGroup = chip.closest(this.groupParentSelector);
-      radios = chipGroup ? chipGroup.querySelectorAll(`input[type=radio][name="${name}"]`) : document.querySelectorAll(`input[type=radio][name="${name}"]`);
-    } else {
-      radios = document.querySelectorAll(`input[type=radio][name="${name}"]`);
-    }
-    for (const i in radios) {
-      if (Object.prototype.hasOwnProperty.call(radios, i) && radios[i] !== input) {
-        this.setChecked(radios[i], false);
+    const chipContainer = (!!this.groupParentSelector && chip.closest(this.groupParentSelector)) || document;
+    const radios = chipContainer.querySelectorAll(`input[type=radio][name="${name}"]`);
+    radios.forEach((radio) => {
+      if (radio !== input) {
+        this.setChecked(radio, false);
       }
-    }
+    });
     this.setChecked(input, true);
   } else {
     this.setChecked(input, input.checked);

--- a/packages/sdc/components/01-atoms/chip/chip.test.js
+++ b/packages/sdc/components/01-atoms/chip/chip.test.js
@@ -25,6 +25,7 @@ describe('Chip Component', () => {
       is_disabled: true,
       is_dismissible: true,
       is_multiple: true,
+      group_parent: 'test-group',
       attributes: 'data-test="true"',
       modifier_class: 'custom-class',
       theme: 'dark',
@@ -32,6 +33,7 @@ describe('Chip Component', () => {
 
     expect(c.querySelectorAll('.ct-chip.custom-class.ct-theme-dark.ct-chip--input.ct-chip--large.active.ct-chip--multiple')).toHaveLength(1);
     expect(c.querySelector('.ct-chip').textContent.trim()).toContain('Sample Chip');
+    expect(c.querySelector('.ct-chip').getAttribute('data-chip-group-parent')).toEqual('test-group');
     expect(c.querySelector('.ct-chip__input').getAttribute('data-test')).toEqual('true');
     expect(c.querySelector('.ct-chip__input').getAttribute('type')).toEqual('checkbox');
     expect(c.querySelector('.ct-chip__input').checked).toBe(true);

--- a/packages/sdc/components/01-atoms/chip/chip.twig
+++ b/packages/sdc/components/01-atoms/chip/chip.twig
@@ -12,6 +12,7 @@
  * - is_multiple: [boolean] Whether multiple selection is allowed.
  * - attributes: [string] Additional HTML attributes.
  * - modifier_class: [string] Additional CSS classes.
+ * - group_parent: [string] Additional parent selector for radio group.
  */
 #}
 
@@ -30,6 +31,7 @@
       class="ct-chip {{ modifier_class -}}"
       data-component-name="chip"
       {% if is_multiple %}data-chip-dismiss{% endif %}
+      {% if group_parent %}data-chip-group-parent="{{ group_parent }}"{% endif %}
     >
       <input
         class="ct-chip__input"

--- a/packages/sdc/components/01-atoms/chip/chip.twig
+++ b/packages/sdc/components/01-atoms/chip/chip.twig
@@ -10,9 +10,9 @@
  * - content: [string] Chip text.
  * - is_selected: [boolean] Whether the chip is selected (for filter chips).
  * - is_multiple: [boolean] Whether multiple selection is allowed.
+ * - group_parent: [string] Additional parent selector for radio group.
  * - attributes: [string] Additional HTML attributes.
  * - modifier_class: [string] Additional CSS classes.
- * - group_parent: [string] Additional parent selector for radio group.
  */
 #}
 

--- a/packages/sdc/components/02-molecules/single-filter/__snapshots__/single-filter.test.js.snap
+++ b/packages/sdc/components/02-molecules/single-filter/__snapshots__/single-filter.test.js.snap
@@ -73,6 +73,7 @@ exports[`Single Filter Component renders with multiple selection enabled 1`] = `
                   <label
                     class="ct-chip ct-theme-light ct-chip--input ct-chip--small active ct-chip--multiple "
                     data-chip-dismiss=""
+                    data-chip-group-parent=".ct-single-filter"
                     data-component-name="chip"
                   >
                     
@@ -118,6 +119,7 @@ exports[`Single Filter Component renders with multiple selection enabled 1`] = `
                   <label
                     class="ct-chip ct-theme-light ct-chip--input ct-chip--small  ct-chip--multiple "
                     data-chip-dismiss=""
+                    data-chip-group-parent=".ct-single-filter"
                     data-component-name="chip"
                   >
                     
@@ -305,6 +307,7 @@ exports[`Single Filter Component renders with optional attributes 1`] = `
       
                   <label
                     class="ct-chip ct-theme-dark ct-chip--input ct-chip--small active  "
+                    data-chip-group-parent=".ct-single-filter"
                     data-component-name="chip"
                   >
                     
@@ -331,6 +334,7 @@ exports[`Single Filter Component renders with optional attributes 1`] = `
       
                   <label
                     class="ct-chip ct-theme-dark ct-chip--input ct-chip--small   "
+                    data-chip-group-parent=".ct-single-filter"
                     data-component-name="chip"
                   >
                     
@@ -508,6 +512,7 @@ exports[`Single Filter Component renders with required attributes 1`] = `
       
                   <label
                     class="ct-chip ct-theme-light ct-chip--input ct-chip--small active  "
+                    data-chip-group-parent=".ct-single-filter"
                     data-component-name="chip"
                   >
                     
@@ -533,6 +538,7 @@ exports[`Single Filter Component renders with required attributes 1`] = `
       
                   <label
                     class="ct-chip ct-theme-light ct-chip--input ct-chip--small   "
+                    data-chip-group-parent=".ct-single-filter"
                     data-component-name="chip"
                   >
                     

--- a/packages/sdc/components/02-molecules/single-filter/single-filter.js
+++ b/packages/sdc/components/02-molecules/single-filter/single-filter.js
@@ -3,46 +3,29 @@
  */
 
 function CivicThemeSingleFilterComponent(el) {
-  if (this.el) {
+  if (el.getAttribute('data-single-filter') === 'true') {
     return;
   }
 
   this.el = el;
 
-  this.el.addEventListener('ct.single-filter.update', this.update.bind(this));
+  this.el.addEventListener('ct.single-filter.update', this.updateEvent.bind(this));
 
-  if (!el.hasEventListener) {
-    el.hasEventListener = true;
-    el.querySelectorAll('input, textarea, select, [type="checkbox"], [type="radio"]').forEach((input) => {
-      input.addEventListener('change', () => {
-        el.dispatchEvent(new CustomEvent('ct.single-filter.update', { detail: { parent: input.parentElement } }));
-      });
+  this.el.querySelectorAll('input, textarea, select, [type="checkbox"], [type="radio"]').forEach((input) => {
+    input.addEventListener('change', () => {
+      el.dispatchEvent(new CustomEvent('ct.single-filter.update', { detail: { parent: input.parentElement } }));
     });
-  }
+  });
 
-  this.activateOrDeactivateSubmitButton(el);
+  // Mark as initialized.
+  this.el.setAttribute('data-single-filter', 'true');
 }
 
 /**
- * Update the instance.
+ * Update event handler.
  */
-CivicThemeSingleFilterComponent.prototype.update = function (el) {
+CivicThemeSingleFilterComponent.prototype.updateEvent = function (el) {
   el.detail.parent.setAttribute('aria-live', 'polite');
-  this.activateOrDeactivateSubmitButton(this.el);
-};
-
-CivicThemeSingleFilterComponent.prototype.activateOrDeactivateSubmitButton = function (el) {
-  const buttons = el.querySelectorAll('.ct-button');
-  const activeChips = el.querySelectorAll('.ct-chip.active');
-  if (!activeChips.length) {
-    buttons.forEach((element) => {
-      element.setAttribute('disabled', 'disabled');
-    });
-  } else {
-    buttons.forEach((element) => {
-      element.removeAttribute('disabled');
-    });
-  }
 };
 
 document.querySelectorAll('.ct-single-filter').forEach((el) => {

--- a/packages/sdc/components/02-molecules/single-filter/single-filter.twig
+++ b/packages/sdc/components/02-molecules/single-filter/single-filter.twig
@@ -61,6 +61,7 @@
                     is_multiple: is_multiple,
                     is_selected: item.is_selected is defined ? item.is_selected : false,
                     content: item.text,
+                    group_parent: '.ct-single-filter',
                     attributes: item_attributes,
                   } only %}
                 {% endif %}

--- a/packages/twig/components/01-atoms/chip/__snapshots__/chip.test.js.snap
+++ b/packages/twig/components/01-atoms/chip/__snapshots__/chip.test.js.snap
@@ -16,6 +16,7 @@ exports[`Chip Component renders with optional attributes 1`] = `
   <label
     class="ct-chip ct-theme-dark ct-chip--input ct-chip--large active ct-chip--multiple custom-class"
     data-chip-dismiss=""
+    data-chip-group-parent="test-group"
     data-component-name="chip"
   >
     

--- a/packages/twig/components/01-atoms/chip/chip.js
+++ b/packages/twig/components/01-atoms/chip/chip.js
@@ -75,13 +75,20 @@ CivicThemeChip.prototype.changeEvent = function (e) {
   // For radios, check current and uncheck others in this group.
   if (input.getAttribute('type') === 'radio') {
     const name = input.getAttribute('name');
-    const radios = document.querySelectorAll(`input[type=radio][name="${name}"]`);
+    // Find the closest chip group container (ct-chip)
+    const chipGroup = chip.closest('.ct-chip');
+    let radios;
+    if (chipGroup) {
+      radios = chipGroup.querySelectorAll(`input[type=radio][name="${name}"]`);
+    } else {
+      // Fallback to just the current input if no group found
+      radios = [input];
+    }
     for (const i in radios) {
       if (Object.prototype.hasOwnProperty.call(radios, i) && radios[i] !== input) {
         this.setChecked(radios[i], false);
       }
     }
-
     this.setChecked(input, true);
   } else {
     this.setChecked(input, input.checked);

--- a/packages/twig/components/01-atoms/chip/chip.js
+++ b/packages/twig/components/01-atoms/chip/chip.js
@@ -8,6 +8,7 @@ function CivicThemeChip(el) {
   }
 
   this.el = el;
+  this.groupParentSelector = el.getAttribute('data-chip-group-parent') || null;
 
   this.el.addEventListener('change', this.changeEvent.bind(this));
   this.el.addEventListener('focusin', this.focusinEvent.bind(this));
@@ -75,14 +76,12 @@ CivicThemeChip.prototype.changeEvent = function (e) {
   // For radios, check current and uncheck others in this group.
   if (input.getAttribute('type') === 'radio') {
     const name = input.getAttribute('name');
-    // Find the closest chip group container (ct-chip)
-    const chipGroup = chip.closest('.ct-chip');
     let radios;
-    if (chipGroup) {
-      radios = chipGroup.querySelectorAll(`input[type=radio][name="${name}"]`);
+    if (this.groupParentSelector) {
+      const chipGroup = chip.closest(this.groupParentSelector);
+      radios = chipGroup ? chipGroup.querySelectorAll(`input[type=radio][name="${name}"]`) : document.querySelectorAll(`input[type=radio][name="${name}"]`);
     } else {
-      // Fallback to just the current input if no group found
-      radios = [input];
+      radios = document.querySelectorAll(`input[type=radio][name="${name}"]`);
     }
     for (const i in radios) {
       if (Object.prototype.hasOwnProperty.call(radios, i) && radios[i] !== input) {

--- a/packages/twig/components/01-atoms/chip/chip.js
+++ b/packages/twig/components/01-atoms/chip/chip.js
@@ -76,18 +76,13 @@ CivicThemeChip.prototype.changeEvent = function (e) {
   // For radios, check current and uncheck others in this group.
   if (input.getAttribute('type') === 'radio') {
     const name = input.getAttribute('name');
-    let radios;
-    if (this.groupParentSelector) {
-      const chipGroup = chip.closest(this.groupParentSelector);
-      radios = chipGroup ? chipGroup.querySelectorAll(`input[type=radio][name="${name}"]`) : document.querySelectorAll(`input[type=radio][name="${name}"]`);
-    } else {
-      radios = document.querySelectorAll(`input[type=radio][name="${name}"]`);
-    }
-    for (const i in radios) {
-      if (Object.prototype.hasOwnProperty.call(radios, i) && radios[i] !== input) {
-        this.setChecked(radios[i], false);
+    const chipContainer = (!!this.groupParentSelector && chip.closest(this.groupParentSelector)) || document;
+    const radios = chipContainer.querySelectorAll(`input[type=radio][name="${name}"]`);
+    radios.forEach((radio) => {
+      if (radio !== input) {
+        this.setChecked(radio, false);
       }
-    }
+    });
     this.setChecked(input, true);
   } else {
     this.setChecked(input, input.checked);

--- a/packages/twig/components/01-atoms/chip/chip.test.js
+++ b/packages/twig/components/01-atoms/chip/chip.test.js
@@ -25,6 +25,7 @@ describe('Chip Component', () => {
       is_disabled: true,
       is_dismissible: true,
       is_multiple: true,
+      group_parent: 'test-group',
       attributes: 'data-test="true"',
       modifier_class: 'custom-class',
       theme: 'dark',
@@ -32,6 +33,7 @@ describe('Chip Component', () => {
 
     expect(c.querySelectorAll('.ct-chip.custom-class.ct-theme-dark.ct-chip--input.ct-chip--large.active.ct-chip--multiple')).toHaveLength(1);
     expect(c.querySelector('.ct-chip').textContent.trim()).toContain('Sample Chip');
+    expect(c.querySelector('.ct-chip').getAttribute('data-chip-group-parent')).toEqual('test-group');
     expect(c.querySelector('.ct-chip__input').getAttribute('data-test')).toEqual('true');
     expect(c.querySelector('.ct-chip__input').getAttribute('type')).toEqual('checkbox');
     expect(c.querySelector('.ct-chip__input').checked).toBe(true);

--- a/packages/twig/components/01-atoms/chip/chip.twig
+++ b/packages/twig/components/01-atoms/chip/chip.twig
@@ -12,6 +12,7 @@
  * - is_multiple: [boolean] Whether multiple selection is allowed.
  * - attributes: [string] Additional HTML attributes.
  * - modifier_class: [string] Additional CSS classes.
+ * - group_parent: [string] Additional parent selector for radio group.
  */
 #}
 
@@ -30,6 +31,7 @@
       class="ct-chip {{ modifier_class -}}"
       data-component-name="chip"
       {% if is_multiple %}data-chip-dismiss{% endif %}
+      {% if group_parent %}data-chip-group-parent="{{ group_parent }}"{% endif %}
     >
       <input
         class="ct-chip__input"

--- a/packages/twig/components/01-atoms/chip/chip.twig
+++ b/packages/twig/components/01-atoms/chip/chip.twig
@@ -10,9 +10,9 @@
  * - content: [string] Chip text.
  * - is_selected: [boolean] Whether the chip is selected (for filter chips).
  * - is_multiple: [boolean] Whether multiple selection is allowed.
+ * - group_parent: [string] Additional parent selector for radio group.
  * - attributes: [string] Additional HTML attributes.
  * - modifier_class: [string] Additional CSS classes.
- * - group_parent: [string] Additional parent selector for radio group.
  */
 #}
 

--- a/packages/twig/components/02-molecules/single-filter/__snapshots__/single-filter.test.js.snap
+++ b/packages/twig/components/02-molecules/single-filter/__snapshots__/single-filter.test.js.snap
@@ -73,6 +73,7 @@ exports[`Single Filter Component renders with multiple selection enabled 1`] = `
                   <label
                     class="ct-chip ct-theme-light ct-chip--input ct-chip--small active ct-chip--multiple "
                     data-chip-dismiss=""
+                    data-chip-group-parent=".ct-single-filter"
                     data-component-name="chip"
                   >
                     
@@ -118,6 +119,7 @@ exports[`Single Filter Component renders with multiple selection enabled 1`] = `
                   <label
                     class="ct-chip ct-theme-light ct-chip--input ct-chip--small  ct-chip--multiple "
                     data-chip-dismiss=""
+                    data-chip-group-parent=".ct-single-filter"
                     data-component-name="chip"
                   >
                     
@@ -305,6 +307,7 @@ exports[`Single Filter Component renders with optional attributes 1`] = `
       
                   <label
                     class="ct-chip ct-theme-dark ct-chip--input ct-chip--small active  "
+                    data-chip-group-parent=".ct-single-filter"
                     data-component-name="chip"
                   >
                     
@@ -331,6 +334,7 @@ exports[`Single Filter Component renders with optional attributes 1`] = `
       
                   <label
                     class="ct-chip ct-theme-dark ct-chip--input ct-chip--small   "
+                    data-chip-group-parent=".ct-single-filter"
                     data-component-name="chip"
                   >
                     
@@ -508,6 +512,7 @@ exports[`Single Filter Component renders with required attributes 1`] = `
       
                   <label
                     class="ct-chip ct-theme-light ct-chip--input ct-chip--small active  "
+                    data-chip-group-parent=".ct-single-filter"
                     data-component-name="chip"
                   >
                     
@@ -533,6 +538,7 @@ exports[`Single Filter Component renders with required attributes 1`] = `
       
                   <label
                     class="ct-chip ct-theme-light ct-chip--input ct-chip--small   "
+                    data-chip-group-parent=".ct-single-filter"
                     data-component-name="chip"
                   >
                     

--- a/packages/twig/components/02-molecules/single-filter/single-filter.js
+++ b/packages/twig/components/02-molecules/single-filter/single-filter.js
@@ -3,46 +3,29 @@
  */
 
 function CivicThemeSingleFilterComponent(el) {
-  if (this.el) {
+  if (el.getAttribute('data-single-filter') === 'true') {
     return;
   }
 
   this.el = el;
 
-  this.el.addEventListener('ct.single-filter.update', this.update.bind(this));
+  this.el.addEventListener('ct.single-filter.update', this.updateEvent.bind(this));
 
-  if (!el.hasEventListener) {
-    el.hasEventListener = true;
-    el.querySelectorAll('input, textarea, select, [type="checkbox"], [type="radio"]').forEach((input) => {
-      input.addEventListener('change', () => {
-        el.dispatchEvent(new CustomEvent('ct.single-filter.update', { detail: { parent: input.parentElement } }));
-      });
+  this.el.querySelectorAll('input, textarea, select, [type="checkbox"], [type="radio"]').forEach((input) => {
+    input.addEventListener('change', () => {
+      el.dispatchEvent(new CustomEvent('ct.single-filter.update', { detail: { parent: input.parentElement } }));
     });
-  }
+  });
 
-  this.activateOrDeactivateSubmitButton(el);
+  // Mark as initialized.
+  this.el.setAttribute('data-single-filter', 'true');
 }
 
 /**
- * Update the instance.
+ * Update event handler.
  */
-CivicThemeSingleFilterComponent.prototype.update = function (el) {
+CivicThemeSingleFilterComponent.prototype.updateEvent = function (el) {
   el.detail.parent.setAttribute('aria-live', 'polite');
-  this.activateOrDeactivateSubmitButton(this.el);
-};
-
-CivicThemeSingleFilterComponent.prototype.activateOrDeactivateSubmitButton = function (el) {
-  const buttons = el.querySelectorAll('.ct-button');
-  const activeChips = el.querySelectorAll('.ct-chip.active');
-  if (!activeChips.length) {
-    buttons.forEach((element) => {
-      element.setAttribute('disabled', 'disabled');
-    });
-  } else {
-    buttons.forEach((element) => {
-      element.removeAttribute('disabled');
-    });
-  }
 };
 
 document.querySelectorAll('.ct-single-filter').forEach((el) => {

--- a/packages/twig/components/02-molecules/single-filter/single-filter.twig
+++ b/packages/twig/components/02-molecules/single-filter/single-filter.twig
@@ -61,6 +61,7 @@
                     is_multiple: is_multiple,
                     is_selected: item.is_selected is defined ? item.is_selected : false,
                     content: item.text,
+                    group_parent: '.ct-single-filter',
                     attributes: item_attributes,
                   } only %}
                 {% endif %}

--- a/packages/twig/dist/civictheme.storybook.js
+++ b/packages/twig/dist/civictheme.storybook.js
@@ -2900,18 +2900,13 @@ CivicThemeChip.prototype.changeEvent = function (e) {
   // For radios, check current and uncheck others in this group.
   if (input.getAttribute('type') === 'radio') {
     const name = input.getAttribute('name');
-    let radios;
-    if (this.groupParentSelector) {
-      const chipGroup = chip.closest(this.groupParentSelector);
-      radios = chipGroup ? chipGroup.querySelectorAll(`input[type=radio][name="${name}"]`) : document.querySelectorAll(`input[type=radio][name="${name}"]`);
-    } else {
-      radios = document.querySelectorAll(`input[type=radio][name="${name}"]`);
-    }
-    for (const i in radios) {
-      if (Object.prototype.hasOwnProperty.call(radios, i) && radios[i] !== input) {
-        this.setChecked(radios[i], false);
+    const chipContainer = (!!this.groupParentSelector && chip.closest(this.groupParentSelector)) || document;
+    const radios = chipContainer.querySelectorAll(`input[type=radio][name="${name}"]`);
+    radios.forEach((radio) => {
+      if (radio !== input) {
+        this.setChecked(radio, false);
       }
-    }
+    });
     this.setChecked(input, true);
   } else {
     this.setChecked(input, input.checked);


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have formatted the subject to include the issue number
  as `[#123] Verb in past tense with a period at the end.`
- [x] I have provided information in the `Changed` section about WHY something was
  done if this was a bespoke implementation.
- [x] I have performed a self-review of my code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have run new and existing relevant tests locally with my changes,
  and they have passed.
- [ ] I have provided screenshots, where applicable.

## Changed

**1. Fixed `Chip` events being duplicated and not correctly firing.**
   `Chip`'s `ct.chip.dismiss` event fires twice - for both check and uncheck, but should only for uncheck. This is because it is bound to `click` and `change` of the underlying inputs. This PR fixes it to fire only on `change` for those inputs and filters by the actual state to only fire on uncheck. See inline comment for more details.

**2. Removed `Apply`/`Reset` button state management from `Single Filter`.**
   Currently FE manages the enabled/disabled state of the `Apply` and `Reset` buttons based on if the user clicked on `Chips` in FE. But there is an edge case where such state management prevents the user to use the buttons: when one of the items is pre-selected and the user clicks it twice - the underlying checked value has not changed, but the incorrect FE script thinks that it did. This behaviour brings more harm than value because it does not track the correct initial states of all chips to compare it with the currently selected values. Instead of implementing this state tracking, I have completely removed this making it a responsibility of consumer sites to handle this buttons state management.
   This change had to be bundled with the `Chip` changes as fixes to the `Chip` have broken the broken state management of the `Single filter`.

Related to https://github.com/civictheme/uikit/issues/497

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Chips now use input change events for toggling and dismissal; dismissible chips emit dismiss when unchecked.
  - Single-filter components mark initialization in DOM and always attach input listeners; submit buttons no longer auto enable/disable.

- **New Features**
  - Chip accepts an optional group_parent selector to constrain radio grouping within a container.

- **Tests**
  - Chip tests updated to assert the new group_parent attribute.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->