### PR TITLE
[#700] Updated content link visited colors to existing var names.

### DIFF
--- a/packages/sdc/components/00-base/mixins/_content-link.scss
+++ b/packages/sdc/components/00-base/mixins/_content-link.scss
@@ -13,10 +13,6 @@
     text-decoration: none;
     padding: ct-spacing(0.375) 0 ct-spacing(0.5);
   }
-
-  &:visited {
-    @include ct-content-link-visited();
-  }
 }
 
 @mixin ct-content-link-light() {
@@ -29,6 +25,15 @@
   &:hover {
     background-color: $ct-content-link-light-hover-background-color;
     color: $ct-content-link-light-hover-color;
+  }
+
+  &:visited {
+    color: $ct-content-link-light-visited-color;
+
+    &:hover {
+      border-color: $ct-content-link-light-visited-hover-border-color;
+      color: $ct-content-link-light-visited-hover-color;
+    }
   }
 }
 
@@ -43,17 +48,13 @@
     background-color: $ct-content-link-dark-hover-background-color;
     color: $ct-content-link-dark-hover-color;
   }
-}
 
-@mixin ct-content-link-visited() {
-  $root: &;
-
-  @include ct-component-theme($root) using($root, $theme) {
-    color: ct-component-var($root, $theme, visited, color);
+  &:visited {
+    color: $ct-content-link-dark-visited-color;
 
     &:hover {
-      @include ct-component-property($root, $theme, visited, hover, border-color);
-      @include ct-component-property($root, $theme, visited, hover, color);
+      border-color: $ct-content-link-dark-visited-hover-border-color;
+      color: $ct-content-link-dark-visited-hover-color;
     }
   }
 }

--- a/packages/sdc/components/01-atoms/content-link/content-link.css
+++ b/packages/sdc/components/01-atoms/content-link/content-link.css
@@ -13,20 +13,6 @@
   text-decoration: none;
   padding: 0.1875rem 0 0.25rem;
 }
-.ct-content-link:visited.ct-theme-light {
-  color: var(--ct-content-link:visited-light-visited-color);
-}
-.ct-content-link:visited.ct-theme-light:hover {
-  border-color: var(--ct-content-link:visited-light-visited-hover-border-color);
-  color: var(--ct-content-link:visited-light-visited-hover-color);
-}
-.ct-content-link:visited.ct-theme-dark {
-  color: var(--ct-content-link:visited-dark-visited-color);
-}
-.ct-content-link:visited.ct-theme-dark:hover {
-  border-color: var(--ct-content-link:visited-dark-visited-hover-border-color);
-  color: var(--ct-content-link:visited-dark-visited-hover-color);
-}
 .ct-content-link, .ct-content-link.ct-theme-light {
   color: var(--ct-color-light-interaction-background);
 }
@@ -40,6 +26,13 @@
   background-color: var(--ct-color-light-interaction-hover-background);
   color: var(--ct-color-light-interaction-hover-text);
 }
+.ct-content-link:visited, .ct-content-link.ct-theme-light:visited {
+  color: var(--ct-color-light-body);
+}
+.ct-content-link:visited:hover, .ct-content-link.ct-theme-light:visited:hover {
+  border-color: var(--ct-color-light-interaction-focus);
+  color: var(--ct-color-light-interaction-hover-text);
+}
 .ct-content-link.ct-theme-dark {
   color: var(--ct-color-dark-interaction-background);
 }
@@ -51,5 +44,12 @@
 }
 .ct-content-link.ct-theme-dark:hover {
   background-color: var(--ct-color-dark-interaction-hover-background);
+  color: var(--ct-color-dark-interaction-hover-text);
+}
+.ct-content-link.ct-theme-dark:visited {
+  color: var(--ct-color-dark-body);
+}
+.ct-content-link.ct-theme-dark:visited:hover {
+  border-color: var(--ct-color-dark-interaction-focus);
   color: var(--ct-color-dark-interaction-hover-text);
 }

--- a/packages/sdc/components/01-atoms/paragraph/paragraph.css
+++ b/packages/sdc/components/01-atoms/paragraph/paragraph.css
@@ -238,20 +238,6 @@
   text-decoration: none;
   padding: 0.1875rem 0 0.25rem;
 }
-.ct-paragraph a:not(.ct-button):visited.ct-theme-light {
-  color: var(--ct-paragraph a:not(ct-button):visited-light-visited-color);
-}
-.ct-paragraph a:not(.ct-button):visited.ct-theme-light:hover {
-  border-color: var(--ct-paragraph a:not(ct-button):visited-light-visited-hover-border-color);
-  color: var(--ct-paragraph a:not(ct-button):visited-light-visited-hover-color);
-}
-.ct-paragraph a:not(.ct-button):visited.ct-theme-dark {
-  color: var(--ct-paragraph a:not(ct-button):visited-dark-visited-color);
-}
-.ct-paragraph a:not(.ct-button):visited.ct-theme-dark:hover {
-  border-color: var(--ct-paragraph a:not(ct-button):visited-dark-visited-hover-border-color);
-  color: var(--ct-paragraph a:not(ct-button):visited-dark-visited-hover-color);
-}
 @media (min-width: 0) {
   .ct-paragraph blockquote {
     font-size: 1.125rem;
@@ -669,6 +655,13 @@
   background-color: var(--ct-color-light-interaction-hover-background);
   color: var(--ct-color-light-interaction-hover-text);
 }
+.ct-paragraph.ct-theme-light a:not(.ct-button):visited {
+  color: var(--ct-color-light-body);
+}
+.ct-paragraph.ct-theme-light a:not(.ct-button):visited:hover {
+  border-color: var(--ct-color-light-interaction-focus);
+  color: var(--ct-color-light-interaction-hover-text);
+}
 .ct-paragraph.ct-theme-light blockquote {
   color: var(--ct-color-light-body);
   background-color: var(--ct-color-light-background-light);
@@ -770,6 +763,13 @@
 }
 .ct-paragraph.ct-theme-dark a:not(.ct-button):hover {
   background-color: var(--ct-color-dark-interaction-hover-background);
+  color: var(--ct-color-dark-interaction-hover-text);
+}
+.ct-paragraph.ct-theme-dark a:not(.ct-button):visited {
+  color: var(--ct-color-dark-body);
+}
+.ct-paragraph.ct-theme-dark a:not(.ct-button):visited:hover {
+  border-color: var(--ct-color-dark-interaction-focus);
   color: var(--ct-color-dark-interaction-hover-text);
 }
 .ct-paragraph.ct-theme-dark blockquote {

--- a/packages/sdc/components/02-molecules/basic-content/basic-content.css
+++ b/packages/sdc/components/02-molecules/basic-content/basic-content.css
@@ -237,20 +237,6 @@
   text-decoration: none;
   padding: 0.1875rem 0 0.25rem;
 }
-.ct-basic-content a:not(.ct-button):visited.ct-theme-light {
-  color: var(--ct-basic-content a:not(ct-button):visited-light-visited-color);
-}
-.ct-basic-content a:not(.ct-button):visited.ct-theme-light:hover {
-  border-color: var(--ct-basic-content a:not(ct-button):visited-light-visited-hover-border-color);
-  color: var(--ct-basic-content a:not(ct-button):visited-light-visited-hover-color);
-}
-.ct-basic-content a:not(.ct-button):visited.ct-theme-dark {
-  color: var(--ct-basic-content a:not(ct-button):visited-dark-visited-color);
-}
-.ct-basic-content a:not(.ct-button):visited.ct-theme-dark:hover {
-  border-color: var(--ct-basic-content a:not(ct-button):visited-dark-visited-hover-border-color);
-  color: var(--ct-basic-content a:not(ct-button):visited-dark-visited-hover-color);
-}
 @media (min-width: 0) {
   .ct-basic-content blockquote {
     font-size: 1.125rem;
@@ -599,6 +585,13 @@
   background-color: var(--ct-color-light-interaction-hover-background);
   color: var(--ct-color-light-interaction-hover-text);
 }
+.ct-basic-content.ct-theme-light a:not(.ct-button):visited {
+  color: var(--ct-color-light-body);
+}
+.ct-basic-content.ct-theme-light a:not(.ct-button):visited:hover {
+  border-color: var(--ct-color-light-interaction-focus);
+  color: var(--ct-color-light-interaction-hover-text);
+}
 .ct-basic-content.ct-theme-light blockquote {
   color: var(--ct-color-light-body);
   background-color: var(--ct-color-light-background-light);
@@ -703,6 +696,13 @@
 }
 .ct-basic-content.ct-theme-dark a:not(.ct-button):hover {
   background-color: var(--ct-color-dark-interaction-hover-background);
+  color: var(--ct-color-dark-interaction-hover-text);
+}
+.ct-basic-content.ct-theme-dark a:not(.ct-button):visited {
+  color: var(--ct-color-dark-body);
+}
+.ct-basic-content.ct-theme-dark a:not(.ct-button):visited:hover {
+  border-color: var(--ct-color-dark-interaction-focus);
   color: var(--ct-color-dark-interaction-hover-text);
 }
 .ct-basic-content.ct-theme-dark blockquote {

--- a/packages/twig/components/00-base/mixins/_content-link.scss
+++ b/packages/twig/components/00-base/mixins/_content-link.scss
@@ -13,10 +13,6 @@
     text-decoration: none;
     padding: ct-spacing(0.375) 0 ct-spacing(0.5);
   }
-
-  &:visited {
-    @include ct-content-link-visited();
-  }
 }
 
 @mixin ct-content-link-light() {
@@ -29,6 +25,15 @@
   &:hover {
     background-color: $ct-content-link-light-hover-background-color;
     color: $ct-content-link-light-hover-color;
+  }
+
+  &:visited {
+    color: $ct-content-link-light-visited-color;
+
+    &:hover {
+      border-color: $ct-content-link-light-visited-hover-border-color;
+      color: $ct-content-link-light-visited-hover-color;
+    }
   }
 }
 
@@ -43,17 +48,13 @@
     background-color: $ct-content-link-dark-hover-background-color;
     color: $ct-content-link-dark-hover-color;
   }
-}
 
-@mixin ct-content-link-visited() {
-  $root: &;
-
-  @include ct-component-theme($root) using($root, $theme) {
-    color: ct-component-var($root, $theme, visited, color);
+  &:visited {
+    color: $ct-content-link-dark-visited-color;
 
     &:hover {
-      @include ct-component-property($root, $theme, visited, hover, border-color);
-      @include ct-component-property($root, $theme, visited, hover, color);
+      border-color: $ct-content-link-dark-visited-hover-border-color;
+      color: $ct-content-link-dark-visited-hover-color;
     }
   }
 }

--- a/packages/twig/dist/civictheme.css
+++ b/packages/twig/dist/civictheme.css
@@ -4567,20 +4567,6 @@ ol ol ol {
   text-decoration: none;
   padding: 0.1875rem 0 0.25rem;
 }
-.ct-content-link:visited.ct-theme-light {
-  color: var(--ct-content-link:visited-light-visited-color);
-}
-.ct-content-link:visited.ct-theme-light:hover {
-  border-color: var(--ct-content-link:visited-light-visited-hover-border-color);
-  color: var(--ct-content-link:visited-light-visited-hover-color);
-}
-.ct-content-link:visited.ct-theme-dark {
-  color: var(--ct-content-link:visited-dark-visited-color);
-}
-.ct-content-link:visited.ct-theme-dark:hover {
-  border-color: var(--ct-content-link:visited-dark-visited-hover-border-color);
-  color: var(--ct-content-link:visited-dark-visited-hover-color);
-}
 .ct-content-link, .ct-content-link.ct-theme-light {
   color: var(--ct-color-light-interaction-background);
 }
@@ -4594,6 +4580,13 @@ ol ol ol {
   background-color: var(--ct-color-light-interaction-hover-background);
   color: var(--ct-color-light-interaction-hover-text);
 }
+.ct-content-link:visited, .ct-content-link.ct-theme-light:visited {
+  color: var(--ct-color-light-body);
+}
+.ct-content-link:visited:hover, .ct-content-link.ct-theme-light:visited:hover {
+  border-color: var(--ct-color-light-interaction-focus);
+  color: var(--ct-color-light-interaction-hover-text);
+}
 .ct-content-link.ct-theme-dark {
   color: var(--ct-color-dark-interaction-background);
 }
@@ -4605,6 +4598,13 @@ ol ol ol {
 }
 .ct-content-link.ct-theme-dark:hover {
   background-color: var(--ct-color-dark-interaction-hover-background);
+  color: var(--ct-color-dark-interaction-hover-text);
+}
+.ct-content-link.ct-theme-dark:visited {
+  color: var(--ct-color-dark-body);
+}
+.ct-content-link.ct-theme-dark:visited:hover {
+  border-color: var(--ct-color-dark-interaction-focus);
   color: var(--ct-color-dark-interaction-hover-text);
 }
 
@@ -5418,20 +5418,6 @@ ol ol ol {
   text-decoration: none;
   padding: 0.1875rem 0 0.25rem;
 }
-.ct-paragraph a:not(.ct-button):visited.ct-theme-light {
-  color: var(--ct-paragraph a:not(ct-button):visited-light-visited-color);
-}
-.ct-paragraph a:not(.ct-button):visited.ct-theme-light:hover {
-  border-color: var(--ct-paragraph a:not(ct-button):visited-light-visited-hover-border-color);
-  color: var(--ct-paragraph a:not(ct-button):visited-light-visited-hover-color);
-}
-.ct-paragraph a:not(.ct-button):visited.ct-theme-dark {
-  color: var(--ct-paragraph a:not(ct-button):visited-dark-visited-color);
-}
-.ct-paragraph a:not(.ct-button):visited.ct-theme-dark:hover {
-  border-color: var(--ct-paragraph a:not(ct-button):visited-dark-visited-hover-border-color);
-  color: var(--ct-paragraph a:not(ct-button):visited-dark-visited-hover-color);
-}
 @media (min-width: 0) {
   .ct-paragraph blockquote {
     font-size: 1.125rem;
@@ -5849,6 +5835,13 @@ ol ol ol {
   background-color: var(--ct-color-light-interaction-hover-background);
   color: var(--ct-color-light-interaction-hover-text);
 }
+.ct-paragraph.ct-theme-light a:not(.ct-button):visited {
+  color: var(--ct-color-light-body);
+}
+.ct-paragraph.ct-theme-light a:not(.ct-button):visited:hover {
+  border-color: var(--ct-color-light-interaction-focus);
+  color: var(--ct-color-light-interaction-hover-text);
+}
 .ct-paragraph.ct-theme-light blockquote {
   color: var(--ct-color-light-body);
   background-color: var(--ct-color-light-background-light);
@@ -5950,6 +5943,13 @@ ol ol ol {
 }
 .ct-paragraph.ct-theme-dark a:not(.ct-button):hover {
   background-color: var(--ct-color-dark-interaction-hover-background);
+  color: var(--ct-color-dark-interaction-hover-text);
+}
+.ct-paragraph.ct-theme-dark a:not(.ct-button):visited {
+  color: var(--ct-color-dark-body);
+}
+.ct-paragraph.ct-theme-dark a:not(.ct-button):visited:hover {
+  border-color: var(--ct-color-dark-interaction-focus);
   color: var(--ct-color-dark-interaction-hover-text);
 }
 .ct-paragraph.ct-theme-dark blockquote {
@@ -7369,20 +7369,6 @@ ol ol ol {
   text-decoration: none;
   padding: 0.1875rem 0 0.25rem;
 }
-.ct-basic-content a:not(.ct-button):visited.ct-theme-light {
-  color: var(--ct-basic-content a:not(ct-button):visited-light-visited-color);
-}
-.ct-basic-content a:not(.ct-button):visited.ct-theme-light:hover {
-  border-color: var(--ct-basic-content a:not(ct-button):visited-light-visited-hover-border-color);
-  color: var(--ct-basic-content a:not(ct-button):visited-light-visited-hover-color);
-}
-.ct-basic-content a:not(.ct-button):visited.ct-theme-dark {
-  color: var(--ct-basic-content a:not(ct-button):visited-dark-visited-color);
-}
-.ct-basic-content a:not(.ct-button):visited.ct-theme-dark:hover {
-  border-color: var(--ct-basic-content a:not(ct-button):visited-dark-visited-hover-border-color);
-  color: var(--ct-basic-content a:not(ct-button):visited-dark-visited-hover-color);
-}
 @media (min-width: 0) {
   .ct-basic-content blockquote {
     font-size: 1.125rem;
@@ -7731,6 +7717,13 @@ ol ol ol {
   background-color: var(--ct-color-light-interaction-hover-background);
   color: var(--ct-color-light-interaction-hover-text);
 }
+.ct-basic-content.ct-theme-light a:not(.ct-button):visited {
+  color: var(--ct-color-light-body);
+}
+.ct-basic-content.ct-theme-light a:not(.ct-button):visited:hover {
+  border-color: var(--ct-color-light-interaction-focus);
+  color: var(--ct-color-light-interaction-hover-text);
+}
 .ct-basic-content.ct-theme-light blockquote {
   color: var(--ct-color-light-body);
   background-color: var(--ct-color-light-background-light);
@@ -7835,6 +7828,13 @@ ol ol ol {
 }
 .ct-basic-content.ct-theme-dark a:not(.ct-button):hover {
   background-color: var(--ct-color-dark-interaction-hover-background);
+  color: var(--ct-color-dark-interaction-hover-text);
+}
+.ct-basic-content.ct-theme-dark a:not(.ct-button):visited {
+  color: var(--ct-color-dark-body);
+}
+.ct-basic-content.ct-theme-dark a:not(.ct-button):visited:hover {
+  border-color: var(--ct-color-dark-interaction-focus);
   color: var(--ct-color-dark-interaction-hover-text);
 }
 .ct-basic-content.ct-theme-dark blockquote {

--- a/packages/twig/dist/civictheme.storybook.css
+++ b/packages/twig/dist/civictheme.storybook.css
@@ -4567,20 +4567,6 @@ ol ol ol {
   text-decoration: none;
   padding: 0.1875rem 0 0.25rem;
 }
-.ct-content-link:visited.ct-theme-light {
-  color: var(--ct-content-link:visited-light-visited-color);
-}
-.ct-content-link:visited.ct-theme-light:hover {
-  border-color: var(--ct-content-link:visited-light-visited-hover-border-color);
-  color: var(--ct-content-link:visited-light-visited-hover-color);
-}
-.ct-content-link:visited.ct-theme-dark {
-  color: var(--ct-content-link:visited-dark-visited-color);
-}
-.ct-content-link:visited.ct-theme-dark:hover {
-  border-color: var(--ct-content-link:visited-dark-visited-hover-border-color);
-  color: var(--ct-content-link:visited-dark-visited-hover-color);
-}
 .ct-content-link, .ct-content-link.ct-theme-light {
   color: var(--ct-color-light-interaction-background);
 }
@@ -4594,6 +4580,13 @@ ol ol ol {
   background-color: var(--ct-color-light-interaction-hover-background);
   color: var(--ct-color-light-interaction-hover-text);
 }
+.ct-content-link:visited, .ct-content-link.ct-theme-light:visited {
+  color: var(--ct-color-light-body);
+}
+.ct-content-link:visited:hover, .ct-content-link.ct-theme-light:visited:hover {
+  border-color: var(--ct-color-light-interaction-focus);
+  color: var(--ct-color-light-interaction-hover-text);
+}
 .ct-content-link.ct-theme-dark {
   color: var(--ct-color-dark-interaction-background);
 }
@@ -4605,6 +4598,13 @@ ol ol ol {
 }
 .ct-content-link.ct-theme-dark:hover {
   background-color: var(--ct-color-dark-interaction-hover-background);
+  color: var(--ct-color-dark-interaction-hover-text);
+}
+.ct-content-link.ct-theme-dark:visited {
+  color: var(--ct-color-dark-body);
+}
+.ct-content-link.ct-theme-dark:visited:hover {
+  border-color: var(--ct-color-dark-interaction-focus);
   color: var(--ct-color-dark-interaction-hover-text);
 }
 
@@ -5418,20 +5418,6 @@ ol ol ol {
   text-decoration: none;
   padding: 0.1875rem 0 0.25rem;
 }
-.ct-paragraph a:not(.ct-button):visited.ct-theme-light {
-  color: var(--ct-paragraph a:not(ct-button):visited-light-visited-color);
-}
-.ct-paragraph a:not(.ct-button):visited.ct-theme-light:hover {
-  border-color: var(--ct-paragraph a:not(ct-button):visited-light-visited-hover-border-color);
-  color: var(--ct-paragraph a:not(ct-button):visited-light-visited-hover-color);
-}
-.ct-paragraph a:not(.ct-button):visited.ct-theme-dark {
-  color: var(--ct-paragraph a:not(ct-button):visited-dark-visited-color);
-}
-.ct-paragraph a:not(.ct-button):visited.ct-theme-dark:hover {
-  border-color: var(--ct-paragraph a:not(ct-button):visited-dark-visited-hover-border-color);
-  color: var(--ct-paragraph a:not(ct-button):visited-dark-visited-hover-color);
-}
 @media (min-width: 0) {
   .ct-paragraph blockquote {
     font-size: 1.125rem;
@@ -5849,6 +5835,13 @@ ol ol ol {
   background-color: var(--ct-color-light-interaction-hover-background);
   color: var(--ct-color-light-interaction-hover-text);
 }
+.ct-paragraph.ct-theme-light a:not(.ct-button):visited {
+  color: var(--ct-color-light-body);
+}
+.ct-paragraph.ct-theme-light a:not(.ct-button):visited:hover {
+  border-color: var(--ct-color-light-interaction-focus);
+  color: var(--ct-color-light-interaction-hover-text);
+}
 .ct-paragraph.ct-theme-light blockquote {
   color: var(--ct-color-light-body);
   background-color: var(--ct-color-light-background-light);
@@ -5950,6 +5943,13 @@ ol ol ol {
 }
 .ct-paragraph.ct-theme-dark a:not(.ct-button):hover {
   background-color: var(--ct-color-dark-interaction-hover-background);
+  color: var(--ct-color-dark-interaction-hover-text);
+}
+.ct-paragraph.ct-theme-dark a:not(.ct-button):visited {
+  color: var(--ct-color-dark-body);
+}
+.ct-paragraph.ct-theme-dark a:not(.ct-button):visited:hover {
+  border-color: var(--ct-color-dark-interaction-focus);
   color: var(--ct-color-dark-interaction-hover-text);
 }
 .ct-paragraph.ct-theme-dark blockquote {
@@ -7369,20 +7369,6 @@ ol ol ol {
   text-decoration: none;
   padding: 0.1875rem 0 0.25rem;
 }
-.ct-basic-content a:not(.ct-button):visited.ct-theme-light {
-  color: var(--ct-basic-content a:not(ct-button):visited-light-visited-color);
-}
-.ct-basic-content a:not(.ct-button):visited.ct-theme-light:hover {
-  border-color: var(--ct-basic-content a:not(ct-button):visited-light-visited-hover-border-color);
-  color: var(--ct-basic-content a:not(ct-button):visited-light-visited-hover-color);
-}
-.ct-basic-content a:not(.ct-button):visited.ct-theme-dark {
-  color: var(--ct-basic-content a:not(ct-button):visited-dark-visited-color);
-}
-.ct-basic-content a:not(.ct-button):visited.ct-theme-dark:hover {
-  border-color: var(--ct-basic-content a:not(ct-button):visited-dark-visited-hover-border-color);
-  color: var(--ct-basic-content a:not(ct-button):visited-dark-visited-hover-color);
-}
 @media (min-width: 0) {
   .ct-basic-content blockquote {
     font-size: 1.125rem;
@@ -7731,6 +7717,13 @@ ol ol ol {
   background-color: var(--ct-color-light-interaction-hover-background);
   color: var(--ct-color-light-interaction-hover-text);
 }
+.ct-basic-content.ct-theme-light a:not(.ct-button):visited {
+  color: var(--ct-color-light-body);
+}
+.ct-basic-content.ct-theme-light a:not(.ct-button):visited:hover {
+  border-color: var(--ct-color-light-interaction-focus);
+  color: var(--ct-color-light-interaction-hover-text);
+}
 .ct-basic-content.ct-theme-light blockquote {
   color: var(--ct-color-light-body);
   background-color: var(--ct-color-light-background-light);
@@ -7835,6 +7828,13 @@ ol ol ol {
 }
 .ct-basic-content.ct-theme-dark a:not(.ct-button):hover {
   background-color: var(--ct-color-dark-interaction-hover-background);
+  color: var(--ct-color-dark-interaction-hover-text);
+}
+.ct-basic-content.ct-theme-dark a:not(.ct-button):visited {
+  color: var(--ct-color-dark-body);
+}
+.ct-basic-content.ct-theme-dark a:not(.ct-button):visited:hover {
+  border-color: var(--ct-color-dark-interaction-focus);
   color: var(--ct-color-dark-interaction-hover-text);
 }
 .ct-basic-content.ct-theme-dark blockquote {

--- a/packages/twig/dist/civictheme.storybook.js
+++ b/packages/twig/dist/civictheme.storybook.js
@@ -1827,6 +1827,46 @@
 
 document.addEventListener('DOMContentLoaded', () => {
 /**
+ * CivicTheme Webform component.
+ */
+
+// phpcs:ignoreFile
+function CivicThemeWebform(el) {
+  if (el.getAttribute('data-webform') === 'true' || this.el) {
+    return;
+  }
+
+  this.el = el;
+
+  // Check for form errors and scroll to error message if present.
+  const fieldErrors = this.el.querySelectorAll('.ct-field-message--error');
+  if (fieldErrors.length > 0) {
+    const errorMessage = document.querySelector('.ct-message--error');
+    if (errorMessage) {
+      // Make error message focusable if it's not a link.
+      if (!errorMessage.matches('a')) {
+        errorMessage.setAttribute('tabindex', '-1');
+      }
+      errorMessage.focus();
+      errorMessage.scrollIntoView({
+        behavior: 'smooth',
+      });
+    }
+  }
+
+  // Mark as initialized.
+  this.el.setAttribute('data-webform', 'true');
+}
+
+// Initialize CivicThemeWebform on every element.
+document.querySelectorAll('.ct-webform').forEach((webform) => {
+  // eslint-disable-next-line no-new
+  new CivicThemeWebform(webform);
+});
+
+});
+document.addEventListener('DOMContentLoaded', () => {
+/**
  * CivicTheme Slider component.
  */
 


### PR DESCRIPTION
https://github.com/civictheme/uikit/issues/700

## Checklist before requesting a review

- [x] I have formatted the subject to include the issue number
  as `[#123] Verb in past tense with a period at the end.`
- [x] I have provided information in the `Changed` section about WHY something was
  done if this was a bespoke implementation.
- [x] I have performed a self-review of my code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have run new and existing relevant tests locally with my changes,
  and they have passed.
- [x] I have provided screenshots, where applicable.

## Changed

Visited links were using `ct-component-var` to generate a variable name, however this did not support `:not()`. While I could have fixed the function to strip `:()` and spaces, it would produce variable names that don't look nice, and don't follow the other existing variables being set (:hover, :visited-link). It turns out variables already existed for this component, but were being unused.

```
$ct-content-link-light-visited-color
$ct-content-link-light-visited-hover-border-color
$ct-content-link-light-visited-hover-color
$ct-content-link-dark-visited-color
$ct-content-link-dark-visited-hover-border-color
$ct-content-link-dark-visited-hover-color
```

These have now been applied and should fix the issue. There are some style changes, as the variable are now being correctly set. Namely the visited color is different to the non-visited color (that would have been showing before).

## Screenshots
<img width="1015" height="198" alt="700" src="https://github.com/user-attachments/assets/540356be-55bd-47bd-ac0d-945b0d097ef4" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Simplified and consolidated visited link styling across light and dark themes for content links, paragraphs, and basic content components.
  * Updated visited link colors and hover states to use clearer, theme-specific variables.
  * Reduced complexity by removing redundant and theme-based visited link mixins and selectors, resulting in more consistent and maintainable styles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->