### PR TITLE
[#843] Fix table of contents error when empty heading is found.

### DIFF
--- a/packages/sdc/components/02-molecules/table-of-contents/table-of-contents.js
+++ b/packages/sdc/components/02-molecules/table-of-contents/table-of-contents.js
@@ -60,6 +60,11 @@ CivicThemeTableOfContents.prototype.findLinks = function (anchorSelector, scopeS
       let anchorId = elAnchor.id || null;
       const anchorText = elAnchor.innerText;
 
+      // Ignore blank headings.
+      if (anchorText.trim() === '') {
+        return;
+      }
+
       // Generate new ID if no existing ID.
       if (!anchorId || anchorId.length === 0) {
         anchorId = this.makeAnchorId(anchorText);

--- a/packages/sdc/components/02-molecules/table-of-contents/table-of-contents.stories.js
+++ b/packages/sdc/components/02-molecules/table-of-contents/table-of-contents.stories.js
@@ -80,6 +80,7 @@ export const TableOfContentsAutomatic = {
       <p>Est incididunt irure eu elit eiusmod incididunt occaecat labore aute in ad non irure sunt ad ut nostrud commodo do fugiat fugiat tempor occaecat mollit sunt in id sed commodo enim occaecat eu proident nostrud fugiat cupidatat.</p>
       <h2>Heading 2 - 3</h2>
       <p>Nulla sed cupidatat irure quis veniam ut in in pariatur do minim adipisicing minim exercitation magna eiusmod culpa tempor.</p>
+      <h2>&nbsp;</h2>
     ` }),
     modifier_class: '',
     attributes: null,

--- a/packages/twig/components/02-molecules/table-of-contents/table-of-contents.js
+++ b/packages/twig/components/02-molecules/table-of-contents/table-of-contents.js
@@ -60,6 +60,11 @@ CivicThemeTableOfContents.prototype.findLinks = function (anchorSelector, scopeS
       let anchorId = elAnchor.id || null;
       const anchorText = elAnchor.innerText;
 
+      // Ignore blank headings.
+      if (anchorText.trim() === '') {
+        return;
+      }
+
       // Generate new ID if no existing ID.
       if (!anchorId || anchorId.length === 0) {
         anchorId = this.makeAnchorId(anchorText);

--- a/packages/twig/components/02-molecules/table-of-contents/table-of-contents.stories.js
+++ b/packages/twig/components/02-molecules/table-of-contents/table-of-contents.stories.js
@@ -80,6 +80,7 @@ export const TableOfContentsAutomatic = {
       <p>Est incididunt irure eu elit eiusmod incididunt occaecat labore aute in ad non irure sunt ad ut nostrud commodo do fugiat fugiat tempor occaecat mollit sunt in id sed commodo enim occaecat eu proident nostrud fugiat cupidatat.</p>
       <h2>Heading 2 - 3</h2>
       <p>Nulla sed cupidatat irure quis veniam ut in in pariatur do minim adipisicing minim exercitation magna eiusmod culpa tempor.</p>
+      <h2>&nbsp;</h2>
     ` }),
     modifier_class: '',
     attributes: null,

--- a/packages/twig/dist/civictheme.storybook.js
+++ b/packages/twig/dist/civictheme.storybook.js
@@ -2585,6 +2585,11 @@ CivicThemeTableOfContents.prototype.findLinks = function (anchorSelector, scopeS
       let anchorId = elAnchor.id || null;
       const anchorText = elAnchor.innerText;
 
+      // Ignore blank headings.
+      if (anchorText.trim() === '') {
+        return;
+      }
+
       // Generate new ID if no existing ID.
       if (!anchorId || anchorId.length === 0) {
         anchorId = this.makeAnchorId(anchorText);


### PR DESCRIPTION
https://github.com/civictheme/uikit/issues/843

## Checklist before requesting a review

- [x] I have formatted the subject to include the issue number
  as `[#123] Verb in past tense with a period at the end.`
- [x] I have provided information in the `Changed` section about WHY something was
  done if this was a bespoke implementation.
- [x] I have performed a self-review of my code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have run new and existing relevant tests locally with my changes,
  and they have passed.
- [x] I have provided screenshots, where applicable.

## Changed

1. When generating table of contents links, if a heading (when trimmed) is empty, then continue to the next heading.

## Screenshots
<img width="1615" height="806" alt="Screenshot 2025-12-10 at 2 49 18 pm" src="https://github.com/user-attachments/assets/74cc498d-fd5f-48ba-984f-36eee1944b73" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed table of contents generation to skip empty headings, preventing blank entries from appearing in the navigation list.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->