### PR TITLE
[#772] Fixed php twig bug - menu_level_modifier_class not in scope.

### DIFF
--- a/packages/sdc/components/00-base/menu/menu.twig
+++ b/packages/sdc/components/00-base/menu/menu.twig
@@ -33,7 +33,7 @@
 
 {% import _self as menus %}
 
-{% macro menu_links(items, menu_level, modifier_class, theme, is_collapsible, menu_level_modifier_class, parent_key) %}
+{% macro menu_links(items, menu_level, modifier_class, theme, is_collapsible, menu_level_modifier_class) %}
   {% if items %}
     {% if menu_level == 0 %}
       <ul class="ct-menu ct-menu--level-{{- menu_level }} {{ modifier_class -}} " data-component-name="ct-menu" {{- attributes|default('') -}}>
@@ -97,7 +97,7 @@
         {% endif %}
 
         {% if item.below %}
-          {{- menus.menu_links_below(item.below, menu_level + 1, '', theme, is_collapsible, menu_level_modifier_class, key) -}}
+          {{- menus.menu_links_below(item.below, menu_level + 1, '', theme, is_collapsible, menu_level_modifier_class) -}}
         {% endif %}
 
       </li>
@@ -120,8 +120,8 @@ clone this whole file and override it as required.
 The main macro is split into multiple macros to allow to override only the
 required parts while preserving (cloned) main generation macro.
 #}
-{% macro menu_links_below(items, menu_level, modifier_class, theme, is_collapsible, menu_level_modifier_class, parent_key) %}
-  {{ menus.menu_links(items, menu_level, modifier_class, theme, is_collapsible, menu_level_modifier_class, parent_key) }}
+{% macro menu_links_below(items, menu_level, modifier_class, theme, is_collapsible, menu_level_modifier_class) %}
+  {{ menus.menu_links(items, menu_level, modifier_class, theme, is_collapsible, menu_level_modifier_class) }}
 {% endmacro %}
 
 {{ menus.menu_links(items, 0, modifier_class, theme, is_collapsible, menu_level_modifier_class) }}

--- a/packages/twig/components/00-base/menu/menu.twig
+++ b/packages/twig/components/00-base/menu/menu.twig
@@ -33,7 +33,7 @@
 
 {% import _self as menus %}
 
-{% macro menu_links(items, menu_level, modifier_class, theme, is_collapsible, menu_level_modifier_class, parent_key) %}
+{% macro menu_links(items, menu_level, modifier_class, theme, is_collapsible, menu_level_modifier_class) %}
   {% if items %}
     {% if menu_level == 0 %}
       <ul class="ct-menu ct-menu--level-{{- menu_level }} {{ modifier_class -}} " data-component-name="ct-menu" {{- attributes|default('') -}}>
@@ -97,7 +97,7 @@
         {% endif %}
 
         {% if item.below %}
-          {{- menus.menu_links_below(item.below, menu_level + 1, '', theme, is_collapsible, menu_level_modifier_class, key) -}}
+          {{- menus.menu_links_below(item.below, menu_level + 1, '', theme, is_collapsible, menu_level_modifier_class) -}}
         {% endif %}
 
       </li>
@@ -120,8 +120,8 @@ clone this whole file and override it as required.
 The main macro is split into multiple macros to allow to override only the
 required parts while preserving (cloned) main generation macro.
 #}
-{% macro menu_links_below(items, menu_level, modifier_class, theme, is_collapsible, menu_level_modifier_class, parent_key) %}
-  {{ menus.menu_links(items, menu_level, modifier_class, theme, is_collapsible, menu_level_modifier_class, parent_key) }}
+{% macro menu_links_below(items, menu_level, modifier_class, theme, is_collapsible, menu_level_modifier_class) %}
+  {{ menus.menu_links(items, menu_level, modifier_class, theme, is_collapsible, menu_level_modifier_class) }}
 {% endmacro %}
 
 {{ menus.menu_links(items, 0, modifier_class, theme, is_collapsible, menu_level_modifier_class) }}


### PR DESCRIPTION
https://github.com/civictheme/uikit/issues/772

## Checklist before requesting a review

- [x] I have formatted the subject to include the issue number
  as `[#123] Verb in past tense with a period at the end.`
- [x] I have provided information in the `Changed` section about WHY something was
  done if this was a bespoke implementation.
- [x] I have performed a self-review of my code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have run new and existing relevant tests locally with my changes,
  and they have passed.
- [x] I have provided screenshots, where applicable.

## Changed

1. Original implementation of the variable `menu_level_modifier_class` is available to the inner macros in twigjs, but does not work in Drupal (likely due to function scoping). Passing the variable as a property into the macro fixes this issue.
2. This issue can be seen in the Primary Navigation secondary level drawer - the `container` class is not applied to the dropdown menus, meaning the menus will be touching the left-edge. This PR should fix that issue, and menu should remain positioned within the page column.

## Screenshots
<img width="1541" height="315" alt="Screenshot 2025-10-21 at 9 24 46 am" src="https://github.com/user-attachments/assets/8b807380-9c50-4851-a7a9-719110e165f3" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced menu component parameter structure to improve handling of styling modifiers across menu levels. Updated how menu level modifier classes are passed through nested menu rendering, streamlining the internal menu styling mechanism for better maintainability and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->