### PR TITLE
[#366] Update slider to remove tab index.

### DIFF
--- a/packages/sdc/components/03-organisms/slider/__snapshots__/slider.test.js.snap
+++ b/packages/sdc/components/03-organisms/slider/__snapshots__/slider.test.js.snap
@@ -191,7 +191,6 @@ exports[`Slider Component renders with all attributes provided 1`] = `
                 aria-live="polite"
                 class="ct-tag ct-theme-dark ct-tag--primary    ct-slider__controls__progress-indicator"
                 data-slider-progress=""
-                tabindex="0"
               >
                     Slide 1  
               </span>
@@ -386,7 +385,6 @@ exports[`Slider Component renders with only required attributes 1`] = `
                 aria-live="polite"
                 class="ct-tag ct-theme-light ct-tag--primary    ct-slider__controls__progress-indicator"
                 data-slider-progress=""
-                tabindex="0"
               >
                     Slide 1  
               </span>
@@ -591,7 +589,6 @@ exports[`Slider Component renders without some attributes 1`] = `
                 aria-live="polite"
                 class="ct-tag ct-theme-light ct-tag--primary    ct-slider__controls__progress-indicator"
                 data-slider-progress=""
-                tabindex="0"
               >
                     Slide 1  
               </span>

--- a/packages/sdc/components/03-organisms/slider/slider.twig
+++ b/packages/sdc/components/03-organisms/slider/slider.twig
@@ -35,11 +35,7 @@
 {% if slides is not empty %}
   <div
     role="region"
-    {% if title is not empty %}
-      aria-label="{{ title }}"
-    {% else %}
-      aria-label="Slider"
-    {% endif %}
+    aria-label="{{ title|default('Slider') }}"
     aria-roledescription="carousel"
     class="ct-slider {{ modifier_class -}}" {% if attributes is not empty %}{{- attributes|raw -}}{% endif %}>
     <div class="container">
@@ -100,7 +96,7 @@
                   theme: theme,
                   content: 'Slide 1',
                   modifier_class: 'ct-slider__controls__progress-indicator',
-                  attributes: 'aria-live="polite" data-slider-progress tabindex="0"',
+                  attributes: 'aria-live="polite" data-slider-progress',
                 } only %}
               </div>
             {% endblock %}

--- a/packages/twig/components/03-organisms/slider/__snapshots__/slider.test.js.snap
+++ b/packages/twig/components/03-organisms/slider/__snapshots__/slider.test.js.snap
@@ -191,7 +191,6 @@ exports[`Slider Component renders with all attributes provided 1`] = `
                 aria-live="polite"
                 class="ct-tag ct-theme-dark ct-tag--primary    ct-slider__controls__progress-indicator"
                 data-slider-progress=""
-                tabindex="0"
               >
                     Slide 1  
               </span>
@@ -386,7 +385,6 @@ exports[`Slider Component renders with only required attributes 1`] = `
                 aria-live="polite"
                 class="ct-tag ct-theme-light ct-tag--primary    ct-slider__controls__progress-indicator"
                 data-slider-progress=""
-                tabindex="0"
               >
                     Slide 1  
               </span>
@@ -591,7 +589,6 @@ exports[`Slider Component renders without some attributes 1`] = `
                 aria-live="polite"
                 class="ct-tag ct-theme-light ct-tag--primary    ct-slider__controls__progress-indicator"
                 data-slider-progress=""
-                tabindex="0"
               >
                     Slide 1  
               </span>

--- a/packages/twig/components/03-organisms/slider/slider.twig
+++ b/packages/twig/components/03-organisms/slider/slider.twig
@@ -35,11 +35,7 @@
 {% if slides is not empty %}
   <div
     role="region"
-    {% if title is not empty %}
-      aria-label="{{ title }}"
-    {% else %}
-      aria-label="Slider"
-    {% endif %}
+    aria-label="{{ title|default('Slider') }}"
     aria-roledescription="carousel"
     class="ct-slider {{ modifier_class -}}" {% if attributes is not empty %}{{- attributes|raw -}}{% endif %}>
     <div class="container">
@@ -100,7 +96,7 @@
                   theme: theme,
                   content: 'Slide 1',
                   modifier_class: 'ct-slider__controls__progress-indicator',
-                  attributes: 'aria-live="polite" data-slider-progress tabindex="0"',
+                  attributes: 'aria-live="polite" data-slider-progress',
                 } only %}
               </div>
             {% endblock %}


### PR DESCRIPTION
https://github.com/civictheme/uikit/issues/366

## Checklist before requesting a review

- [x] I have formatted the subject to include the issue number
  as `[#123] Verb in past tense with a period at the end.`
- [x] I have provided information in the `Changed` section about WHY something was
  done if this was a bespoke implementation.
- [x] I have performed a self-review of my code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have run new and existing relevant tests locally with my changes,
  and they have passed.
- [x] I have provided screenshots, where applicable.

## Changed

1. Removed tabindex=0 from slider count.
2. Simplified the default aria label for slider.

## Screenshots
<img width="1691" height="900" alt="Screenshot 2025-10-01 at 4 35 16 pm" src="https://github.com/user-attachments/assets/d16654b5-a106-40b8-a77f-9f09dc4a30ca" />
