### PR TITLE
[#71] Added spacing below tables and video player component within Basic Content.

### DIFF
--- a/packages/sdc/components/02-molecules/basic-content/basic-content.css
+++ b/packages/sdc/components/02-molecules/basic-content/basic-content.css
@@ -388,6 +388,12 @@
 .ct-basic-content .ct-content-link .ct-icon {
   vertical-align: middle;
 }
+.ct-basic-content .ct-table {
+  margin-bottom: var(--ct-basic-content-vertical-spacing);
+}
+.ct-basic-content .ct-video-player {
+  margin-bottom: var(--ct-basic-content-vertical-spacing);
+}
 .ct-basic-content.ct-theme-light {
   color: var(--ct-basic-content-light-base-color);
 }

--- a/packages/sdc/components/02-molecules/basic-content/basic-content.css
+++ b/packages/sdc/components/02-molecules/basic-content/basic-content.css
@@ -388,11 +388,13 @@
 .ct-basic-content .ct-content-link .ct-icon {
   vertical-align: middle;
 }
-.ct-basic-content .ct-table {
-  margin-bottom: var(--ct-basic-content-vertical-spacing);
-}
+.ct-basic-content .ct-table,
 .ct-basic-content .ct-video-player {
   margin-bottom: var(--ct-basic-content-vertical-spacing);
+}
+.ct-basic-content .ct-table:last-child,
+.ct-basic-content .ct-video-player:last-child {
+  margin-bottom: 0;
 }
 .ct-basic-content.ct-theme-light {
   color: var(--ct-basic-content-light-base-color);

--- a/packages/sdc/components/02-molecules/basic-content/basic-content.scss
+++ b/packages/sdc/components/02-molecules/basic-content/basic-content.scss
@@ -20,6 +20,14 @@
     }
   }
 
+  .ct-table {
+    margin-bottom: var(--ct-basic-content-vertical-spacing);
+  }
+
+  .ct-video-player {
+    margin-bottom: var(--ct-basic-content-vertical-spacing);
+  }
+
   @include ct-component-theme($root) using($root, $theme) {
     @include ct-content-theme($theme);
 

--- a/packages/sdc/components/02-molecules/basic-content/basic-content.scss
+++ b/packages/sdc/components/02-molecules/basic-content/basic-content.scss
@@ -20,12 +20,13 @@
     }
   }
 
-  .ct-table {
-    margin-bottom: var(--ct-basic-content-vertical-spacing);
-  }
-
+  .ct-table,
   .ct-video-player {
     margin-bottom: var(--ct-basic-content-vertical-spacing);
+
+    &:last-child {
+      margin-bottom: 0;
+    }
   }
 
   @include ct-component-theme($root) using($root, $theme) {

--- a/packages/sdc/components/02-molecules/basic-content/basic-content.stories.data.js
+++ b/packages/sdc/components/02-molecules/basic-content/basic-content.stories.data.js
@@ -146,6 +146,7 @@ export default {
       ],
     })
     }
+    <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc auctor risus nec nisl tempor, vel sodales metus bibendum.</p>
       `,
     is_contained: true,
     vertical_spacing: 'none',

--- a/packages/twig/components/02-molecules/basic-content/basic-content.scss
+++ b/packages/twig/components/02-molecules/basic-content/basic-content.scss
@@ -20,6 +20,14 @@
     }
   }
 
+  .ct-table {
+    margin-bottom: var(--ct-basic-content-vertical-spacing);
+  }
+
+  .ct-video-player {
+    margin-bottom: var(--ct-basic-content-vertical-spacing);
+  }
+
   @include ct-component-theme($root) using($root, $theme) {
     @include ct-content-theme($theme);
 

--- a/packages/twig/components/02-molecules/basic-content/basic-content.scss
+++ b/packages/twig/components/02-molecules/basic-content/basic-content.scss
@@ -20,12 +20,13 @@
     }
   }
 
-  .ct-table {
-    margin-bottom: var(--ct-basic-content-vertical-spacing);
-  }
-
+  .ct-table,
   .ct-video-player {
     margin-bottom: var(--ct-basic-content-vertical-spacing);
+
+    &:last-child {
+      margin-bottom: 0;
+    }
   }
 
   @include ct-component-theme($root) using($root, $theme) {

--- a/packages/twig/components/02-molecules/basic-content/basic-content.stories.data.js
+++ b/packages/twig/components/02-molecules/basic-content/basic-content.stories.data.js
@@ -146,6 +146,7 @@ export default {
       ],
     })
     }
+    <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc auctor risus nec nisl tempor, vel sodales metus bibendum.</p>
       `,
     is_contained: true,
     vertical_spacing: 'none',

--- a/packages/twig/dist/civictheme.css
+++ b/packages/twig/dist/civictheme.css
@@ -6730,11 +6730,13 @@ ol ol ol {
 .ct-basic-content .ct-content-link .ct-icon {
   vertical-align: middle;
 }
-.ct-basic-content .ct-table {
-  margin-bottom: var(--ct-basic-content-vertical-spacing);
-}
+.ct-basic-content .ct-table,
 .ct-basic-content .ct-video-player {
   margin-bottom: var(--ct-basic-content-vertical-spacing);
+}
+.ct-basic-content .ct-table:last-child,
+.ct-basic-content .ct-video-player:last-child {
+  margin-bottom: 0;
 }
 .ct-basic-content.ct-theme-light {
   color: var(--ct-basic-content-light-base-color);

--- a/packages/twig/dist/civictheme.css
+++ b/packages/twig/dist/civictheme.css
@@ -6730,6 +6730,12 @@ ol ol ol {
 .ct-basic-content .ct-content-link .ct-icon {
   vertical-align: middle;
 }
+.ct-basic-content .ct-table {
+  margin-bottom: var(--ct-basic-content-vertical-spacing);
+}
+.ct-basic-content .ct-video-player {
+  margin-bottom: var(--ct-basic-content-vertical-spacing);
+}
 .ct-basic-content.ct-theme-light {
   color: var(--ct-basic-content-light-base-color);
 }

--- a/packages/twig/dist/civictheme.storybook.css
+++ b/packages/twig/dist/civictheme.storybook.css
@@ -6730,11 +6730,13 @@ ol ol ol {
 .ct-basic-content .ct-content-link .ct-icon {
   vertical-align: middle;
 }
-.ct-basic-content .ct-table {
-  margin-bottom: var(--ct-basic-content-vertical-spacing);
-}
+.ct-basic-content .ct-table,
 .ct-basic-content .ct-video-player {
   margin-bottom: var(--ct-basic-content-vertical-spacing);
+}
+.ct-basic-content .ct-table:last-child,
+.ct-basic-content .ct-video-player:last-child {
+  margin-bottom: 0;
 }
 .ct-basic-content.ct-theme-light {
   color: var(--ct-basic-content-light-base-color);

--- a/packages/twig/dist/civictheme.storybook.css
+++ b/packages/twig/dist/civictheme.storybook.css
@@ -6730,6 +6730,12 @@ ol ol ol {
 .ct-basic-content .ct-content-link .ct-icon {
   vertical-align: middle;
 }
+.ct-basic-content .ct-table {
+  margin-bottom: var(--ct-basic-content-vertical-spacing);
+}
+.ct-basic-content .ct-video-player {
+  margin-bottom: var(--ct-basic-content-vertical-spacing);
+}
 .ct-basic-content.ct-theme-light {
   color: var(--ct-basic-content-light-base-color);
 }


### PR DESCRIPTION
**Issue:** https://github.com/civictheme/uikit/issues/71

## Checklist before requesting a review

- [x] I have formatted the subject to include the issue number
  as `[#123] Verb in past tense with a period at the end.`
- [x] I have provided information in the `Changed` section about WHY something was
  done if this was a bespoke implementation.
- [x] I have performed a self-review of my code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have run new and existing relevant tests locally with my changes,
  and they have passed.
- [x] I have provided screenshots, where applicable.

## Changed

1. Added standard margin below table and video component when used within the Basic Content component.
2. Added some content below the table in Storybook to test the spacing below table.

## Screenshots
<img width="1530" height="805" alt="Screenshot 2026-04-27 at 6 20 44 pm" src="https://github.com/user-attachments/assets/c359b438-d3b9-4a92-8a85-3a90ce08b827" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Applied consistent vertical spacing to tables and video players within basic-content components for improved visual alignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->