### PR TITLE
[#942] Aligned Attachment molecule styles with Figma file.

### DIFF
--- a/packages/sdc/components/02-molecules/attachment/attachment.css
+++ b/packages/sdc/components/02-molecules/attachment/attachment.css
@@ -28,6 +28,9 @@
   display: flex;
   gap: 0 0.5rem;
 }
+.ct-attachment .ct-attachment__links__link__icon {
+  flex-shrink: 0;
+}
 .ct-attachment .ct-attachment__links__link__extension {
   text-transform: uppercase;
 }

--- a/packages/sdc/components/02-molecules/attachment/attachment.css
+++ b/packages/sdc/components/02-molecules/attachment/attachment.css
@@ -19,7 +19,7 @@
   }
 }
 .ct-attachment .ct-attachment__title {
-  margin-bottom: 1rem;
+  margin-bottom: 0.5rem;
 }
 .ct-attachment .ct-attachment__content {
   margin-bottom: 1rem;
@@ -27,6 +27,9 @@
 .ct-attachment .ct-attachment__links .ct-item-list__item {
   display: flex;
   gap: 0 0.5rem;
+}
+.ct-attachment .ct-attachment__links__link__changed {
+  margin-bottom: 0;
 }
 .ct-attachment .ct-attachment__links__link__extension {
   text-transform: uppercase;

--- a/packages/sdc/components/02-molecules/attachment/attachment.scss
+++ b/packages/sdc/components/02-molecules/attachment/attachment.scss
@@ -35,6 +35,10 @@
     gap: 0 ct-spacing();
   }
 
+  #{$root}__links__link__icon {
+    flex-shrink: 0;
+  }
+
   #{$root}__links__link__extension {
     text-transform: uppercase;
   }

--- a/packages/sdc/components/02-molecules/attachment/attachment.scss
+++ b/packages/sdc/components/02-molecules/attachment/attachment.scss
@@ -23,7 +23,7 @@
   }
 
   #{$root}__title {
-    margin-bottom: ct-spacing(2);
+    margin-bottom: ct-spacing();
   }
 
   #{$root}__content {
@@ -33,6 +33,10 @@
   #{$root}__links .ct-item-list__item {
     display: flex;
     gap: 0 ct-spacing();
+  }
+
+  #{$root}__links__link__changed {
+    margin-bottom: 0;
   }
 
   #{$root}__links__link__extension {

--- a/packages/twig/components/02-molecules/attachment/attachment.scss
+++ b/packages/twig/components/02-molecules/attachment/attachment.scss
@@ -35,6 +35,10 @@
     gap: 0 ct-spacing();
   }
 
+  #{$root}__links__link__icon {
+    flex-shrink: 0;
+  }
+
   #{$root}__links__link__extension {
     text-transform: uppercase;
   }

--- a/packages/twig/components/02-molecules/attachment/attachment.scss
+++ b/packages/twig/components/02-molecules/attachment/attachment.scss
@@ -23,7 +23,7 @@
   }
 
   #{$root}__title {
-    margin-bottom: ct-spacing(2);
+    margin-bottom: ct-spacing();
   }
 
   #{$root}__content {
@@ -33,6 +33,10 @@
   #{$root}__links .ct-item-list__item {
     display: flex;
     gap: 0 ct-spacing();
+  }
+
+  #{$root}__links__link__changed {
+    margin-bottom: 0;
   }
 
   #{$root}__links__link__extension {

--- a/packages/twig/dist/civictheme.css
+++ b/packages/twig/dist/civictheme.css
@@ -6293,6 +6293,9 @@ ol ol ol {
   display: flex;
   gap: 0 0.5rem;
 }
+.ct-attachment .ct-attachment__links__link__icon {
+  flex-shrink: 0;
+}
 .ct-attachment .ct-attachment__links__link__extension {
   text-transform: uppercase;
 }

--- a/packages/twig/dist/civictheme.css
+++ b/packages/twig/dist/civictheme.css
@@ -6284,7 +6284,7 @@ ol ol ol {
   }
 }
 .ct-attachment .ct-attachment__title {
-  margin-bottom: 1rem;
+  margin-bottom: 0.5rem;
 }
 .ct-attachment .ct-attachment__content {
   margin-bottom: 1rem;
@@ -6292,6 +6292,9 @@ ol ol ol {
 .ct-attachment .ct-attachment__links .ct-item-list__item {
   display: flex;
   gap: 0 0.5rem;
+}
+.ct-attachment .ct-attachment__links__link__changed {
+  margin-bottom: 0;
 }
 .ct-attachment .ct-attachment__links__link__extension {
   text-transform: uppercase;

--- a/packages/twig/dist/civictheme.storybook.css
+++ b/packages/twig/dist/civictheme.storybook.css
@@ -6293,6 +6293,9 @@ ol ol ol {
   display: flex;
   gap: 0 0.5rem;
 }
+.ct-attachment .ct-attachment__links__link__icon {
+  flex-shrink: 0;
+}
 .ct-attachment .ct-attachment__links__link__extension {
   text-transform: uppercase;
 }

--- a/packages/twig/dist/civictheme.storybook.css
+++ b/packages/twig/dist/civictheme.storybook.css
@@ -6284,7 +6284,7 @@ ol ol ol {
   }
 }
 .ct-attachment .ct-attachment__title {
-  margin-bottom: 1rem;
+  margin-bottom: 0.5rem;
 }
 .ct-attachment .ct-attachment__content {
   margin-bottom: 1rem;
@@ -6292,6 +6292,9 @@ ol ol ol {
 .ct-attachment .ct-attachment__links .ct-item-list__item {
   display: flex;
   gap: 0 0.5rem;
+}
+.ct-attachment .ct-attachment__links__link__changed {
+  margin-bottom: 0;
 }
 .ct-attachment .ct-attachment__links__link__extension {
   text-transform: uppercase;


### PR DESCRIPTION
## Issue URL:  https://github.com/civictheme/uikit/issues/930 https://github.com/civictheme/uikit/issues/942

## Checklist before requesting a review

- [x] I have formatted the subject to include the issue number
  as `[#123] Verb in past tense with a period at the end.`
- [x] I have provided information in the `Changed` section about WHY something was
  done if this was a bespoke implementation.
- [x] I have performed a self-review of my code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have run new and existing relevant tests locally with my changes,
  and they have passed.
- [x] I have provided screenshots, where applicable.

## Changed

1. Adjusted some Figma styles.
2. Removed margin bottom on Last Updated date which was causing spacing issues.
3. Reduced space between Title and Attachments as per Figma file.
4. This also pulls in Alan's changes from: https://github.com/civictheme/uikit/pull/931

## Screenshots
<img width="1421" height="860" alt="Attachments right" src="https://github.com/user-attachments/assets/ce338f09-3f3e-400e-a131-f0b6ae1c940a" />

Long name changes fixed thanks to @alan-cole  https://github.com/civictheme/uikit/pull/931
<img width="673" height="378" alt="Screenshot 2026-06-22 at 2 25 25 pm" src="https://github.com/user-attachments/assets/07d61432-2aaa-4e2d-b429-a534c39a845c" />

