### PR TITLE
[#978] Fixed clipping path of feature image on Banner organism.

### DIFF
--- a/packages/sdc/components/00-base/_variables.components.scss
+++ b/packages/sdc/components/00-base/_variables.components.scss
@@ -1025,7 +1025,7 @@ $ct-alert-dark-warning-icon-color: $ct-alert-dark-warning-color !default;
 $ct-banner-decorative-mobile-clip-path: polygon(0% 0%, 100% 0%, 100% calc(100% - #{ct-spacing(2)}), 0% 100%) !default;
 $ct-banner-decorative-desktop-clip-path: polygon(0% 0%, 100% 0%, 100% calc(100% - #{ct-spacing(6)}), 0% 100%) !default;
 $ct-banner-featured-image-width: 40% !default;
-$ct-banner-featured-image-clip-path: polygon(13% 10%, 100% 0, 100% 100%, 0% 100%) !default;
+$ct-banner-featured-image-clip-path: polygon(7.5% 7.5%, 100% 0, 100% 100%, 0% 100%) !default;
 $ct-banner-light-background-color: ct-color-light('background') !default;
 $ct-banner-light-featured-image-shadow-color: ct-color-light('background-light') !default;
 $ct-banner-dark-background-color: ct-color-dark('background') !default;

--- a/packages/sdc/dist/civictheme.variables.css
+++ b/packages/sdc/dist/civictheme.variables.css
@@ -849,7 +849,7 @@ html {
   --ct-banner-decorative-mobile-clip-path: polygon(0% 0%, 100% 0%, 100% calc(100% - 1rem), 0% 100%);
   --ct-banner-decorative-desktop-clip-path: polygon(0% 0%, 100% 0%, 100% calc(100% - 3rem), 0% 100%);
   --ct-banner-featured-image-width: 40%;
-  --ct-banner-featured-image-clip-path: polygon(13% 10%, 100% 0, 100% 100%, 0% 100%);
+  --ct-banner-featured-image-clip-path: polygon(7.5% 7.5%, 100% 0, 100% 100%, 0% 100%);
   --ct-banner-light-background-color: var(--ct-color-light-background);
   --ct-banner-light-featured-image-shadow-color: var(--ct-color-light-background-light);
   --ct-banner-dark-background-color: var(--ct-color-dark-background);

--- a/packages/sdc/dist/constants.json
+++ b/packages/sdc/dist/constants.json
@@ -1343,7 +1343,7 @@
     "ct-banner-decorative-mobile-clip-path": "polygon(0% 0%, 100% 0%, 100% calc(100% - #{ct-spacing(2)}), 0% 100%)",
     "ct-banner-decorative-desktop-clip-path": "polygon(0% 0%, 100% 0%, 100% calc(100% - #{ct-spacing(6)}), 0% 100%)",
     "ct-banner-featured-image-width": "40%",
-    "ct-banner-featured-image-clip-path": "polygon(13% 10%, 100% 0, 100% 100%, 0% 100%)",
+    "ct-banner-featured-image-clip-path": "polygon(7.5% 7.5%, 100% 0, 100% 100%, 0% 100%)",
     "ct-banner-light-background-color": "ct-color-light('background')",
     "ct-banner-light-featured-image-shadow-color": "ct-color-light('background-light')",
     "ct-banner-dark-background-color": "ct-color-dark('background')",

--- a/packages/twig/components/00-base/_variables.components.scss
+++ b/packages/twig/components/00-base/_variables.components.scss
@@ -1025,7 +1025,7 @@ $ct-alert-dark-warning-icon-color: $ct-alert-dark-warning-color !default;
 $ct-banner-decorative-mobile-clip-path: polygon(0% 0%, 100% 0%, 100% calc(100% - #{ct-spacing(2)}), 0% 100%) !default;
 $ct-banner-decorative-desktop-clip-path: polygon(0% 0%, 100% 0%, 100% calc(100% - #{ct-spacing(6)}), 0% 100%) !default;
 $ct-banner-featured-image-width: 40% !default;
-$ct-banner-featured-image-clip-path: polygon(13% 10%, 100% 0, 100% 100%, 0% 100%) !default;
+$ct-banner-featured-image-clip-path: polygon(7.5% 7.5%, 100% 0, 100% 100%, 0% 100%) !default;
 $ct-banner-light-background-color: ct-color-light('background') !default;
 $ct-banner-light-featured-image-shadow-color: ct-color-light('background-light') !default;
 $ct-banner-dark-background-color: ct-color-dark('background') !default;

--- a/packages/twig/dist/civictheme.css
+++ b/packages/twig/dist/civictheme.css
@@ -12000,7 +12000,7 @@ html {
   --ct-banner-decorative-mobile-clip-path: polygon(0% 0%, 100% 0%, 100% calc(100% - 1rem), 0% 100%);
   --ct-banner-decorative-desktop-clip-path: polygon(0% 0%, 100% 0%, 100% calc(100% - 3rem), 0% 100%);
   --ct-banner-featured-image-width: 40%;
-  --ct-banner-featured-image-clip-path: polygon(13% 10%, 100% 0, 100% 100%, 0% 100%);
+  --ct-banner-featured-image-clip-path: polygon(7.5% 7.5%, 100% 0, 100% 100%, 0% 100%);
   --ct-banner-light-background-color: var(--ct-color-light-background);
   --ct-banner-light-featured-image-shadow-color: var(--ct-color-light-background-light);
   --ct-banner-dark-background-color: var(--ct-color-dark-background);

--- a/packages/twig/dist/civictheme.storybook.css
+++ b/packages/twig/dist/civictheme.storybook.css
@@ -12000,7 +12000,7 @@ html {
   --ct-banner-decorative-mobile-clip-path: polygon(0% 0%, 100% 0%, 100% calc(100% - 1rem), 0% 100%);
   --ct-banner-decorative-desktop-clip-path: polygon(0% 0%, 100% 0%, 100% calc(100% - 3rem), 0% 100%);
   --ct-banner-featured-image-width: 40%;
-  --ct-banner-featured-image-clip-path: polygon(13% 10%, 100% 0, 100% 100%, 0% 100%);
+  --ct-banner-featured-image-clip-path: polygon(7.5% 7.5%, 100% 0, 100% 100%, 0% 100%);
   --ct-banner-light-background-color: var(--ct-color-light-background);
   --ct-banner-light-featured-image-shadow-color: var(--ct-color-light-background-light);
   --ct-banner-dark-background-color: var(--ct-color-dark-background);

--- a/packages/twig/dist/civictheme.variables.css
+++ b/packages/twig/dist/civictheme.variables.css
@@ -849,7 +849,7 @@ html {
   --ct-banner-decorative-mobile-clip-path: polygon(0% 0%, 100% 0%, 100% calc(100% - 1rem), 0% 100%);
   --ct-banner-decorative-desktop-clip-path: polygon(0% 0%, 100% 0%, 100% calc(100% - 3rem), 0% 100%);
   --ct-banner-featured-image-width: 40%;
-  --ct-banner-featured-image-clip-path: polygon(13% 10%, 100% 0, 100% 100%, 0% 100%);
+  --ct-banner-featured-image-clip-path: polygon(7.5% 7.5%, 100% 0, 100% 100%, 0% 100%);
   --ct-banner-light-background-color: var(--ct-color-light-background);
   --ct-banner-light-featured-image-shadow-color: var(--ct-color-light-background-light);
   --ct-banner-dark-background-color: var(--ct-color-dark-background);

--- a/packages/twig/dist/constants.json
+++ b/packages/twig/dist/constants.json
@@ -1343,7 +1343,7 @@
     "ct-banner-decorative-mobile-clip-path": "polygon(0% 0%, 100% 0%, 100% calc(100% - #{ct-spacing(2)}), 0% 100%)",
     "ct-banner-decorative-desktop-clip-path": "polygon(0% 0%, 100% 0%, 100% calc(100% - #{ct-spacing(6)}), 0% 100%)",
     "ct-banner-featured-image-width": "40%",
-    "ct-banner-featured-image-clip-path": "polygon(13% 10%, 100% 0, 100% 100%, 0% 100%)",
+    "ct-banner-featured-image-clip-path": "polygon(7.5% 7.5%, 100% 0, 100% 100%, 0% 100%)",
     "ct-banner-light-background-color": "ct-color-light('background')",
     "ct-banner-light-featured-image-shadow-color": "ct-color-light('background-light')",
     "ct-banner-dark-background-color": "ct-color-dark('background')",


### PR DESCRIPTION
## Issue URL: https://github.com/civictheme/uikit/issues/978

## Checklist before requesting a review

- [x] I have formatted the subject to include the issue number
  as `[#123] Verb in past tense with a period at the end.`
- [x] I have provided information in the `Changed` section about WHY something was
  done if this was a bespoke implementation.
- [x] I have performed a self-review of my code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have run new and existing relevant tests locally with my changes,
  and they have passed.
- [x] I have provided screenshots, where applicable.

## Changed

1. Masking shape of feature image is more pronounced in Drupal versus Figma (obscures more of the image because the top left corner is lower and to the right in Drupal). This makes it difficult to use feature images as it is harder to find suitable images for an even more pronounced shape. Propose changing the mask to one that more closely resembles the Figma.

## Screenshots
<img width="3326" height="1978" alt="Banner 2" src="https://github.com/user-attachments/assets/cdb93192-ce51-4b99-81cc-8cd791d3bbc9" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the banner featured image shape for a slightly softer, more balanced clipped corner.
  * Applied the same visual adjustment across the supported component themes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->