### PR TITLE
[#948] Fixed bug that caused background image to spill over border radius on Subject card.

### DIFF
--- a/packages/sdc/components/02-molecules/subject-card/subject-card.css
+++ b/packages/sdc/components/02-molecules/subject-card/subject-card.css
@@ -6,6 +6,7 @@
   position: relative;
   border-radius: var(--ct-subject-card-border-radius);
   width: 100%;
+  overflow: hidden;
 }
 .ct-subject-card {
   box-shadow: 0 0.25rem 1rem rgba(0, 0, 0, 0.2);

--- a/packages/sdc/components/02-molecules/subject-card/subject-card.scss
+++ b/packages/sdc/components/02-molecules/subject-card/subject-card.scss
@@ -11,6 +11,7 @@
     position: relative;
     border-radius: var(--ct-subject-card-border-radius);
     width: 100%;
+    overflow: hidden;
 
     &:hover {
       outline: 1px solid transparent;

--- a/packages/twig/components/02-molecules/subject-card/subject-card.scss
+++ b/packages/twig/components/02-molecules/subject-card/subject-card.scss
@@ -11,6 +11,7 @@
     position: relative;
     border-radius: var(--ct-subject-card-border-radius);
     width: 100%;
+    overflow: hidden;
 
     &:hover {
       outline: 1px solid transparent;

--- a/packages/twig/dist/civictheme.css
+++ b/packages/twig/dist/civictheme.css
@@ -8612,6 +8612,7 @@ ol ol ol {
   position: relative;
   border-radius: var(--ct-subject-card-border-radius);
   width: 100%;
+  overflow: hidden;
 }
 .ct-subject-card {
   box-shadow: 0 0.25rem 1rem rgba(0, 0, 0, 0.2);

--- a/packages/twig/dist/civictheme.storybook.css
+++ b/packages/twig/dist/civictheme.storybook.css
@@ -8612,6 +8612,7 @@ ol ol ol {
   position: relative;
   border-radius: var(--ct-subject-card-border-radius);
   width: 100%;
+  overflow: hidden;
 }
 .ct-subject-card {
   box-shadow: 0 0.25rem 1rem rgba(0, 0, 0, 0.2);


### PR DESCRIPTION
## Issue URL: https://github.com/civictheme/uikit/issues/948

## Checklist before requesting a review

- [x] I have formatted the subject to include the issue number
  as `[#123] Verb in past tense with a period at the end.`
- [x] I have provided information in the `Changed` section about WHY something was
  done if this was a bespoke implementation.
- [ ] I have performed a self-review of my code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have run new and existing relevant tests locally with my changes,
  and they have passed.
- [x] I have provided screenshots, where applicable.

## Changed

1.  Fixed bug that caused background image to spill over border radius on Subject card.
 
## Screenshots
<img width="1182" height="755" alt="Subjec Card Fixes" src="https://github.com/user-attachments/assets/90c1d937-544b-42e0-94ba-06f8457afd05" />

