### PR TITLE
[#990] Added custom colour mixer to produce accurate blends to Figma.

### DIFF
--- a/packages/sdc/components/00-base/mixins/_color.scss
+++ b/packages/sdc/components/00-base/mixins/_color.scss
@@ -3,6 +3,7 @@
 //
 
 @use 'sass:color';
+@use 'sass:list';
 @use 'sass:map';
 @use 'sass:math';
 @use 'sass:string';
@@ -39,14 +40,14 @@
 // Color shade. Do not use on components directly - map to a color variant instead.
 //
 @function ct-color-shade($color, $number) {
-  @return color.mix(black, $color, math.percentage(math.div($number, 100)));
+  @return ct-color-blend($color, (black math.percentage(math.div($number, 100))));
 }
 
 //
 // Color tint. Do not use on components directly - map to a color variant instead.
 //
 @function ct-color-tint($color, $number) {
-  @return color.mix(white, $color, math.percentage(math.div($number, 100)));
+  @return ct-color-blend($color, (white math.percentage(math.div($number, 100))));
 }
 
 //
@@ -55,7 +56,24 @@
 @function ct-color-tone($base, $color) {
   $neutral: color.adjust(color.adjust($base, $saturation: -20%), $lightness: -1 * math.max(color.lightness($base) - 5%, 0%));
 
-  @return color.mix($neutral, white, math.percentage(math.div($color, 100)));
+  @return ct-color-blend(white, ($neutral math.percentage(math.div($color, 100))));
+}
+
+//
+// Composite fills over $base so the result renders like Figma.
+//
+// Each entry in $fills is a `<color> <opacity>` pair, listed bottom-to-top.
+//
+@function ct-color-blend($base, $fills...) {
+  $channels: _ct-color-blend-channels($base, $fills);
+
+  // color.change() keeps the alpha of $base and the hex serialization that
+  // ct-color-encode() relies on.
+  @return color.change($base,
+    $red: _ct-color-byte(list.nth($channels, 1)),
+    $green: _ct-color-byte(list.nth($channels, 2)),
+    $blue: _ct-color-byte(list.nth($channels, 3))
+  );
 }
 
 //
@@ -77,6 +95,63 @@
 //
 @function ct-color-svg-fill($svg, $color) {
   @return ct-str-replace($svg, "fill=''", "fill='#{ct-color-encode($color)}'");
+}
+
+//
+// Interpolate fills over $base the way Figma does, returning unrounded
+// 0-255 channels.
+//
+// Done by hand because color.mix() rounds to 8 bits internally, which loses
+// the precision needed to round like Figma at the end.
+//
+// Do not use directly.
+//
+@function _ct-color-blend-channels($base, $fills) {
+  $red: color.red($base);
+  $green: color.green($base);
+  $blue: color.blue($base);
+
+  @each $fill in $fills {
+    $color: list.nth($fill, 1);
+    $alpha: list.nth($fill, 2);
+
+    @if not math.is-unitless($alpha) {
+      $alpha: math.div($alpha, 100%);
+    }
+
+    $red: $red * (1 - $alpha) + color.red($color) * $alpha;
+    $green: $green * (1 - $alpha) + color.green($color) * $alpha;
+    $blue: $blue * (1 - $alpha) + color.blue($color) * $alpha;
+  }
+
+  @return $red $green $blue;
+}
+
+//
+// Convert a 0-255 channel to a byte the way Figma renders one.
+//
+// Rounds half to even rather than half away from zero like math.round, with a
+// tolerance on the tie test to absorb Figma's float32 storage.
+//
+// Do not use directly.
+//
+@function _ct-color-byte($channel) {
+  $floor: math.floor($channel);
+  $remainder: $channel - $floor;
+
+  @if math.abs($remainder - 0.5) > 0.0001 {
+    @if $remainder > 0.5 {
+      @return $floor + 1;
+    }
+
+    @return $floor;
+  }
+
+  @if $floor % 2 == 0 {
+    @return $floor;
+  }
+
+  @return $floor + 1;
 }
 
 //

--- a/packages/sdc/dist/civictheme.stories.css
+++ b/packages/sdc/dist/civictheme.stories.css
@@ -696,9 +696,9 @@ code {
 .story-colors-wrapper .story-color-light--background-light .story-color-element {
   display: block;
   height: 3.75rem;
-  box-shadow: inset 0 0 0 0.0625rem #989898;
+  box-shadow: inset 0 0 0 0.0625rem #83acac;
   position: relative;
-  background-color: #fdfdfd;
+  background-color: #fcfdfd;
 }
 .story-colors-wrapper .story-color-light--background-light .story-color-text {
   display: block;
@@ -713,7 +713,7 @@ code {
   margin: 0.5rem 0;
 }
 .story-colors-wrapper .story-color-light--background-light .story-color-text::after {
-  content: "#FDFDFD";
+  content: "#FCFDFD";
   font-family: "Courier New", monospace, sans-serif;
   text-align: center;
   display: block;
@@ -795,9 +795,9 @@ code {
 .story-colors-wrapper .story-color-light--border-light .story-color-element {
   display: block;
   height: 3.75rem;
-  box-shadow: inset 0 0 0 0.0625rem #67696b;
+  box-shadow: inset 0 0 0 0.0625rem #666a6b;
   position: relative;
-  background-color: #adafb0;
+  background-color: #acafb0;
 }
 .story-colors-wrapper .story-color-light--border-light .story-color-text {
   display: block;
@@ -812,7 +812,7 @@ code {
   margin: 0.5rem 0;
 }
 .story-colors-wrapper .story-color-light--border-light .story-color-text::after {
-  content: "#ADAFB0";
+  content: "#ACAFB0";
   font-family: "Courier New", monospace, sans-serif;
   text-align: center;
   display: block;

--- a/packages/sdc/dist/civictheme.variables.css
+++ b/packages/sdc/dist/civictheme.variables.css
@@ -1,10 +1,10 @@
 html {
   --ct-color-light-heading: #002a39;
   --ct-color-light-body: #33444a;
-  --ct-color-light-background-light: #fdfdfd;
+  --ct-color-light-background-light: #fcfdfd;
   --ct-color-light-background: #e6e9eb;
   --ct-color-light-background-dark: #b8babc;
-  --ct-color-light-border-light: #adafb0;
+  --ct-color-light-border-light: #acafb0;
   --ct-color-light-border: #5c5d5e;
   --ct-color-light-border-dark: #171718;
   --ct-color-light-interaction-text: #fafbfb;

--- a/packages/twig/components/00-base/mixins/_color.scss
+++ b/packages/twig/components/00-base/mixins/_color.scss
@@ -3,6 +3,7 @@
 //
 
 @use 'sass:color';
+@use 'sass:list';
 @use 'sass:map';
 @use 'sass:math';
 @use 'sass:string';
@@ -39,14 +40,14 @@
 // Color shade. Do not use on components directly - map to a color variant instead.
 //
 @function ct-color-shade($color, $number) {
-  @return color.mix(black, $color, math.percentage(math.div($number, 100)));
+  @return ct-color-blend($color, (black math.percentage(math.div($number, 100))));
 }
 
 //
 // Color tint. Do not use on components directly - map to a color variant instead.
 //
 @function ct-color-tint($color, $number) {
-  @return color.mix(white, $color, math.percentage(math.div($number, 100)));
+  @return ct-color-blend($color, (white math.percentage(math.div($number, 100))));
 }
 
 //
@@ -55,7 +56,24 @@
 @function ct-color-tone($base, $color) {
   $neutral: color.adjust(color.adjust($base, $saturation: -20%), $lightness: -1 * math.max(color.lightness($base) - 5%, 0%));
 
-  @return color.mix($neutral, white, math.percentage(math.div($color, 100)));
+  @return ct-color-blend(white, ($neutral math.percentage(math.div($color, 100))));
+}
+
+//
+// Composite fills over $base so the result renders like Figma.
+//
+// Each entry in $fills is a `<color> <opacity>` pair, listed bottom-to-top.
+//
+@function ct-color-blend($base, $fills...) {
+  $channels: _ct-color-blend-channels($base, $fills);
+
+  // color.change() keeps the alpha of $base and the hex serialization that
+  // ct-color-encode() relies on.
+  @return color.change($base,
+    $red: _ct-color-byte(list.nth($channels, 1)),
+    $green: _ct-color-byte(list.nth($channels, 2)),
+    $blue: _ct-color-byte(list.nth($channels, 3))
+  );
 }
 
 //
@@ -77,6 +95,63 @@
 //
 @function ct-color-svg-fill($svg, $color) {
   @return ct-str-replace($svg, "fill=''", "fill='#{ct-color-encode($color)}'");
+}
+
+//
+// Interpolate fills over $base the way Figma does, returning unrounded
+// 0-255 channels.
+//
+// Done by hand because color.mix() rounds to 8 bits internally, which loses
+// the precision needed to round like Figma at the end.
+//
+// Do not use directly.
+//
+@function _ct-color-blend-channels($base, $fills) {
+  $red: color.red($base);
+  $green: color.green($base);
+  $blue: color.blue($base);
+
+  @each $fill in $fills {
+    $color: list.nth($fill, 1);
+    $alpha: list.nth($fill, 2);
+
+    @if not math.is-unitless($alpha) {
+      $alpha: math.div($alpha, 100%);
+    }
+
+    $red: $red * (1 - $alpha) + color.red($color) * $alpha;
+    $green: $green * (1 - $alpha) + color.green($color) * $alpha;
+    $blue: $blue * (1 - $alpha) + color.blue($color) * $alpha;
+  }
+
+  @return $red $green $blue;
+}
+
+//
+// Convert a 0-255 channel to a byte the way Figma renders one.
+//
+// Rounds half to even rather than half away from zero like math.round, with a
+// tolerance on the tie test to absorb Figma's float32 storage.
+//
+// Do not use directly.
+//
+@function _ct-color-byte($channel) {
+  $floor: math.floor($channel);
+  $remainder: $channel - $floor;
+
+  @if math.abs($remainder - 0.5) > 0.0001 {
+    @if $remainder > 0.5 {
+      @return $floor + 1;
+    }
+
+    @return $floor;
+  }
+
+  @if $floor % 2 == 0 {
+    @return $floor;
+  }
+
+  @return $floor + 1;
 }
 
 //

--- a/packages/twig/dist/civictheme.css
+++ b/packages/twig/dist/civictheme.css
@@ -11152,10 +11152,10 @@ ol ol ol {
 html {
   --ct-color-light-heading: #002a39;
   --ct-color-light-body: #33444a;
-  --ct-color-light-background-light: #fdfdfd;
+  --ct-color-light-background-light: #fcfdfd;
   --ct-color-light-background: #e6e9eb;
   --ct-color-light-background-dark: #b8babc;
-  --ct-color-light-border-light: #adafb0;
+  --ct-color-light-border-light: #acafb0;
   --ct-color-light-border: #5c5d5e;
   --ct-color-light-border-dark: #171718;
   --ct-color-light-interaction-text: #fafbfb;

--- a/packages/twig/dist/civictheme.stories.css
+++ b/packages/twig/dist/civictheme.stories.css
@@ -696,9 +696,9 @@ code {
 .story-colors-wrapper .story-color-light--background-light .story-color-element {
   display: block;
   height: 3.75rem;
-  box-shadow: inset 0 0 0 0.0625rem #989898;
+  box-shadow: inset 0 0 0 0.0625rem #83acac;
   position: relative;
-  background-color: #fdfdfd;
+  background-color: #fcfdfd;
 }
 .story-colors-wrapper .story-color-light--background-light .story-color-text {
   display: block;
@@ -713,7 +713,7 @@ code {
   margin: 0.5rem 0;
 }
 .story-colors-wrapper .story-color-light--background-light .story-color-text::after {
-  content: "#FDFDFD";
+  content: "#FCFDFD";
   font-family: "Courier New", monospace, sans-serif;
   text-align: center;
   display: block;
@@ -795,9 +795,9 @@ code {
 .story-colors-wrapper .story-color-light--border-light .story-color-element {
   display: block;
   height: 3.75rem;
-  box-shadow: inset 0 0 0 0.0625rem #67696b;
+  box-shadow: inset 0 0 0 0.0625rem #666a6b;
   position: relative;
-  background-color: #adafb0;
+  background-color: #acafb0;
 }
 .story-colors-wrapper .story-color-light--border-light .story-color-text {
   display: block;
@@ -812,7 +812,7 @@ code {
   margin: 0.5rem 0;
 }
 .story-colors-wrapper .story-color-light--border-light .story-color-text::after {
-  content: "#ADAFB0";
+  content: "#ACAFB0";
   font-family: "Courier New", monospace, sans-serif;
   text-align: center;
   display: block;

--- a/packages/twig/dist/civictheme.storybook.css
+++ b/packages/twig/dist/civictheme.storybook.css
@@ -11152,10 +11152,10 @@ ol ol ol {
 html {
   --ct-color-light-heading: #002a39;
   --ct-color-light-body: #33444a;
-  --ct-color-light-background-light: #fdfdfd;
+  --ct-color-light-background-light: #fcfdfd;
   --ct-color-light-background: #e6e9eb;
   --ct-color-light-background-dark: #b8babc;
-  --ct-color-light-border-light: #adafb0;
+  --ct-color-light-border-light: #acafb0;
   --ct-color-light-border: #5c5d5e;
   --ct-color-light-border-dark: #171718;
   --ct-color-light-interaction-text: #fafbfb;

--- a/packages/twig/dist/civictheme.variables.css
+++ b/packages/twig/dist/civictheme.variables.css
@@ -1,10 +1,10 @@
 html {
   --ct-color-light-heading: #002a39;
   --ct-color-light-body: #33444a;
-  --ct-color-light-background-light: #fdfdfd;
+  --ct-color-light-background-light: #fcfdfd;
   --ct-color-light-background: #e6e9eb;
   --ct-color-light-background-dark: #b8babc;
-  --ct-color-light-border-light: #adafb0;
+  --ct-color-light-border-light: #acafb0;
   --ct-color-light-border: #5c5d5e;
   --ct-color-light-border-dark: #171718;
   --ct-color-light-interaction-text: #fafbfb;


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have formatted the subject to include the issue number
  as `[#123] Verb in past tense with a period at the end.`
- [x] I have provided information in the `Changed` section about WHY something was
  done if this was a bespoke implementation.
- [x] I have performed a self-review of my code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have run new and existing relevant tests locally with my changes,
  and they have passed.
- [ ] I have provided screenshots, where applicable.

## Changed

1. Added custom colour blend function to produce accurate hex blends, compared to Figma.

## Screenshots
<img width="468" height="734" alt="Screenshot 2026-07-31 at 5 13 55 pm" src="https://github.com/user-attachments/assets/cc59ab9f-1cb0-4e39-946e-3aae87aaebdf" />
<img width="565" height="411" alt="Screenshot 2026-07-31 at 5 13 45 pm" src="https://github.com/user-attachments/assets/6d37d778-8a35-4f06-a633-3c93e3ccae56" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added color blending support for combining multiple fill colors over a base color.
  * Improved shade, tint, and tone calculations for more precise, design-tool-compatible color results.
  * Preserved transparency during color compositing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->