### PR TITLE
[#3533316] Includes using the subtheme namespace do not work in storybook.

### DIFF
--- a/packages/sdc/.storybook/sdc-plugin.js
+++ b/packages/sdc/.storybook/sdc-plugin.js
@@ -18,10 +18,12 @@ import { globSync } from 'glob';
  *
  * @param {string} storiesPath - Path to the story file to scan
  * @param {string} componentDirectory - Root directory containing all components
+ * @param {string[]} namespaces - Array of supported include namespaces
  * @returns {string[]} Array of paths to component assets
  */
-function getDependencyImports(storiesPath, componentDirectory) {
+function getDependencyImports(storiesPath, componentDirectory, namespaces = ['civictheme']) {
   const dir = path.dirname(storiesPath);
+  const includeRegex = new RegExp(`include\\s+'(${namespaces.join('|')}):([^']+)'`, 'g');
   const twigFiles = new Set(); // Store unique twig files to scan
   const scannedFiles = new Set(); // Prevent infinite recursion
 
@@ -47,13 +49,12 @@ function getDependencyImports(storiesPath, componentDirectory) {
     scannedFiles.add(twigPath);
 
     const twigContent = fs.readFileSync(twigPath, 'utf8');
-    twigContent.matchAll(/include\s+(?:'|")civictheme:([^'"]+)(?:'|")/g).forEach((match) => {
-      const componentPath = path.join(path.dirname(twigPath), `../../${match[1]}`);
-      const componentName = path.basename(componentPath);
+    twigContent.matchAll(includeRegex).forEach((match) => {
+      const componentName = match[2];
       const dependencyPath = globSync(`${componentDirectory}/**/${componentName}.twig`);
       if (dependencyPath.length > 0) {
-        const dependencyTwigPath = path.join(path.dirname(dependencyPath[0]), `${componentName}.twig`);
-        twigFiles.add(path.resolve(dependencyTwigPath));
+        const dependencyTwigPath = dependencyPath.pop();
+        twigFiles.add(dependencyTwigPath);
       }
     });
   };
@@ -106,11 +107,12 @@ export default (options = {}) => ({
   transform: (code, id) => {
     const componentDir = path.resolve(__dirname, options.path || '../components');
     const isWithinComponentDir = id.indexOf(componentDir) >= 0;
+    const namespaces = options.namespaces || ['civictheme'];
 
     if (isWithinComponentDir) {
       // For stories - resolve their dependencies.
       if (id.endsWith('.stories.js')) {
-        const imports = getDependencyImports(id, componentDir).map((i) => `import '${i}';`).join('\n');
+        const imports = getDependencyImports(id, componentDir, namespaces).map((i) => `import '${i}';`).join('\n');
         return {
           code: `${imports}\n${code}`,
           map: null,


### PR DESCRIPTION
Issue: https://www.drupal.org/project/civictheme/issues/3533316
Civictheme Monorepo Fix: https://github.com/civictheme/monorepo-drupal/pull/1395

## Checklist before requesting a review

- [x] I have formatted the subject to include the issue number
  as `[#123] Verb in past tense with a period at the end.`
- [ ] I have provided information in the `Changed` section about WHY something was
  done if this was a bespoke implementation.
- [x] I have performed a self-review of my code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have run new and existing relevant tests locally with my changes,
  and they have passed.
- [ ] I have provided screenshots, where applicable.

## Changed


1. This PR is to align the sdc-plugin.js used here with the subthemes. The changes are not relevant for the UI Kit build system, and therefore no vite.config.js changes have been included.
2. Added option for namespaces to be passed in from vite.config.js
3. Regular expression is now generated from the namespaces provided. Defaults to 'civictheme' (for the civictheme contrib theme, and for uikit).

## Screenshots


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced support for scanning dependencies across multiple namespaces in Twig includes, allowing for greater flexibility in component usage.

* **Improvements**
  * Improved accuracy in resolving dependency file paths for components included via Twig statements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->