### PR TITLE
Issue #3570945 by richardgaunt, joshua1234511, fionamorrison23: CivicTheme table does not render Drupal row or cell attributes

### DIFF
--- a/packages/sdc/components/01-atoms/table/table.component.yml
+++ b/packages/sdc/components/01-atoms/table/table.component.yml
@@ -56,7 +56,7 @@ props:
                     - type: object
                       properties:
                         content:
-                          type: [string, 'null', integer]
+                          type: [string, 'null', integer, object]
                         attributes:
                           type: object
               attributes:


### PR DESCRIPTION
https://www.drupal.org/project/civictheme/issues/3570945

## Checklist before requesting a review

- [x] I have formatted the subject to include the issue number
  as `[#123] Verb in past tense with a period at the end.`
- [ ] I have provided information in the `Changed` section about WHY something was
  done if this was a bespoke implementation.
- [ ] I have performed a self-review of my code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have run new and existing relevant tests locally with my changes,
  and they have passed.
- [ ] I have provided screenshots, where applicable.

## Changed

1.

## Screenshots


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Table cells now support object-type content in addition to strings, numbers, and null values. This update expands table flexibility, enabling more diverse data representation. Tables can now display complex information structures alongside traditional text and numeric content, providing enhanced display capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->