### PR TITLE
Issue #3612927 by alan.cole: UI Kit fonts do not correctly embed otf / ttf

### DIFF
--- a/packages/sdc/components/00-base/mixins/_font.scss
+++ b/packages/sdc/components/00-base/mixins/_font.scss
@@ -96,9 +96,13 @@
           // Extract format from file extension.
           $format: string.slice($path, ct-string-last-index($path, '.') + 1);
 
-          // Handle special case for EOT and IE.
+          // Handle special cases for EOT / OTF / TTF.
           @if $format == 'eot' {
             $format: 'embedded-opentype';
+          } @else if $format == 'otf' {
+            $format: 'opentype';
+          } @else if $format == 'ttf' {
+            $format: 'truetype';
           }
 
           // noinspection CssInvalidFunction

--- a/packages/twig/components/00-base/mixins/_font.scss
+++ b/packages/twig/components/00-base/mixins/_font.scss
@@ -96,9 +96,13 @@
           // Extract format from file extension.
           $format: string.slice($path, ct-string-last-index($path, '.') + 1);
 
-          // Handle special case for EOT and IE.
+          // Handle special cases for EOT / OTF / TTF.
           @if $format == 'eot' {
             $format: 'embedded-opentype';
+          } @else if $format == 'otf' {
+            $format: 'opentype';
+          } @else if $format == 'ttf' {
+            $format: 'truetype';
           }
 
           // noinspection CssInvalidFunction


### PR DESCRIPTION
https://www.drupal.org/project/civictheme/issues/3612927

## Checklist before requesting a review

- [ ] I have formatted the subject to include the issue number
  as `[#123] Verb in past tense with a period at the end.`
- [ ] I have provided information in the `Changed` section about WHY something was
  done if this was a bespoke implementation.
- [ ] I have performed a self-review of my code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have run new and existing relevant tests locally with my changes,
  and they have passed.
- [ ] I have provided screenshots, where applicable.

## Changed

1. Added cases for otf and ttf to use opentype and truetype.

## Screenshots


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved web font handling by correctly identifying OpenType and TrueType font formats.
  * Ensured font files use standardized CSS format values for more reliable browser loading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->