### PR TITLE
[#769] Fixed inline filter component design to support a large label instead of a title.

### DIFF
--- a/packages/sdc/components/02-molecules/field/field.component.yml
+++ b/packages/sdc/components/02-molecules/field/field.component.yml
@@ -29,6 +29,17 @@ props:
         - invisible
         - hidden
       default: visible
+    title_size:
+      type: string
+      title: Title size
+      description: The size of the title (extra-small, small, regular, large, extra-large).
+      enum:
+        - extra-small
+        - small
+        - regular
+        - large
+        - extra-large
+      default: regular
     label:
       type: string
       title: Label

--- a/packages/sdc/components/02-molecules/field/field.stories.data.js
+++ b/packages/sdc/components/02-molecules/field/field.stories.data.js
@@ -25,6 +25,7 @@ export default {
       type: 'textfield',
       title: 'Field title',
       title_display: 'visible',
+      title_size: 'regular',
       description: 'Description content sample.',
       message: {
         content: 'Message conte nt sample.',

--- a/packages/sdc/components/02-molecules/field/field.stories.js
+++ b/packages/sdc/components/02-molecules/field/field.stories.js
@@ -24,6 +24,10 @@ const meta = {
       control: { type: 'radio' },
       options: ['visible', 'invisible', 'hidden'],
     },
+    title_size: {
+      control: { type: 'radio' },
+      options: ['extra-small', 'small', 'regular', 'large', 'extra-large'],
+    },
     description: {
       control: { type: 'text' },
     },

--- a/packages/sdc/components/02-molecules/field/field.twig
+++ b/packages/sdc/components/02-molecules/field/field.twig
@@ -8,6 +8,7 @@
  * - type: [string] Type defined by a control type (required).
  * - title: [string] Field title.
  * - title_display: [string] How to display the field title (visible, invisible, hidden).
+ * - title_size: [string] The size of the title (extra-small, small, regular, large, extra-large).
  * - label: [string] Control label (required only for a radio group or checkbox).
  * - description: [string] Field description.
  * - name: [string] Control DOM name (propagated from `name` if not defined).
@@ -98,6 +99,7 @@
       {% include 'civictheme:label' with {
         theme: theme,
         content: label is not empty ? label : title,
+        size: title_size|default('regular'),
         is_required: is_required,
         required_text: required_text,
         for: control[0].id and type not in ['radio', 'checkbox'] ? control[0].id : null,

--- a/packages/sdc/components/02-molecules/inline-filter/inline-filter.component.yml
+++ b/packages/sdc/components/02-molecules/inline-filter/inline-filter.component.yml
@@ -13,10 +13,6 @@ props:
       enum:
         - light
         - dark
-    title:
-      type: string
-      title: Title
-      description: Title to display above inline items.
     submit_text:
       type: string
       title: Submit text

--- a/packages/sdc/components/02-molecules/inline-filter/inline-filter.css
+++ b/packages/sdc/components/02-molecules/inline-filter/inline-filter.css
@@ -7,13 +7,6 @@
   flex-direction: column;
   gap: 1.5rem;
 }
-.ct-inline-filter__title {
-  font-size: var(--ct-typography-heading-2-font-size);
-  line-height: var(--ct-typography-heading-2-line-height);
-  font-family: var(--ct-typography-heading-2-font-name);
-  font-weight: var(--ct-typography-heading-2-font-weight);
-  letter-spacing: var(--ct-typography-heading-2-letter-spacing);
-}
 .ct-inline-filter__content {
   display: flex;
   flex-direction: column;
@@ -48,6 +41,9 @@
 }
 .ct-inline-filter .ct-field {
   margin-bottom: 0;
+}
+.ct-inline-filter .ct-label--extra-large {
+  margin-bottom: 1rem;
 }
 .ct-inline-filter.ct-theme-light .ct-inline-filter__title {
   color: var(--ct-inline-filter-light-title-color);

--- a/packages/sdc/components/02-molecules/inline-filter/inline-filter.scss
+++ b/packages/sdc/components/02-molecules/inline-filter/inline-filter.scss
@@ -9,10 +9,6 @@
   flex-direction: column;
   gap: ct-spacing(3);
 
-  &__title {
-    @include ct-typography('heading-2');
-  }
-
   &__content {
     display: flex;
     flex-direction: column;
@@ -48,6 +44,10 @@
 
   .ct-field {
     margin-bottom: 0;
+  }
+
+  .ct-label--extra-large {
+    margin-bottom: ct-spacing(2);
   }
 
   @include ct-component-theme($root) using($root, $theme) {

--- a/packages/sdc/components/02-molecules/inline-filter/inline-filter.stories.data.js
+++ b/packages/sdc/components/02-molecules/inline-filter/inline-filter.stories.data.js
@@ -9,6 +9,7 @@ export default {
       Field({
         ...FieldData.args(theme),
         title: 'Search keywords',
+        title_size: 'extra-large',
         placeholder: 'I’m looking for...',
         description: null,
         message: null,

--- a/packages/sdc/components/02-molecules/inline-filter/inline-filter.stories.js
+++ b/packages/sdc/components/02-molecules/inline-filter/inline-filter.stories.js
@@ -13,9 +13,6 @@ const meta = {
       control: { type: 'radio' },
       options: ['light', 'dark'],
     },
-    title: {
-      control: { type: 'text' },
-    },
     items: {
       control: { type: 'text' },
     },

--- a/packages/sdc/components/02-molecules/inline-filter/inline-filter.twig
+++ b/packages/sdc/components/02-molecules/inline-filter/inline-filter.twig
@@ -5,7 +5,6 @@
  *
  * Props:
  * - theme: [string] Theme variation (light or dark).
- * - title: [string] Title to display above inline items.
  * - submit_text: [string] The text of the submit button.
  * - modifier_class: [string] Additional CSS classes.
  * - attributes: [string] Additional HTML attributes.
@@ -19,14 +18,11 @@
 {% set theme_class = 'ct-theme-%s'|format(theme|default('light')) %}
 {% set modifier_class = '%s %s'|format(theme_class, modifier_class|default('')) %}
 
-<div class="ct-inline-filter {{ modifier_class -}}" {% if attributes is not empty %}{{- attributes|raw -}}{% endif %}>
-  {% if title is not empty %}
-    <div class="ct-inline-filter__title">{{ title }}</div>
-  {% endif %}
+<div class="ct-inline-filter {{ modifier_class -}}" {% if attributes is not empty %}{{- attributes -}}{% endif %}>
   <div class="ct-inline-filter__content">
     {% if items is not empty %}
       <div class="ct-inline-filter__items">
-        {{ items|raw }}
+        {{ items }}
         <div class="ct-inline-filter__actions">
           {% include 'civictheme:button' with {
             theme: theme,
@@ -41,7 +37,7 @@
     {% endif %}
     {% if items_end is not empty %}
       <div class="ct-inline-filter__items-end">
-        {{ items_end|raw }}
+        {{ items_end }}
       </div>
     {% endif %}
   </div>

--- a/packages/twig/components/02-molecules/field/field.stories.data.js
+++ b/packages/twig/components/02-molecules/field/field.stories.data.js
@@ -25,6 +25,7 @@ export default {
       type: 'textfield',
       title: 'Field title',
       title_display: 'visible',
+      title_size: 'regular',
       description: 'Description content sample.',
       message: {
         content: 'Message conte nt sample.',

--- a/packages/twig/components/02-molecules/field/field.stories.js
+++ b/packages/twig/components/02-molecules/field/field.stories.js
@@ -24,6 +24,10 @@ const meta = {
       control: { type: 'radio' },
       options: ['visible', 'invisible', 'hidden'],
     },
+    title_size: {
+      control: { type: 'radio' },
+      options: ['extra-small', 'small', 'regular', 'large', 'extra-large'],
+    },
     description: {
       control: { type: 'text' },
     },

--- a/packages/twig/components/02-molecules/field/field.twig
+++ b/packages/twig/components/02-molecules/field/field.twig
@@ -8,6 +8,7 @@
  * - type: [string] Type defined by a control type (required).
  * - title: [string] Field title.
  * - title_display: [string] How to display the field title (visible, invisible, hidden).
+ * - title_size: [string] The size of the title (extra-small, small, regular, large, extra-large).
  * - label: [string] Control label (required only for a radio group or checkbox).
  * - description: [string] Field description.
  * - name: [string] Control DOM name (propagated from `name` if not defined).
@@ -98,6 +99,7 @@
       {% include '@atoms/label/label.twig' with {
         theme: theme,
         content: label is not empty ? label : title,
+        size: title_size|default('regular'),
         is_required: is_required,
         required_text: required_text,
         for: control[0].id and type not in ['radio', 'checkbox'] ? control[0].id : null,

--- a/packages/twig/components/02-molecules/inline-filter/inline-filter.scss
+++ b/packages/twig/components/02-molecules/inline-filter/inline-filter.scss
@@ -9,10 +9,6 @@
   flex-direction: column;
   gap: ct-spacing(3);
 
-  &__title {
-    @include ct-typography('heading-2');
-  }
-
   &__content {
     display: flex;
     flex-direction: column;
@@ -48,6 +44,10 @@
 
   .ct-field {
     margin-bottom: 0;
+  }
+
+  .ct-label--extra-large {
+    margin-bottom: ct-spacing(2);
   }
 
   @include ct-component-theme($root) using($root, $theme) {

--- a/packages/twig/components/02-molecules/inline-filter/inline-filter.stories.data.js
+++ b/packages/twig/components/02-molecules/inline-filter/inline-filter.stories.data.js
@@ -9,6 +9,7 @@ export default {
       Field({
         ...FieldData.args(theme),
         title: 'Search keywords',
+        title_size: 'extra-large',
         placeholder: 'I’m looking for...',
         description: null,
         message: null,

--- a/packages/twig/components/02-molecules/inline-filter/inline-filter.stories.js
+++ b/packages/twig/components/02-molecules/inline-filter/inline-filter.stories.js
@@ -13,9 +13,6 @@ const meta = {
       control: { type: 'radio' },
       options: ['light', 'dark'],
     },
-    title: {
-      control: { type: 'text' },
-    },
     items: {
       control: { type: 'text' },
     },

--- a/packages/twig/components/02-molecules/inline-filter/inline-filter.twig
+++ b/packages/twig/components/02-molecules/inline-filter/inline-filter.twig
@@ -5,7 +5,6 @@
  *
  * Props:
  * - theme: [string] Theme variation (light or dark).
- * - title: [string] Title to display above inline items.
  * - submit_text: [string] The text of the submit button.
  * - modifier_class: [string] Additional CSS classes.
  * - attributes: [string] Additional HTML attributes.
@@ -19,14 +18,11 @@
 {% set theme_class = 'ct-theme-%s'|format(theme|default('light')) %}
 {% set modifier_class = '%s %s'|format(theme_class, modifier_class|default('')) %}
 
-<div class="ct-inline-filter {{ modifier_class -}}" {% if attributes is not empty %}{{- attributes|raw -}}{% endif %}>
-  {% if title is not empty %}
-    <div class="ct-inline-filter__title">{{ title }}</div>
-  {% endif %}
+<div class="ct-inline-filter {{ modifier_class -}}" {% if attributes is not empty %}{{- attributes -}}{% endif %}>
   <div class="ct-inline-filter__content">
     {% if items is not empty %}
       <div class="ct-inline-filter__items">
-        {{ items|raw }}
+        {{ items }}
         <div class="ct-inline-filter__actions">
           {% include '@atoms/button/button.twig' with {
             theme: theme,
@@ -41,7 +37,7 @@
     {% endif %}
     {% if items_end is not empty %}
       <div class="ct-inline-filter__items-end">
-        {{ items_end|raw }}
+        {{ items_end }}
       </div>
     {% endif %}
   </div>

--- a/packages/twig/dist/civictheme.css
+++ b/packages/twig/dist/civictheme.css
@@ -7458,13 +7458,6 @@ ol ol ol {
   flex-direction: column;
   gap: 1.5rem;
 }
-.ct-inline-filter__title {
-  font-size: var(--ct-typography-heading-2-font-size);
-  line-height: var(--ct-typography-heading-2-line-height);
-  font-family: var(--ct-typography-heading-2-font-name);
-  font-weight: var(--ct-typography-heading-2-font-weight);
-  letter-spacing: var(--ct-typography-heading-2-letter-spacing);
-}
 .ct-inline-filter__content {
   display: flex;
   flex-direction: column;
@@ -7499,6 +7492,9 @@ ol ol ol {
 }
 .ct-inline-filter .ct-field {
   margin-bottom: 0;
+}
+.ct-inline-filter .ct-label--extra-large {
+  margin-bottom: 1rem;
 }
 .ct-inline-filter.ct-theme-light .ct-inline-filter__title {
   color: var(--ct-inline-filter-light-title-color);

--- a/packages/twig/dist/civictheme.storybook.css
+++ b/packages/twig/dist/civictheme.storybook.css
@@ -7458,13 +7458,6 @@ ol ol ol {
   flex-direction: column;
   gap: 1.5rem;
 }
-.ct-inline-filter__title {
-  font-size: var(--ct-typography-heading-2-font-size);
-  line-height: var(--ct-typography-heading-2-line-height);
-  font-family: var(--ct-typography-heading-2-font-name);
-  font-weight: var(--ct-typography-heading-2-font-weight);
-  letter-spacing: var(--ct-typography-heading-2-letter-spacing);
-}
 .ct-inline-filter__content {
   display: flex;
   flex-direction: column;
@@ -7499,6 +7492,9 @@ ol ol ol {
 }
 .ct-inline-filter .ct-field {
   margin-bottom: 0;
+}
+.ct-inline-filter .ct-label--extra-large {
+  margin-bottom: 1rem;
 }
 .ct-inline-filter.ct-theme-light .ct-inline-filter__title {
   color: var(--ct-inline-filter-light-title-color);


### PR DESCRIPTION
https://github.com/civictheme/uikit/issues/769

## Checklist before requesting a review

- [x] I have formatted the subject to include the issue number
  as `[#123] Verb in past tense with a period at the end.`
- [x] I have provided information in the `Changed` section about WHY something was
  done if this was a bespoke implementation.
- [x] I have performed a self-review of my code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have run new and existing relevant tests locally with my changes,
  and they have passed.
- [x] I have provided screenshots, where applicable.

## Changed

1. Added `title_size` to field component to allow setting a label size.
2. Updated stories for field and inline-filter to support title size.

## Screenshots
<img width="1327" height="549" alt="Screenshot 2025-10-03 at 4 22 38 pm" src="https://github.com/user-attachments/assets/0b284097-bc06-4e1f-af05-ffb45f1f403e" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Field component now supports configurable title size (extra-small to extra-large) with a default of regular; Storybook controls added.

- Refactor
  - Inline Filter title property removed; title is no longer rendered and the Storybook title control was removed.

- Style
  - Adjusted spacing for extra-large labels within Inline Filter for improved layout.

- Documentation
  - Updated component docs and stories to reflect the new title_size option and the removal of the Inline Filter title.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->