### PR TITLE
[#950] Aligned Navigation card styles with Figma file.

### DIFF
--- a/packages/sdc/components/02-molecules/navigation-card/navigation-card.css
+++ b/packages/sdc/components/02-molecules/navigation-card/navigation-card.css
@@ -67,16 +67,25 @@
 }
 .ct-navigation-card .ct-navigation-card__content {
   width: 100%;
-  padding: 1.5rem;
+  padding: 1rem;
   box-sizing: border-box;
   flex-grow: 1;
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+  gap: 0.5rem;
+}
+@media (min-width: 768px) {
+  .ct-navigation-card .ct-navigation-card__content {
+    padding: 1.5rem;
+  }
 }
 .ct-navigation-card .ct-navigation-card__icon {
-  margin-bottom: 1rem;
   color: inherit;
+}
+@media (min-width: 768px) {
+  .ct-navigation-card .ct-navigation-card__icon {
+    margin-bottom: 0.5rem;
+  }
 }
 .ct-navigation-card .ct-navigation-card__icon__image img {
   height: 1em;

--- a/packages/sdc/components/02-molecules/navigation-card/navigation-card.scss
+++ b/packages/sdc/components/02-molecules/navigation-card/navigation-card.scss
@@ -56,17 +56,24 @@
 
   #{$root}__content {
     width: 100%;
-    padding: ct-spacing(3);
+    padding: ct-spacing(2);
     box-sizing: border-box;
     flex-grow: 1;
     display: flex;
     flex-direction: column;
-    gap: ct-spacing(2);
+    gap: ct-spacing();
+
+    @include ct-breakpoint('m') {
+      padding: ct-spacing(3);
+    }
   }
 
   #{$root}__icon {
-    margin-bottom: ct-spacing(2);
     color: inherit;
+
+    @include ct-breakpoint('m') {
+      margin-bottom: ct-spacing();
+    }
   }
 
   #{$root}__icon__image {

--- a/packages/twig/components/02-molecules/navigation-card/navigation-card.scss
+++ b/packages/twig/components/02-molecules/navigation-card/navigation-card.scss
@@ -56,17 +56,24 @@
 
   #{$root}__content {
     width: 100%;
-    padding: ct-spacing(3);
+    padding: ct-spacing(2);
     box-sizing: border-box;
     flex-grow: 1;
     display: flex;
     flex-direction: column;
-    gap: ct-spacing(2);
+    gap: ct-spacing();
+
+    @include ct-breakpoint('m') {
+      padding: ct-spacing(3);
+    }
   }
 
   #{$root}__icon {
-    margin-bottom: ct-spacing(2);
     color: inherit;
+
+    @include ct-breakpoint('m') {
+      margin-bottom: ct-spacing();
+    }
   }
 
   #{$root}__icon__image {

--- a/packages/twig/dist/civictheme.css
+++ b/packages/twig/dist/civictheme.css
@@ -7710,16 +7710,25 @@ ol ol ol {
 }
 .ct-navigation-card .ct-navigation-card__content {
   width: 100%;
-  padding: 1.5rem;
+  padding: 1rem;
   box-sizing: border-box;
   flex-grow: 1;
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+  gap: 0.5rem;
+}
+@media (min-width: 768px) {
+  .ct-navigation-card .ct-navigation-card__content {
+    padding: 1.5rem;
+  }
 }
 .ct-navigation-card .ct-navigation-card__icon {
-  margin-bottom: 1rem;
   color: inherit;
+}
+@media (min-width: 768px) {
+  .ct-navigation-card .ct-navigation-card__icon {
+    margin-bottom: 0.5rem;
+  }
 }
 .ct-navigation-card .ct-navigation-card__icon__image img {
   height: 1em;

--- a/packages/twig/dist/civictheme.storybook.css
+++ b/packages/twig/dist/civictheme.storybook.css
@@ -7710,16 +7710,25 @@ ol ol ol {
 }
 .ct-navigation-card .ct-navigation-card__content {
   width: 100%;
-  padding: 1.5rem;
+  padding: 1rem;
   box-sizing: border-box;
   flex-grow: 1;
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+  gap: 0.5rem;
+}
+@media (min-width: 768px) {
+  .ct-navigation-card .ct-navigation-card__content {
+    padding: 1.5rem;
+  }
 }
 .ct-navigation-card .ct-navigation-card__icon {
-  margin-bottom: 1rem;
   color: inherit;
+}
+@media (min-width: 768px) {
+  .ct-navigation-card .ct-navigation-card__icon {
+    margin-bottom: 0.5rem;
+  }
 }
 .ct-navigation-card .ct-navigation-card__icon__image img {
   height: 1em;


### PR DESCRIPTION
## Issue URL: https://github.com/civictheme/uikit/issues/950

## Checklist before requesting a review

- [x] I have formatted the subject to include the issue number
  as `[#123] Verb in past tense with a period at the end.`
- [x] I have provided information in the `Changed` section about WHY something was
  done if this was a bespoke implementation.
- [x] I have performed a self-review of my code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have run new and existing relevant tests locally with my changes,
  and they have passed.
- [x] I have provided screenshots, where applicable.

## Changed

1. Fixed difference in gap between icon and heading when compared to Figma.
2. Fixed difference gap between heading and description when compared to Figma.
3. Fixed padding on mobile card (was 24px, now 16px) to match Figma.

## Screenshots
<img width="1243" height="777" alt="Navigation Card Fixes" src="https://github.com/user-attachments/assets/58724330-1ee3-4572-89bb-c1f8c43f03bb" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined navigation card component styling with updated layout and spacing adjustments. Content padding and icon margin behavior now respond to screen size, with responsive adjustments at medium breakpoints. Internal spacing gaps updated to use consistent design tokens for improved visual consistency and component alignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->