### PR TITLE
[#3467058] Fixed duplicate main; moved main to page / layout to use div.

### DIFF
--- a/packages/sdc/components/00-base/layout/__snapshots__/layout.test.js.snap
+++ b/packages/sdc/components/00-base/layout/__snapshots__/layout.test.js.snap
@@ -9,9 +9,8 @@ exports[`Layout Component hides sidebars when specified - contained 1`] = `
 
 
   
-  <main
+  <div
     class="ct-layout ct-layout--no-sidebar-left ct-layout--no-sidebar-right ct-layout--no-top-left ct-layout--no-top-right ct-layout--no-bottom-left ct-layout--no-bottom-right"
-    role="main"
   >
     
               
@@ -36,7 +35,7 @@ exports[`Layout Component hides sidebars when specified - contained 1`] = `
     
 
                 
-  </main>
+  </div>
   
 
 </div>
@@ -51,9 +50,8 @@ exports[`Layout Component hides sidebars when specified 1`] = `
 
 
   
-  <main
+  <div
     class="ct-layout ct-layout--no-sidebar-left ct-layout--no-sidebar-right ct-layout--no-top-left ct-layout--no-top-right ct-layout--no-bottom-left ct-layout--no-bottom-right"
-    role="main"
   >
     
               
@@ -78,7 +76,7 @@ exports[`Layout Component hides sidebars when specified 1`] = `
     
 
                 
-  </main>
+  </div>
   
 
 </div>
@@ -93,9 +91,8 @@ exports[`Layout Component only main - contained 1`] = `
 
 
   
-  <main
+  <div
     class="ct-layout ct-layout--no-top-left ct-layout--no-top-right ct-layout--no-bottom-left ct-layout--no-bottom-right"
-    role="main"
   >
     
               
@@ -120,7 +117,7 @@ exports[`Layout Component only main - contained 1`] = `
     
 
                 
-  </main>
+  </div>
   
 
 </div>
@@ -135,9 +132,8 @@ exports[`Layout Component only main - not contained 1`] = `
 
 
   
-  <main
+  <div
     class="ct-layout ct-layout--no-top-left ct-layout--no-top-right ct-layout--no-bottom-left ct-layout--no-bottom-right"
-    role="main"
   >
     
               
@@ -162,7 +158,7 @@ exports[`Layout Component only main - not contained 1`] = `
     
 
                 
-  </main>
+  </div>
   
 
 </div>
@@ -177,9 +173,8 @@ exports[`Layout Component renders with all sidebars and content sections 1`] = `
 
 
   
-  <main
+  <div
     class="ct-layout ct-vertical-spacing--top"
-    role="main"
   >
     
           Top content    
@@ -232,7 +227,7 @@ exports[`Layout Component renders with all sidebars and content sections 1`] = `
     
 
           Bottom content      
-  </main>
+  </div>
   
 
 </div>
@@ -247,10 +242,9 @@ exports[`Layout Component renders with custom attributes and classes 1`] = `
 
 
   
-  <main
+  <div
     class="ct-layout ct-layout--no-top-left ct-layout--no-top-right ct-layout--no-bottom-left ct-layout--no-bottom-right  custom-modifier"
     data-test="true"
-    role="main"
   >
     
               
@@ -275,7 +269,7 @@ exports[`Layout Component renders with custom attributes and classes 1`] = `
     
 
                 
-  </main>
+  </div>
   
 
 </div>
@@ -290,9 +284,8 @@ exports[`Layout Component renders with default values 1`] = `
 
 
   
-  <main
+  <div
     class="ct-layout ct-layout--no-top-left ct-layout--no-top-right ct-layout--no-bottom-left ct-layout--no-bottom-right"
-    role="main"
   >
     
               
@@ -317,7 +310,7 @@ exports[`Layout Component renders with default values 1`] = `
     
 
                 
-  </main>
+  </div>
   
 
 </div>
@@ -332,9 +325,8 @@ exports[`Layout Component renders with sidebar bottom left 1`] = `
 
 
   
-  <main
+  <div
     class="ct-layout ct-layout--no-top-left ct-layout--no-top-right  ct-layout--no-bottom-right ct-vertical-spacing--top"
-    role="main"
   >
     
               
@@ -366,7 +358,7 @@ exports[`Layout Component renders with sidebar bottom left 1`] = `
     
 
                 
-  </main>
+  </div>
   
 
 </div>
@@ -381,9 +373,8 @@ exports[`Layout Component renders with sidebar bottom right 1`] = `
 
 
   
-  <main
+  <div
     class="ct-layout ct-layout--no-top-left ct-layout--no-top-right ct-layout--no-bottom-left  ct-vertical-spacing--top"
-    role="main"
   >
     
               
@@ -415,7 +406,7 @@ exports[`Layout Component renders with sidebar bottom right 1`] = `
     
 
                 
-  </main>
+  </div>
   
 
 </div>
@@ -430,9 +421,8 @@ exports[`Layout Component renders with sidebar top left 1`] = `
 
 
   
-  <main
+  <div
     class="ct-layout ct-layout--no-top-right ct-layout--no-bottom-left ct-layout--no-bottom-right ct-vertical-spacing--top"
-    role="main"
   >
     
               
@@ -464,7 +454,7 @@ exports[`Layout Component renders with sidebar top left 1`] = `
     
 
                 
-  </main>
+  </div>
   
 
 </div>
@@ -479,9 +469,8 @@ exports[`Layout Component renders with sidebar top right 1`] = `
 
 
   
-  <main
+  <div
     class="ct-layout ct-layout--no-top-left  ct-layout--no-bottom-left ct-layout--no-bottom-right ct-vertical-spacing--top"
-    role="main"
   >
     
               
@@ -513,7 +502,7 @@ exports[`Layout Component renders with sidebar top right 1`] = `
     
 
                 
-  </main>
+  </div>
   
 
 </div>

--- a/packages/sdc/components/00-base/layout/layout.twig
+++ b/packages/sdc/components/00-base/layout/layout.twig
@@ -57,7 +57,7 @@
 {% set modifier_class = modifier_class|trim %}
 
 {% if content %}
-  <main class="ct-layout {{ modifier_class -}}" role="main" {% if attributes is defined and attributes is not null %}{{- attributes -}}{% endif %}>
+  <div class="ct-layout {{ modifier_class -}}" {% if attributes is defined and attributes is not null %}{{- attributes -}}{% endif %}>
     {% block content_top_block %}
       {% if content_top is not empty %}
         {{- content_top -}}
@@ -111,5 +111,5 @@
         {{- content_bottom -}}
       {% endif %}
     {% endblock %}
-  </main>
+  </div>
 {% endif %}

--- a/packages/sdc/components/03-organisms/banner/__snapshots__/banner.test.js.snap
+++ b/packages/sdc/components/03-organisms/banner/__snapshots__/banner.test.js.snap
@@ -16,8 +16,6 @@ exports[`Banner Component renders with all attributes provided 1`] = `
   <div
     class="ct-banner ct-theme-dark ct-banner--decorative additional-class"
     data-test="true"
-    id="main-content"
-    tabindex="-1"
   >
     
     
@@ -469,8 +467,6 @@ exports[`Banner Component renders with only required attributes 1`] = `
   
   <div
     class="ct-banner ct-theme-light  "
-    id="main-content"
-    tabindex="-1"
   >
     
     
@@ -548,8 +544,6 @@ exports[`Banner Component renders without additional attributes and classes 1`] 
   
   <div
     class="ct-banner ct-theme-light  "
-    id="main-content"
-    tabindex="-1"
   >
     
     

--- a/packages/sdc/components/03-organisms/banner/banner.twig
+++ b/packages/sdc/components/03-organisms/banner/banner.twig
@@ -53,7 +53,7 @@
 {% set modifier_class = '%s %s %s'|format(theme_class, is_decorative_class, modifier_class|default('')) %}
 
 {% if content_top1 is not empty or content_top2 is not empty or content_top3 is not empty or site_section is not empty or title is not empty or content_middle is not empty or content is not empty or content_below is not empty or content_bottom is not empty %}
-  <div class="ct-banner {{ modifier_class -}}" id="main-content" tabindex="-1" {% if attributes is defined and attributes is not null %}{{- attributes -}}{% endif %}>
+  <div class="ct-banner {{ modifier_class -}}" {% if attributes is defined and attributes is not null %}{{- attributes -}}{% endif %}>
     <div class="ct-banner__wrapper">
       <div
         class="ct-banner__inner {% if background_image_blend_mode %}ct-background--{{ background_image_blend_mode|default('normal') }}{% endif %}"

--- a/packages/sdc/components/04-templates/page/__snapshots__/page.test.js.snap
+++ b/packages/sdc/components/04-templates/page/__snapshots__/page.test.js.snap
@@ -266,31 +266,40 @@ exports[`Page Component renders all blocks with complex attributes and classes 1
     </header>
     
   
-            
-    <strong>
-      Banner Content
-    </strong>
-    
-      
-            
-    <div
-      class="container"
+  
+    <main
+      id="main-content"
+      tabindex="-1"
     >
       
-        
+                  
+      <strong>
+        Banner Content
+      </strong>
+      
+          
+                  
       <div
-        class="row"
+        class="container"
       >
         
           
         <div
-          class="col-xxs-12"
+          class="row"
         >
           
             
-          <strong>
-            Highlighted Content
-          </strong>
+          <div
+            class="col-xxs-12"
+          >
+            
+              
+            <strong>
+              Highlighted Content
+            </strong>
+            
+            
+          </div>
           
           
         </div>
@@ -298,80 +307,79 @@ exports[`Page Component renders all blocks with complex attributes and classes 1
         
       </div>
       
-      
-    </div>
-    
-      
-      
+          
+          
 
 
 
 
 
   
-    <main
-      class="ct-layout ct-vertical-spacing--top"
-      role="main"
-    >
-      
-          Content Top    
-    
       <div
-        class="ct-layout__inner container"
+        class="ct-layout ct-vertical-spacing--top"
       >
         
-                        
-        <section
-          class="ct-layout__main"
-          data-content="true"
+          Content Top    
+    
+        <div
+          class="ct-layout__inner container"
         >
-          Main Content
-        </section>
-        
+          
+                        
+          <section
+            class="ct-layout__main"
+            data-content="true"
+          >
+            Main Content
+          </section>
+          
               
                         
-        <aside
-          class="ct-layout__sidebar_top_left"
-          data-sidebar-top-left="true"
-        >
-          Sidebar Top Left
-        </aside>
-        
+          <aside
+            class="ct-layout__sidebar_top_left"
+            data-sidebar-top-left="true"
+          >
+            Sidebar Top Left
+          </aside>
+          
               
                         
-        <aside
-          class="ct-layout__sidebar_top_right"
-          data-sidebar-top-right="true"
-        >
-          Sidebar Top Right
-        </aside>
-        
+          <aside
+            class="ct-layout__sidebar_top_right"
+            data-sidebar-top-right="true"
+          >
+            Sidebar Top Right
+          </aside>
+          
               
                         
-        <aside
-          class="ct-layout__sidebar_bottom_left"
-          data-sidebar-bottom-left="true"
-        >
-          Sidebar Bottom Left
-        </aside>
-        
+          <aside
+            class="ct-layout__sidebar_bottom_left"
+            data-sidebar-bottom-left="true"
+          >
+            Sidebar Bottom Left
+          </aside>
+          
               
                         
-        <aside
-          class="ct-layout__sidebar_bottom_right"
-          data-sidebar-bottom-right="true"
-        >
-          Sidebar Bottom Right
-        </aside>
-        
+          <aside
+            class="ct-layout__sidebar_bottom_right"
+            data-sidebar-bottom-right="true"
+          >
+            Sidebar Bottom Right
+          </aside>
+          
                   
-      </div>
-      
+        </div>
+        
 
           Content Bottom      
+      </div>
+      
+      
     </main>
     
-  
+
       
 
   
@@ -659,76 +667,81 @@ exports[`Page Component renders content block with permutations: {
 
 
   
-        
-  
-      
-
-
-
-
-
   
     <main
-      _keys="id tabindex"
-      class="ct-layout ct-vertical-spacing--top"
       id="main-content"
-      role="main"
       tabindex="-1"
     >
       
               
     
+          
+
+
+
+
+
+  
       <div
-        class="ct-layout__inner container"
+        class="ct-layout ct-vertical-spacing--top"
       >
         
-                        
-        <section
-          class="ct-layout__main"
+              
+    
+        <div
+          class="ct-layout__inner container"
         >
-          Main Content
-        </section>
-        
+          
+                        
+          <section
+            class="ct-layout__main"
+          >
+            Main Content
+          </section>
+          
               
                         
-        <aside
-          class="ct-layout__sidebar_top_left"
-        >
-          Sidebar Top Left
-        </aside>
-        
+          <aside
+            class="ct-layout__sidebar_top_left"
+          >
+            Sidebar Top Left
+          </aside>
+          
               
                         
-        <aside
-          class="ct-layout__sidebar_top_right"
-        >
-          Sidebar Top Right
-        </aside>
-        
+          <aside
+            class="ct-layout__sidebar_top_right"
+          >
+            Sidebar Top Right
+          </aside>
+          
               
                         
-        <aside
-          class="ct-layout__sidebar_bottom_left"
-        >
-          Sidebar Bottom Left
-        </aside>
-        
+          <aside
+            class="ct-layout__sidebar_bottom_left"
+          >
+            Sidebar Bottom Left
+          </aside>
+          
               
                         
-        <aside
-          class="ct-layout__sidebar_bottom_right"
-        >
-          Sidebar Bottom Right
-        </aside>
-        
+          <aside
+            class="ct-layout__sidebar_bottom_right"
+          >
+            Sidebar Bottom Right
+          </aside>
+          
                   
-      </div>
-      
+        </div>
+        
 
                 
+      </div>
+      
+      
     </main>
     
-  
+
       
 
   
@@ -821,62 +834,67 @@ exports[`Page Component renders content block with permutations: {
 
 
   
-        
-  
-      
-
-
-
-
-
   
     <main
-      _keys="id tabindex"
-      class="ct-layout ct-layout--no-sidebar-right  ct-layout--no-top-right  ct-layout--no-bottom-right ct-vertical-spacing--top"
       id="main-content"
-      role="main"
       tabindex="-1"
     >
       
               
     
+          
+
+
+
+
+
+  
       <div
-        class="ct-layout__inner container"
+        class="ct-layout ct-layout--no-sidebar-right  ct-layout--no-top-right  ct-layout--no-bottom-right ct-vertical-spacing--top"
       >
         
-                        
-        <section
-          class="ct-layout__main"
+              
+    
+        <div
+          class="ct-layout__inner container"
         >
-          Main Content
-        </section>
-        
+          
+                        
+          <section
+            class="ct-layout__main"
+          >
+            Main Content
+          </section>
+          
               
                         
-        <aside
-          class="ct-layout__sidebar_top_left"
-        >
-          Sidebar Top Left
-        </aside>
-        
+          <aside
+            class="ct-layout__sidebar_top_left"
+          >
+            Sidebar Top Left
+          </aside>
+          
               
       
                         
-        <aside
-          class="ct-layout__sidebar_bottom_left"
-        >
-          Sidebar Bottom Left
-        </aside>
-        
+          <aside
+            class="ct-layout__sidebar_bottom_left"
+          >
+            Sidebar Bottom Left
+          </aside>
+          
               
           
-      </div>
-      
+        </div>
+        
 
                 
+      </div>
+      
+      
     </main>
     
-  
+
       
 
   
@@ -969,62 +987,67 @@ exports[`Page Component renders content block with permutations: {
 
 
   
-        
-  
-      
-
-
-
-
-
   
     <main
-      _keys="id tabindex"
-      class="ct-layout ct-layout--no-sidebar-left  ct-layout--no-top-left  ct-layout--no-bottom-left  ct-vertical-spacing--top"
       id="main-content"
-      role="main"
       tabindex="-1"
     >
       
               
     
+          
+
+
+
+
+
+  
       <div
-        class="ct-layout__inner container"
+        class="ct-layout ct-layout--no-sidebar-left  ct-layout--no-top-left  ct-layout--no-bottom-left  ct-vertical-spacing--top"
       >
         
-                        
-        <section
-          class="ct-layout__main"
+              
+    
+        <div
+          class="ct-layout__inner container"
         >
-          Main Content
-        </section>
-        
+          
+                        
+          <section
+            class="ct-layout__main"
+          >
+            Main Content
+          </section>
+          
               
       
                         
-        <aside
-          class="ct-layout__sidebar_top_right"
-        >
-          Sidebar Top Right
-        </aside>
-        
+          <aside
+            class="ct-layout__sidebar_top_right"
+          >
+            Sidebar Top Right
+          </aside>
+          
               
       
                         
-        <aside
-          class="ct-layout__sidebar_bottom_right"
-        >
-          Sidebar Bottom Right
-        </aside>
-        
+          <aside
+            class="ct-layout__sidebar_bottom_right"
+          >
+            Sidebar Bottom Right
+          </aside>
+          
                   
-      </div>
-      
+        </div>
+        
 
                 
+      </div>
+      
+      
     </main>
     
-  
+
       
 
   
@@ -1117,48 +1140,53 @@ exports[`Page Component renders content block with permutations: {
 
 
   
-        
-  
-      
-
-
-
-
-
   
     <main
-      _keys="id tabindex"
-      class="ct-layout ct-layout--no-sidebar-left ct-layout--no-sidebar-right ct-layout--no-top-left ct-layout--no-top-right ct-layout--no-bottom-left ct-layout--no-bottom-right"
       id="main-content"
-      role="main"
       tabindex="-1"
     >
       
               
     
+          
+
+
+
+
+
+  
       <div
-        class="ct-layout__inner container-fluid"
+        class="ct-layout ct-layout--no-sidebar-left ct-layout--no-sidebar-right ct-layout--no-top-left ct-layout--no-top-right ct-layout--no-bottom-left ct-layout--no-bottom-right"
       >
         
-                        
-        <section
-          class="ct-layout__main"
+              
+    
+        <div
+          class="ct-layout__inner container-fluid"
         >
-          Main Content
-        </section>
-        
+          
+                        
+          <section
+            class="ct-layout__main"
+          >
+            Main Content
+          </section>
+          
               
       
       
       
           
-      </div>
-      
+        </div>
+        
 
                 
+      </div>
+      
+      
     </main>
     
-  
+
       
 
   
@@ -1244,15 +1272,24 @@ exports[`Page Component renders with custom theme and attributes 1`] = `
 
 
   
-        
   
+    <main
+      id="main-content"
+      tabindex="-1"
+    >
       
+              
+    
+          
 
 
 
 
 
-  
+      
+    </main>
+    
+
       
 
   
@@ -1337,15 +1374,24 @@ exports[`Page Component renders with default values 1`] = `
 
 
   
-        
   
+    <main
+      id="main-content"
+      tabindex="-1"
+    >
       
+              
+    
+          
 
 
 
 
 
-  
+      
+    </main>
+    
+
       
 
   
@@ -1431,15 +1477,24 @@ exports[`Page Component strips HTML tags from attributes 1`] = `
 
 
   
-        
   
+    <main
+      id="main-content"
+      tabindex="-1"
+    >
       
+              
+    
+          
 
 
 
 
 
-  
+      
+    </main>
+    
+
       
 
   

--- a/packages/sdc/components/04-templates/page/page.twig
+++ b/packages/sdc/components/04-templates/page/page.twig
@@ -77,45 +77,46 @@
     } only %}
   {% endblock %}
 
-  {% block banner_block %}
-    {% if banner is not empty %}
-      {{ banner }}
-    {% endif %}
-  {% endblock %}
+  <main id="main-content" tabindex="-1">
+    {% block banner_block %}
+      {% if banner is not empty %}
+        {{ banner }}
+      {% endif %}
+    {% endblock %}
 
-  {% if highlighted is not empty %}
-    {% block highlighted_block %}
-      <div class="container">
-        <div class="row">
-          <div class="col-xxs-12">
-            {{ highlighted }}
+    {% if highlighted is not empty %}
+      {% block highlighted_block %}
+        <div class="container">
+          <div class="row">
+            <div class="col-xxs-12">
+              {{ highlighted }}
+            </div>
           </div>
         </div>
-      </div>
-    {% endblock %}
-  {% endif %}
+      {% endblock %}
+    {% endif %}
 
-  {% block content_block %}
-    {% include 'civictheme:layout' with {
-      content_top: content_top,
-      hide_sidebar_left: hide_sidebar_left,
-      hide_sidebar_right: hide_sidebar_right,
-      sidebar_top_left: sidebar_top_left,
-      sidebar_top_left_attributes: sidebar_top_left_attributes,
-      sidebar_top_right: sidebar_top_right,
-      sidebar_top_right_attributes: sidebar_top_right_attributes,
-      content: content,
-      content_attributes: content_attributes,
-      sidebar_bottom_left: sidebar_bottom_left|default(sidebar),
-      sidebar_bottom_left_attributes: sidebar_bottom_left_attributes|default(sidebar_attributes),
-      sidebar_bottom_right: sidebar_bottom_right,
-      sidebar_bottom_right_attributes: sidebar_bottom_right_attributes,
-      is_contained: content_contained,
-      content_bottom: content_bottom,
-      vertical_spacing: vertical_spacing|default('none'),
-      attributes: (banner is empty) ? create_attribute({id: 'main-content', tabindex: '-1'}) : create_attribute(),
-    } only %}
-  {% endblock %}
+    {% block content_block %}
+      {% include 'civictheme:layout' with {
+        content_top: content_top,
+        hide_sidebar_left: hide_sidebar_left,
+        hide_sidebar_right: hide_sidebar_right,
+        sidebar_top_left: sidebar_top_left,
+        sidebar_top_left_attributes: sidebar_top_left_attributes,
+        sidebar_top_right: sidebar_top_right,
+        sidebar_top_right_attributes: sidebar_top_right_attributes,
+        content: content,
+        content_attributes: content_attributes,
+        sidebar_bottom_left: sidebar_bottom_left|default(sidebar),
+        sidebar_bottom_left_attributes: sidebar_bottom_left_attributes|default(sidebar_attributes),
+        sidebar_bottom_right: sidebar_bottom_right,
+        sidebar_bottom_right_attributes: sidebar_bottom_right_attributes,
+        is_contained: content_contained,
+        content_bottom: content_bottom,
+        vertical_spacing: vertical_spacing|default('none'),
+      } only %}
+    {% endblock %}
+  </main>
 
   {% block footer_block %}
     {% include 'civictheme:footer' with {

--- a/packages/twig/components/00-base/layout/__snapshots__/layout.test.js.snap
+++ b/packages/twig/components/00-base/layout/__snapshots__/layout.test.js.snap
@@ -9,9 +9,8 @@ exports[`Layout Component hides sidebars when specified - contained 1`] = `
 
 
   
-  <main
+  <div
     class="ct-layout ct-layout--no-sidebar-left ct-layout--no-sidebar-right ct-layout--no-top-left ct-layout--no-top-right ct-layout--no-bottom-left ct-layout--no-bottom-right"
-    role="main"
   >
     
               
@@ -36,7 +35,7 @@ exports[`Layout Component hides sidebars when specified - contained 1`] = `
     
 
                 
-  </main>
+  </div>
   
 
 </div>
@@ -51,9 +50,8 @@ exports[`Layout Component hides sidebars when specified 1`] = `
 
 
   
-  <main
+  <div
     class="ct-layout ct-layout--no-sidebar-left ct-layout--no-sidebar-right ct-layout--no-top-left ct-layout--no-top-right ct-layout--no-bottom-left ct-layout--no-bottom-right"
-    role="main"
   >
     
               
@@ -78,7 +76,7 @@ exports[`Layout Component hides sidebars when specified 1`] = `
     
 
                 
-  </main>
+  </div>
   
 
 </div>
@@ -93,9 +91,8 @@ exports[`Layout Component only main - contained 1`] = `
 
 
   
-  <main
+  <div
     class="ct-layout ct-layout--no-top-left ct-layout--no-top-right ct-layout--no-bottom-left ct-layout--no-bottom-right"
-    role="main"
   >
     
               
@@ -120,7 +117,7 @@ exports[`Layout Component only main - contained 1`] = `
     
 
                 
-  </main>
+  </div>
   
 
 </div>
@@ -135,9 +132,8 @@ exports[`Layout Component only main - not contained 1`] = `
 
 
   
-  <main
+  <div
     class="ct-layout ct-layout--no-top-left ct-layout--no-top-right ct-layout--no-bottom-left ct-layout--no-bottom-right"
-    role="main"
   >
     
               
@@ -162,7 +158,7 @@ exports[`Layout Component only main - not contained 1`] = `
     
 
                 
-  </main>
+  </div>
   
 
 </div>
@@ -177,9 +173,8 @@ exports[`Layout Component renders with all sidebars and content sections 1`] = `
 
 
   
-  <main
+  <div
     class="ct-layout ct-vertical-spacing--top"
-    role="main"
   >
     
           Top content    
@@ -232,7 +227,7 @@ exports[`Layout Component renders with all sidebars and content sections 1`] = `
     
 
           Bottom content      
-  </main>
+  </div>
   
 
 </div>
@@ -247,10 +242,9 @@ exports[`Layout Component renders with custom attributes and classes 1`] = `
 
 
   
-  <main
+  <div
     class="ct-layout ct-layout--no-top-left ct-layout--no-top-right ct-layout--no-bottom-left ct-layout--no-bottom-right  custom-modifier"
     data-test="true"
-    role="main"
   >
     
               
@@ -275,7 +269,7 @@ exports[`Layout Component renders with custom attributes and classes 1`] = `
     
 
                 
-  </main>
+  </div>
   
 
 </div>
@@ -290,9 +284,8 @@ exports[`Layout Component renders with default values 1`] = `
 
 
   
-  <main
+  <div
     class="ct-layout ct-layout--no-top-left ct-layout--no-top-right ct-layout--no-bottom-left ct-layout--no-bottom-right"
-    role="main"
   >
     
               
@@ -317,7 +310,7 @@ exports[`Layout Component renders with default values 1`] = `
     
 
                 
-  </main>
+  </div>
   
 
 </div>
@@ -332,9 +325,8 @@ exports[`Layout Component renders with sidebar bottom left 1`] = `
 
 
   
-  <main
+  <div
     class="ct-layout ct-layout--no-top-left ct-layout--no-top-right  ct-layout--no-bottom-right ct-vertical-spacing--top"
-    role="main"
   >
     
               
@@ -366,7 +358,7 @@ exports[`Layout Component renders with sidebar bottom left 1`] = `
     
 
                 
-  </main>
+  </div>
   
 
 </div>
@@ -381,9 +373,8 @@ exports[`Layout Component renders with sidebar bottom right 1`] = `
 
 
   
-  <main
+  <div
     class="ct-layout ct-layout--no-top-left ct-layout--no-top-right ct-layout--no-bottom-left  ct-vertical-spacing--top"
-    role="main"
   >
     
               
@@ -415,7 +406,7 @@ exports[`Layout Component renders with sidebar bottom right 1`] = `
     
 
                 
-  </main>
+  </div>
   
 
 </div>
@@ -430,9 +421,8 @@ exports[`Layout Component renders with sidebar top left 1`] = `
 
 
   
-  <main
+  <div
     class="ct-layout ct-layout--no-top-right ct-layout--no-bottom-left ct-layout--no-bottom-right ct-vertical-spacing--top"
-    role="main"
   >
     
               
@@ -464,7 +454,7 @@ exports[`Layout Component renders with sidebar top left 1`] = `
     
 
                 
-  </main>
+  </div>
   
 
 </div>
@@ -479,9 +469,8 @@ exports[`Layout Component renders with sidebar top right 1`] = `
 
 
   
-  <main
+  <div
     class="ct-layout ct-layout--no-top-left  ct-layout--no-bottom-left ct-layout--no-bottom-right ct-vertical-spacing--top"
-    role="main"
   >
     
               
@@ -513,7 +502,7 @@ exports[`Layout Component renders with sidebar top right 1`] = `
     
 
                 
-  </main>
+  </div>
   
 
 </div>

--- a/packages/twig/components/00-base/layout/layout.twig
+++ b/packages/twig/components/00-base/layout/layout.twig
@@ -57,7 +57,7 @@
 {% set modifier_class = modifier_class|trim %}
 
 {% if content %}
-  <main class="ct-layout {{ modifier_class -}}" role="main" {% if attributes is defined and attributes is not null %}{{- attributes -}}{% endif %}>
+  <div class="ct-layout {{ modifier_class -}}" {% if attributes is defined and attributes is not null %}{{- attributes -}}{% endif %}>
     {% block content_top_block %}
       {% if content_top is not empty %}
         {{- content_top -}}
@@ -111,5 +111,5 @@
         {{- content_bottom -}}
       {% endif %}
     {% endblock %}
-  </main>
+  </div>
 {% endif %}

--- a/packages/twig/components/03-organisms/banner/__snapshots__/banner.test.js.snap
+++ b/packages/twig/components/03-organisms/banner/__snapshots__/banner.test.js.snap
@@ -16,8 +16,6 @@ exports[`Banner Component renders with all attributes provided 1`] = `
   <div
     class="ct-banner ct-theme-dark ct-banner--decorative additional-class"
     data-test="true"
-    id="main-content"
-    tabindex="-1"
   >
     
     
@@ -469,8 +467,6 @@ exports[`Banner Component renders with only required attributes 1`] = `
   
   <div
     class="ct-banner ct-theme-light  "
-    id="main-content"
-    tabindex="-1"
   >
     
     
@@ -548,8 +544,6 @@ exports[`Banner Component renders without additional attributes and classes 1`] 
   
   <div
     class="ct-banner ct-theme-light  "
-    id="main-content"
-    tabindex="-1"
   >
     
     

--- a/packages/twig/components/03-organisms/banner/banner.twig
+++ b/packages/twig/components/03-organisms/banner/banner.twig
@@ -53,7 +53,7 @@
 {% set modifier_class = '%s %s %s'|format(theme_class, is_decorative_class, modifier_class|default('')) %}
 
 {% if content_top1 is not empty or content_top2 is not empty or content_top3 is not empty or site_section is not empty or title is not empty or content_middle is not empty or content is not empty or content_below is not empty or content_bottom is not empty %}
-  <div class="ct-banner {{ modifier_class -}}" id="main-content" tabindex="-1" {% if attributes is defined and attributes is not null %}{{- attributes -}}{% endif %}>
+  <div class="ct-banner {{ modifier_class -}}" {% if attributes is defined and attributes is not null %}{{- attributes -}}{% endif %}>
     <div class="ct-banner__wrapper">
       <div
         class="ct-banner__inner {% if background_image_blend_mode %}ct-background--{{ background_image_blend_mode|default('normal') }}{% endif %}"

--- a/packages/twig/components/04-templates/page/__snapshots__/page.test.js.snap
+++ b/packages/twig/components/04-templates/page/__snapshots__/page.test.js.snap
@@ -266,31 +266,40 @@ exports[`Page Component renders all blocks with complex attributes and classes 1
     </header>
     
   
-            
-    <strong>
-      Banner Content
-    </strong>
-    
-      
-            
-    <div
-      class="container"
+  
+    <main
+      id="main-content"
+      tabindex="-1"
     >
       
-        
+                  
+      <strong>
+        Banner Content
+      </strong>
+      
+          
+                  
       <div
-        class="row"
+        class="container"
       >
         
           
         <div
-          class="col-xxs-12"
+          class="row"
         >
           
             
-          <strong>
-            Highlighted Content
-          </strong>
+          <div
+            class="col-xxs-12"
+          >
+            
+              
+            <strong>
+              Highlighted Content
+            </strong>
+            
+            
+          </div>
           
           
         </div>
@@ -298,80 +307,79 @@ exports[`Page Component renders all blocks with complex attributes and classes 1
         
       </div>
       
-      
-    </div>
-    
-      
-      
+          
+          
 
 
 
 
 
   
-    <main
-      class="ct-layout ct-vertical-spacing--top"
-      role="main"
-    >
-      
-          Content Top    
-    
       <div
-        class="ct-layout__inner container"
+        class="ct-layout ct-vertical-spacing--top"
       >
         
-                        
-        <section
-          class="ct-layout__main"
-          data-content="true"
+          Content Top    
+    
+        <div
+          class="ct-layout__inner container"
         >
-          Main Content
-        </section>
-        
+          
+                        
+          <section
+            class="ct-layout__main"
+            data-content="true"
+          >
+            Main Content
+          </section>
+          
               
                         
-        <aside
-          class="ct-layout__sidebar_top_left"
-          data-sidebar-top-left="true"
-        >
-          Sidebar Top Left
-        </aside>
-        
+          <aside
+            class="ct-layout__sidebar_top_left"
+            data-sidebar-top-left="true"
+          >
+            Sidebar Top Left
+          </aside>
+          
               
                         
-        <aside
-          class="ct-layout__sidebar_top_right"
-          data-sidebar-top-right="true"
-        >
-          Sidebar Top Right
-        </aside>
-        
+          <aside
+            class="ct-layout__sidebar_top_right"
+            data-sidebar-top-right="true"
+          >
+            Sidebar Top Right
+          </aside>
+          
               
                         
-        <aside
-          class="ct-layout__sidebar_bottom_left"
-          data-sidebar-bottom-left="true"
-        >
-          Sidebar Bottom Left
-        </aside>
-        
+          <aside
+            class="ct-layout__sidebar_bottom_left"
+            data-sidebar-bottom-left="true"
+          >
+            Sidebar Bottom Left
+          </aside>
+          
               
                         
-        <aside
-          class="ct-layout__sidebar_bottom_right"
-          data-sidebar-bottom-right="true"
-        >
-          Sidebar Bottom Right
-        </aside>
-        
+          <aside
+            class="ct-layout__sidebar_bottom_right"
+            data-sidebar-bottom-right="true"
+          >
+            Sidebar Bottom Right
+          </aside>
+          
                   
-      </div>
-      
+        </div>
+        
 
           Content Bottom      
+      </div>
+      
+      
     </main>
     
-  
+
       
 
   
@@ -659,76 +667,81 @@ exports[`Page Component renders content block with permutations: {
 
 
   
-        
-  
-      
-
-
-
-
-
   
     <main
-      _keys="id tabindex"
-      class="ct-layout ct-vertical-spacing--top"
       id="main-content"
-      role="main"
       tabindex="-1"
     >
       
               
     
+          
+
+
+
+
+
+  
       <div
-        class="ct-layout__inner container"
+        class="ct-layout ct-vertical-spacing--top"
       >
         
-                        
-        <section
-          class="ct-layout__main"
+              
+    
+        <div
+          class="ct-layout__inner container"
         >
-          Main Content
-        </section>
-        
+          
+                        
+          <section
+            class="ct-layout__main"
+          >
+            Main Content
+          </section>
+          
               
                         
-        <aside
-          class="ct-layout__sidebar_top_left"
-        >
-          Sidebar Top Left
-        </aside>
-        
+          <aside
+            class="ct-layout__sidebar_top_left"
+          >
+            Sidebar Top Left
+          </aside>
+          
               
                         
-        <aside
-          class="ct-layout__sidebar_top_right"
-        >
-          Sidebar Top Right
-        </aside>
-        
+          <aside
+            class="ct-layout__sidebar_top_right"
+          >
+            Sidebar Top Right
+          </aside>
+          
               
                         
-        <aside
-          class="ct-layout__sidebar_bottom_left"
-        >
-          Sidebar Bottom Left
-        </aside>
-        
+          <aside
+            class="ct-layout__sidebar_bottom_left"
+          >
+            Sidebar Bottom Left
+          </aside>
+          
               
                         
-        <aside
-          class="ct-layout__sidebar_bottom_right"
-        >
-          Sidebar Bottom Right
-        </aside>
-        
+          <aside
+            class="ct-layout__sidebar_bottom_right"
+          >
+            Sidebar Bottom Right
+          </aside>
+          
                   
-      </div>
-      
+        </div>
+        
 
                 
+      </div>
+      
+      
     </main>
     
-  
+
       
 
   
@@ -821,62 +834,67 @@ exports[`Page Component renders content block with permutations: {
 
 
   
-        
-  
-      
-
-
-
-
-
   
     <main
-      _keys="id tabindex"
-      class="ct-layout ct-layout--no-sidebar-right  ct-layout--no-top-right  ct-layout--no-bottom-right ct-vertical-spacing--top"
       id="main-content"
-      role="main"
       tabindex="-1"
     >
       
               
     
+          
+
+
+
+
+
+  
       <div
-        class="ct-layout__inner container"
+        class="ct-layout ct-layout--no-sidebar-right  ct-layout--no-top-right  ct-layout--no-bottom-right ct-vertical-spacing--top"
       >
         
-                        
-        <section
-          class="ct-layout__main"
+              
+    
+        <div
+          class="ct-layout__inner container"
         >
-          Main Content
-        </section>
-        
+          
+                        
+          <section
+            class="ct-layout__main"
+          >
+            Main Content
+          </section>
+          
               
                         
-        <aside
-          class="ct-layout__sidebar_top_left"
-        >
-          Sidebar Top Left
-        </aside>
-        
+          <aside
+            class="ct-layout__sidebar_top_left"
+          >
+            Sidebar Top Left
+          </aside>
+          
               
       
                         
-        <aside
-          class="ct-layout__sidebar_bottom_left"
-        >
-          Sidebar Bottom Left
-        </aside>
-        
+          <aside
+            class="ct-layout__sidebar_bottom_left"
+          >
+            Sidebar Bottom Left
+          </aside>
+          
               
           
-      </div>
-      
+        </div>
+        
 
                 
+      </div>
+      
+      
     </main>
     
-  
+
       
 
   
@@ -969,62 +987,67 @@ exports[`Page Component renders content block with permutations: {
 
 
   
-        
-  
-      
-
-
-
-
-
   
     <main
-      _keys="id tabindex"
-      class="ct-layout ct-layout--no-sidebar-left  ct-layout--no-top-left  ct-layout--no-bottom-left  ct-vertical-spacing--top"
       id="main-content"
-      role="main"
       tabindex="-1"
     >
       
               
     
+          
+
+
+
+
+
+  
       <div
-        class="ct-layout__inner container"
+        class="ct-layout ct-layout--no-sidebar-left  ct-layout--no-top-left  ct-layout--no-bottom-left  ct-vertical-spacing--top"
       >
         
-                        
-        <section
-          class="ct-layout__main"
+              
+    
+        <div
+          class="ct-layout__inner container"
         >
-          Main Content
-        </section>
-        
+          
+                        
+          <section
+            class="ct-layout__main"
+          >
+            Main Content
+          </section>
+          
               
       
                         
-        <aside
-          class="ct-layout__sidebar_top_right"
-        >
-          Sidebar Top Right
-        </aside>
-        
+          <aside
+            class="ct-layout__sidebar_top_right"
+          >
+            Sidebar Top Right
+          </aside>
+          
               
       
                         
-        <aside
-          class="ct-layout__sidebar_bottom_right"
-        >
-          Sidebar Bottom Right
-        </aside>
-        
+          <aside
+            class="ct-layout__sidebar_bottom_right"
+          >
+            Sidebar Bottom Right
+          </aside>
+          
                   
-      </div>
-      
+        </div>
+        
 
                 
+      </div>
+      
+      
     </main>
     
-  
+
       
 
   
@@ -1117,48 +1140,53 @@ exports[`Page Component renders content block with permutations: {
 
 
   
-        
-  
-      
-
-
-
-
-
   
     <main
-      _keys="id tabindex"
-      class="ct-layout ct-layout--no-sidebar-left ct-layout--no-sidebar-right ct-layout--no-top-left ct-layout--no-top-right ct-layout--no-bottom-left ct-layout--no-bottom-right"
       id="main-content"
-      role="main"
       tabindex="-1"
     >
       
               
     
+          
+
+
+
+
+
+  
       <div
-        class="ct-layout__inner container-fluid"
+        class="ct-layout ct-layout--no-sidebar-left ct-layout--no-sidebar-right ct-layout--no-top-left ct-layout--no-top-right ct-layout--no-bottom-left ct-layout--no-bottom-right"
       >
         
-                        
-        <section
-          class="ct-layout__main"
+              
+    
+        <div
+          class="ct-layout__inner container-fluid"
         >
-          Main Content
-        </section>
-        
+          
+                        
+          <section
+            class="ct-layout__main"
+          >
+            Main Content
+          </section>
+          
               
       
       
       
           
-      </div>
-      
+        </div>
+        
 
                 
+      </div>
+      
+      
     </main>
     
-  
+
       
 
   
@@ -1244,15 +1272,24 @@ exports[`Page Component renders with custom theme and attributes 1`] = `
 
 
   
-        
   
+    <main
+      id="main-content"
+      tabindex="-1"
+    >
       
+              
+    
+          
 
 
 
 
 
-  
+      
+    </main>
+    
+
       
 
   
@@ -1337,15 +1374,24 @@ exports[`Page Component renders with default values 1`] = `
 
 
   
-        
   
+    <main
+      id="main-content"
+      tabindex="-1"
+    >
       
+              
+    
+          
 
 
 
 
 
-  
+      
+    </main>
+    
+
       
 
   
@@ -1431,15 +1477,24 @@ exports[`Page Component strips HTML tags from attributes 1`] = `
 
 
   
-        
   
+    <main
+      id="main-content"
+      tabindex="-1"
+    >
       
+              
+    
+          
 
 
 
 
 
-  
+      
+    </main>
+    
+
       
 
   

--- a/packages/twig/components/04-templates/page/page.twig
+++ b/packages/twig/components/04-templates/page/page.twig
@@ -77,45 +77,46 @@
     } only %}
   {% endblock %}
 
-  {% block banner_block %}
-    {% if banner is not empty %}
-      {{ banner }}
-    {% endif %}
-  {% endblock %}
+  <main id="main-content" tabindex="-1">
+    {% block banner_block %}
+      {% if banner is not empty %}
+        {{ banner }}
+      {% endif %}
+    {% endblock %}
 
-  {% if highlighted is not empty %}
-    {% block highlighted_block %}
-      <div class="container">
-        <div class="row">
-          <div class="col-xxs-12">
-            {{ highlighted }}
+    {% if highlighted is not empty %}
+      {% block highlighted_block %}
+        <div class="container">
+          <div class="row">
+            <div class="col-xxs-12">
+              {{ highlighted }}
+            </div>
           </div>
         </div>
-      </div>
-    {% endblock %}
-  {% endif %}
+      {% endblock %}
+    {% endif %}
 
-  {% block content_block %}
-    {% include '@base/layout/layout.twig' with {
-      content_top: content_top,
-      hide_sidebar_left: hide_sidebar_left,
-      hide_sidebar_right: hide_sidebar_right,
-      sidebar_top_left: sidebar_top_left,
-      sidebar_top_left_attributes: sidebar_top_left_attributes,
-      sidebar_top_right: sidebar_top_right,
-      sidebar_top_right_attributes: sidebar_top_right_attributes,
-      content: content,
-      content_attributes: content_attributes,
-      sidebar_bottom_left: sidebar_bottom_left|default(sidebar),
-      sidebar_bottom_left_attributes: sidebar_bottom_left_attributes|default(sidebar_attributes),
-      sidebar_bottom_right: sidebar_bottom_right,
-      sidebar_bottom_right_attributes: sidebar_bottom_right_attributes,
-      is_contained: content_contained,
-      content_bottom: content_bottom,
-      vertical_spacing: vertical_spacing|default('none'),
-      attributes: (banner is empty) ? create_attribute({id: 'main-content', tabindex: '-1'}) : create_attribute(),
-    } only %}
-  {% endblock %}
+    {% block content_block %}
+      {% include '@base/layout/layout.twig' with {
+        content_top: content_top,
+        hide_sidebar_left: hide_sidebar_left,
+        hide_sidebar_right: hide_sidebar_right,
+        sidebar_top_left: sidebar_top_left,
+        sidebar_top_left_attributes: sidebar_top_left_attributes,
+        sidebar_top_right: sidebar_top_right,
+        sidebar_top_right_attributes: sidebar_top_right_attributes,
+        content: content,
+        content_attributes: content_attributes,
+        sidebar_bottom_left: sidebar_bottom_left|default(sidebar),
+        sidebar_bottom_left_attributes: sidebar_bottom_left_attributes|default(sidebar_attributes),
+        sidebar_bottom_right: sidebar_bottom_right,
+        sidebar_bottom_right_attributes: sidebar_bottom_right_attributes,
+        is_contained: content_contained,
+        content_bottom: content_bottom,
+        vertical_spacing: vertical_spacing|default('none'),
+      } only %}
+    {% endblock %}
+  </main>
 
   {% block footer_block %}
     {% include '@organisms/footer/footer.twig' with {


### PR DESCRIPTION
https://www.drupal.org/project/civictheme/issues/3467058

## Checklist before requesting a review

- [x] I have formatted the subject to include the issue number
  as `[#123] Verb in past tense with a period at the end.`
- [x] I have provided information in the `Changed` section about WHY something was
  done if this was a bespoke implementation.
- [x] I have performed a self-review of my code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have run new and existing relevant tests locally with my changes,
  and they have passed.
- [x] I have provided screenshots, where applicable.

## Changed

1. `civictheme:layout` component to use `<div>` instead of `<main>`. Remove `role="main"` as well.
2. `civictheme:page` should then wrap the following slots (`banner_block`, `highlighted_block`, `content_block`) in a `<main>`.
3. Removed logic to place skip link on banner or layout as `<main>` is now the single place to skip to.

This should ensure a single main exists, and wraps the non-header / non-footer content in a `<main>`.

Given that page handles the `header` and `footer` slot - it would make sense for it to handle the `main` slot as well.

## Screenshots
<img width="2106" height="570" alt="image" src="https://github.com/user-attachments/assets/3b673f9e-e598-4d3f-8d48-0615ae685446" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured page layout markup by consolidating main content semantics into a dedicated wrapper element, moving main-content attributes from conditional layout logic to improve code organization and clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->