### PR TITLE
[#930] Fixed icon shrinking when large attachment name provided.

### DIFF
--- a/packages/sdc/components/02-molecules/attachment/attachment.css
+++ b/packages/sdc/components/02-molecules/attachment/attachment.css
@@ -28,6 +28,9 @@
   display: flex;
   gap: 0 0.5rem;
 }
+.ct-attachment .ct-attachment__links__link__icon {
+  flex-shrink: 0;
+}
 .ct-attachment .ct-attachment__links__link__extension {
   text-transform: uppercase;
 }

--- a/packages/sdc/components/02-molecules/attachment/attachment.scss
+++ b/packages/sdc/components/02-molecules/attachment/attachment.scss
@@ -35,6 +35,10 @@
     gap: 0 ct-spacing();
   }
 
+  #{$root}__links__link__icon {
+    flex-shrink: 0;
+  }
+
   #{$root}__links__link__extension {
     text-transform: uppercase;
   }

--- a/packages/twig/components/02-molecules/attachment/attachment.scss
+++ b/packages/twig/components/02-molecules/attachment/attachment.scss
@@ -35,6 +35,10 @@
     gap: 0 ct-spacing();
   }
 
+  #{$root}__links__link__icon {
+    flex-shrink: 0;
+  }
+
   #{$root}__links__link__extension {
     text-transform: uppercase;
   }

--- a/packages/twig/dist/civictheme.css
+++ b/packages/twig/dist/civictheme.css
@@ -6293,6 +6293,9 @@ ol ol ol {
   display: flex;
   gap: 0 0.5rem;
 }
+.ct-attachment .ct-attachment__links__link__icon {
+  flex-shrink: 0;
+}
 .ct-attachment .ct-attachment__links__link__extension {
   text-transform: uppercase;
 }

--- a/packages/twig/dist/civictheme.storybook.css
+++ b/packages/twig/dist/civictheme.storybook.css
@@ -6293,6 +6293,9 @@ ol ol ol {
   display: flex;
   gap: 0 0.5rem;
 }
+.ct-attachment .ct-attachment__links__link__icon {
+  flex-shrink: 0;
+}
 .ct-attachment .ct-attachment__links__link__extension {
   text-transform: uppercase;
 }


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have formatted the subject to include the issue number
  as `[#123] Verb in past tense with a period at the end.`
- [x] I have provided information in the `Changed` section about WHY something was
  done if this was a bespoke implementation.
- [x] I have performed a self-review of my code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have run new and existing relevant tests locally with my changes,
  and they have passed.
- [x] I have provided screenshots, where applicable.

## Changed

1. Fixed icon shrinking when large attachment name provided.

## Screenshots
<img width="1369" height="1152" alt="Screen Shot 2026-05-22 at 16 06 41" src="https://github.com/user-attachments/assets/0321353e-61bb-4c83-aeb7-9419275fc900" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Attachment component icons now properly maintain their size without shrinking in flex layouts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/civictheme/uikit/pull/931?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->