### PR TITLE
Updated drupal-attribute to the published @civictheme/drupal-attribute package.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,11 @@
         "twig/twig": "^3.16.0",
         "vincentlanglet/twig-cs-fixer": "^3.0"
     },
+    "config": {
+        "allow-plugins": {
+            "symfony/runtime": true
+        }
+    },
     "scripts": {
         "lint": "vendor/bin/twig-cs-fixer --no-cache",
         "lint-fix": "vendor/bin/twig-cs-fixer --no-cache --fix"

--- a/package-lock.json
+++ b/package-lock.json
@@ -176,13 +176,13 @@
       "license": "ISC"
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
-      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/helper-validator-identifier": "^7.29.7",
         "js-tokens": "^4.0.0",
         "picocolors": "^1.1.1"
       },
@@ -191,9 +191,9 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.29.3",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.3.tgz",
-      "integrity": "sha512-LIVqM46zQWZhj17qA8wb4nW/ixr2y1Nw+r1etiAWgRM6U1IqP+LNhL1yg440jYZR72jCWcWbLWzIosH+uP1fqg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -201,21 +201,21 @@
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
-      "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.29.0",
-        "@babel/generator": "^7.29.0",
-        "@babel/helper-compilation-targets": "^7.28.6",
-        "@babel/helper-module-transforms": "^7.28.6",
-        "@babel/helpers": "^7.28.6",
-        "@babel/parser": "^7.29.0",
-        "@babel/template": "^7.28.6",
-        "@babel/traverse": "^7.29.0",
-        "@babel/types": "^7.29.0",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "@jridgewell/remapping": "^2.3.5",
         "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
@@ -232,14 +232,14 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.29.1",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
-      "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.8.tgz",
+      "integrity": "sha512-gZbepsdh3WDtgZKWL+vTPh71LSBrm/Y4/QDZBVCcYfmeTEEuoOYwlSy+G1StfJg+/Zy550u/3TATbm7qDbbMtg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.29.0",
-        "@babel/types": "^7.29.0",
+        "@babel/parser": "^7.29.8",
+        "@babel/types": "^7.29.8",
         "@jridgewell/gen-mapping": "^0.3.12",
         "@jridgewell/trace-mapping": "^0.3.28",
         "jsesc": "^3.0.2"
@@ -249,14 +249,14 @@
       }
     },
     "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
-      "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/compat-data": "^7.28.6",
-        "@babel/helper-validator-option": "^7.27.1",
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
         "browserslist": "^4.24.0",
         "lru-cache": "^5.1.1",
         "semver": "^6.3.1"
@@ -266,9 +266,9 @@
       }
     },
     "node_modules/@babel/helper-globals": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
-      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -276,29 +276,29 @@
       }
     },
     "node_modules/@babel/helper-module-imports": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
-      "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/traverse": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
-      "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-module-imports": "^7.28.6",
-        "@babel/helper-validator-identifier": "^7.28.5",
-        "@babel/traverse": "^7.28.6"
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -318,9 +318,9 @@
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -328,9 +328,9 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -338,9 +338,9 @@
       }
     },
     "node_modules/@babel/helper-validator-option": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
-      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -348,27 +348,27 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.29.2",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.2.tgz",
-      "integrity": "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/template": "^7.28.6",
-        "@babel/types": "^7.29.0"
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.29.3",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
-      "integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.8.tgz",
+      "integrity": "sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.29.0"
+        "@babel/types": "^7.29.8"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -640,33 +640,33 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
-      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.28.6",
-        "@babel/parser": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
-      "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.8.tgz",
+      "integrity": "sha512-I5z7H3bf/41ktsNVLtpN0wAa336HkqIHQ5BuPLEhTkt1jVSyZpeNKIzTgEWmlxjdg81R0IgUCcaE+Ok3NvrfZg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.29.0",
-        "@babel/generator": "^7.29.0",
-        "@babel/helper-globals": "^7.28.0",
-        "@babel/parser": "^7.29.0",
-        "@babel/template": "^7.28.6",
-        "@babel/types": "^7.29.0",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.8",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.8",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.8",
         "debug": "^4.3.1"
       },
       "engines": {
@@ -674,14 +674,14 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
-      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.8.tgz",
+      "integrity": "sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.28.5"
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1991,9 +1991,9 @@
       }
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
+      "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2499,9 +2499,9 @@
       "license": "MIT"
     },
     "node_modules/@jest/reporters/node_modules/brace-expansion": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4309,9 +4309,9 @@
       }
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.28",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.28.tgz",
-      "integrity": "sha512-Ic44hnOtFIgravCunj1ifSoQPSUrkNiJuH9Mf6jr2jjoA74icqV8wU0KuadXeOR8zuIJMOoTv0GuQjZ9ZYNMeA==",
+      "version": "2.11.12",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.12.tgz",
+      "integrity": "sha512-r7WnVImvVCeFpf2DOXfy41aPWzeNg3H/A2X4dKmy1QL0MSyyk/e7z8ihJ3N6Nn2PsdhkVlqnEfnUE4a05P2aTA==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -4339,16 +4339,16 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/braces": {
@@ -4365,9 +4365,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.28.2",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
-      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
+      "version": "4.28.7",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.7.tgz",
+      "integrity": "sha512-JxV13hNrFxqjOc8alRbq9dK1MM79NEXYpma2B2J4wAtpWS5zIEIKqWPGCl7N4o7Uc7B7itylh7SuDujATRyyTw==",
       "dev": true,
       "funding": [
         {
@@ -4385,10 +4385,10 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "baseline-browser-mapping": "^2.10.12",
-        "caniuse-lite": "^1.0.30001782",
-        "electron-to-chromium": "^1.5.328",
-        "node-releases": "^2.0.36",
+        "baseline-browser-mapping": "^2.10.44",
+        "caniuse-lite": "^1.0.30001806",
+        "electron-to-chromium": "^1.5.393",
+        "node-releases": "^2.0.51",
         "update-browserslist-db": "^1.2.3"
       },
       "bin": {
@@ -4521,9 +4521,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001792",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001792.tgz",
-      "integrity": "sha512-hVLMUZFgR4JJ6ACt1uEESvQN1/dBVqPAKY0hgrV70eN3391K6juAfTjKZLKvOMsx8PxA7gsY1/tLMMTcfFLLpw==",
+      "version": "1.0.30001806",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001806.tgz",
+      "integrity": "sha512-72Cuvd95zbSYPKq6Fhg8eDJRlzgWDf7/mtoZv6Qe/DYNCEBdNxoA3+rZAU2ZhGCpZlns3EssFavaZomckT5Uuw==",
       "dev": true,
       "funding": [
         {
@@ -5207,9 +5207,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.353",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.353.tgz",
-      "integrity": "sha512-kOrWphBi8TOZyiJZqsgqIle0lw+tzmnQK83pV9dZUd01Nm2POECSyFQMAuarzZdYqQW7FH9RaYOuaRo3h+bQ3w==",
+      "version": "1.5.401",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.401.tgz",
+      "integrity": "sha512-H6ViHN68nGYlChEvlIU67fn8O2/tpbWQPwck98yaJmh+08LSvHiydzDQ6oXNccLU3kNRVIRS9A4mA7CG+i6fLQ==",
       "dev": true,
       "license": "ISC"
     },
@@ -5735,9 +5735,9 @@
       }
     },
     "node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "dev": true,
       "funding": [
         {
@@ -6333,9 +6333,9 @@
       }
     },
     "node_modules/immutable": {
-      "version": "4.3.8",
-      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.8.tgz",
-      "integrity": "sha512-d/Ld9aLbKpNwyl0KiM2CT1WYvkitQ1TSvmRtkcV8FKStiDoA7Slzgjmb/1G2yhKM1p0XeNOieaTbFZmU1d3Xuw==",
+      "version": "4.3.9",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.9.tgz",
+      "integrity": "sha512-ObHy4YN7ycwZOUCLI1/6svfyAFu7vL8RhAvVu/bh/RZW9EPlOyDaQ9jDQWCtdqzaXUjgXZCW1migtHE7YI7UGQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -6471,9 +6471,9 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
-      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.4.0.tgz",
+      "integrity": "sha512-oSK96Grm3aP6OrS263xVxbNDGVL7rzBtYdpGqlDG8iQdoenDoTs/nkki+DflYbAEE8Xl6o5YxhxlrKvI3nqKXQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6926,9 +6926,9 @@
       "license": "MIT"
     },
     "node_modules/jest-config/node_modules/brace-expansion": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7494,9 +7494,9 @@
       "license": "MIT"
     },
     "node_modules/jest-runtime/node_modules/brace-expansion": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7707,10 +7707,20 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -8252,9 +8262,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.12",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "version": "3.3.17",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
+      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
       "dev": true,
       "funding": [
         {
@@ -8295,11 +8305,14 @@
       "license": "MIT"
     },
     "node_modules/node-releases": {
-      "version": "2.0.38",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.38.tgz",
-      "integrity": "sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw==",
+      "version": "2.0.52",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.52.tgz",
+      "integrity": "sha512-MRlTqhAfoMx/4mhEbPo3Hi02g9LJZaJkka69V6h67Cb1gjrAG0jsTE4CZX1eptNx+VCAwJmfpnDIF4P0Nh1A7A==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/normalize-package-data": {
       "version": "3.0.3",
@@ -8798,9 +8811,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.14",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
-      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
+      "version": "8.5.25",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.25.tgz",
+      "integrity": "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==",
       "dev": true,
       "funding": [
         {
@@ -8818,7 +8831,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -9465,9 +9478,9 @@
       "license": "MIT"
     },
     "node_modules/reg-cli/node_modules/brace-expansion": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10177,9 +10190,9 @@
       "license": "MIT"
     },
     "node_modules/serve-handler/node_modules/brace-expansion": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -11093,9 +11106,9 @@
       "license": "MIT"
     },
     "node_modules/test-exclude/node_modules/brace-expansion": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -11533,9 +11546,9 @@
       "license": "MIT"
     },
     "node_modules/vite": {
-      "version": "6.4.2",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.2.tgz",
-      "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
+      "version": "6.4.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.3.tgz",
+      "integrity": "sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5196,12 +5196,12 @@
       }
     },
     "node_modules/drupal-twig-extensions": {
-      "version": "1.0.0-beta.5",
-      "resolved": "git+ssh://git@github.com/civictheme/drupal-twig-extensions.git#092058b870917ffd6e15ce07503e32a471484147",
+      "version": "1.0.0-beta.5.ct.1",
+      "resolved": "git+ssh://git@github.com/civictheme/drupal-twig-extensions.git#a893a09d3526c0de0f5414ddc5d24755479ef46f",
       "dev": true,
       "license": "(MIT OR GPL-2.0-only)",
       "dependencies": {
-        "drupal-attribute": "^1.0.2",
+        "@civictheme/drupal-attribute": "^2.0.1",
         "locutus": "^3.0.24",
         "lodash.clonedeep": "^4.5.0"
       }
@@ -11608,26 +11608,18 @@
       }
     },
     "node_modules/vite-plugin-twig-drupal": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/vite-plugin-twig-drupal/-/vite-plugin-twig-drupal-1.7.0.tgz",
-      "integrity": "sha512-yJI5JHm+COQObytCrxiuWanh5m6fZuy2MrIsPFJeeAIPG/OBW2wpdq2q7xLk5Nd+gfzT133j+L6zTmSyYWzOJw==",
+      "version": "1.7.1-ct.1",
+      "resolved": "git+ssh://git@github.com/civictheme/vite-plugin-twig-drupal.git#752b285ac7aa66e83e5560af0d120ccf52957b57",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "drupal-attribute": "^1.0.2",
-        "drupal-twig-extensions": "^1.0.0-beta.5",
+        "@civictheme/drupal-attribute": "^2.0.1",
+        "drupal-twig-extensions": "github:civictheme/drupal-twig-extensions#semver:^1.0.0-beta.5.ct.1",
         "twig": "^1.16.0 || ^2 || ^3"
       },
       "peerDependencies": {
         "vite": "^4.4.11 || ^5 || ^6 || ^7 || ^8"
       }
-    },
-    "node_modules/vite-plugin-twig-drupal/node_modules/drupal-attribute": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/drupal-attribute/-/drupal-attribute-1.2.1.tgz",
-      "integrity": "sha512-SM0Htd9sBEM08X9/6uqIgm9PzWWKY/Bdef/xsuaTzzzmv6eKPuin1QgwY+Vsp3lX4uYWgrKzXehpp6vqFmpxDQ==",
-      "dev": true,
-      "license": "MIT License"
     },
     "node_modules/vite/node_modules/fdir": {
       "version": "6.5.0",
@@ -12064,7 +12056,7 @@
         "stylelint-config-standard-scss": "^17.0.0",
         "twig-testing-library": "^1.2.0",
         "vite": "^6.3.5",
-        "vite-plugin-twig-drupal": "^1.7.0"
+        "vite-plugin-twig-drupal": "git+https://github.com/civictheme/vite-plugin-twig-drupal.git#semver:^1.7.1-ct.1"
       },
       "engines": {
         "node": ">=22.6.0"
@@ -12106,7 +12098,7 @@
         "stylelint-config-standard-scss": "^17.0.0",
         "twig-testing-library": "^1.2.0",
         "vite": "^6.3.5",
-        "vite-plugin-twig-drupal": "^1.7.0"
+        "vite-plugin-twig-drupal": "git+https://github.com/civictheme/vite-plugin-twig-drupal.git#semver:^1.7.1-ct.1"
       },
       "engines": {
         "node": ">=22.6.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -762,6 +762,16 @@
         "@keyv/serialize": "^1.1.1"
       }
     },
+    "node_modules/@civictheme/drupal-attribute": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@civictheme/drupal-attribute/-/drupal-attribute-2.0.0.tgz",
+      "integrity": "sha512-Uj9BpGrHC5GM82amQ/8A5sn8bH+/9JpnkfZCaxnESkaKLCOUh5bEEcuUQqVf6gJ1tGBS1/kQVdjK2jIIPL88VA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/@civictheme/scss-variables-extractor": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/@civictheme/scss-variables-extractor/-/scss-variables-extractor-0.2.1.tgz",
@@ -1939,16 +1949,6 @@
         }
       }
     },
-    "node_modules/@isaacs/cliui": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-9.0.0.tgz",
-      "integrity": "sha512-AokJm4tuBHillT+FpMtxQ60n8ObyXBatq7jD2/JA9dxbDDokKQm8KMht5ibGzLVU9IJDIKK4TPKgMHEYMn3lMg==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
@@ -2699,469 +2699,12 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
-    "node_modules/@jsonjoy.com/base64": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@jsonjoy.com/base64/-/base64-1.1.2.tgz",
-      "integrity": "sha512-q6XAnWQDIMA3+FTiOYajoYqySkO+JSat0ytXGSuRdq9uXE7o92gzuQwQM14xaCRlBLGq3v5miDGC4vkVTn54xA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=10.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/streamich"
-      },
-      "peerDependencies": {
-        "tslib": "2"
-      }
-    },
-    "node_modules/@jsonjoy.com/buffers": {
-      "version": "17.67.0",
-      "resolved": "https://registry.npmjs.org/@jsonjoy.com/buffers/-/buffers-17.67.0.tgz",
-      "integrity": "sha512-tfExRpYxBvi32vPs9ZHaTjSP4fHAfzSmcahOfNxtvGHcyJel+aibkPlGeBB+7AoC6hL7lXIE++8okecBxx7lcw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=10.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/streamich"
-      },
-      "peerDependencies": {
-        "tslib": "2"
-      }
-    },
-    "node_modules/@jsonjoy.com/codegen": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@jsonjoy.com/codegen/-/codegen-1.0.0.tgz",
-      "integrity": "sha512-E8Oy+08cmCf0EK/NMxpaJZmOxPqM+6iSe2S4nlSBrPZOORoDJILxtbSUEDKQyTamm/BVAhIGllOBNU79/dwf0g==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=10.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/streamich"
-      },
-      "peerDependencies": {
-        "tslib": "2"
-      }
-    },
-    "node_modules/@jsonjoy.com/fs-core": {
-      "version": "4.57.2",
-      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-core/-/fs-core-4.57.2.tgz",
-      "integrity": "sha512-SVjwklkpIV5wrynpYtuYnfYH1QF4/nDuLBX7VXdb+3miglcAgBVZb/5y0cOsehRV/9Vb+3UqhkMq3/NR3ztdkQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@jsonjoy.com/fs-node-builtins": "4.57.2",
-        "@jsonjoy.com/fs-node-utils": "4.57.2",
-        "thingies": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=10.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/streamich"
-      },
-      "peerDependencies": {
-        "tslib": "2"
-      }
-    },
-    "node_modules/@jsonjoy.com/fs-fsa": {
-      "version": "4.57.2",
-      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-fsa/-/fs-fsa-4.57.2.tgz",
-      "integrity": "sha512-fhO8+iR2I+OCw668ISDJdn1aArc9zx033sWejIyzQ8RBeXa9bDSaUeA3ix0poYOfrj1KdOzytmYNv2/uLDfV6g==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@jsonjoy.com/fs-core": "4.57.2",
-        "@jsonjoy.com/fs-node-builtins": "4.57.2",
-        "@jsonjoy.com/fs-node-utils": "4.57.2",
-        "thingies": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=10.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/streamich"
-      },
-      "peerDependencies": {
-        "tslib": "2"
-      }
-    },
-    "node_modules/@jsonjoy.com/fs-node": {
-      "version": "4.57.2",
-      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node/-/fs-node-4.57.2.tgz",
-      "integrity": "sha512-nX2AdL6cOFwLdju9G4/nbRnYevmCJbh7N7hvR3gGm97Cs60uEjyd0rpR+YBS7cTg175zzl22pGKXR5USaQMvKg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@jsonjoy.com/fs-core": "4.57.2",
-        "@jsonjoy.com/fs-node-builtins": "4.57.2",
-        "@jsonjoy.com/fs-node-utils": "4.57.2",
-        "@jsonjoy.com/fs-print": "4.57.2",
-        "@jsonjoy.com/fs-snapshot": "4.57.2",
-        "glob-to-regex.js": "^1.0.0",
-        "thingies": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=10.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/streamich"
-      },
-      "peerDependencies": {
-        "tslib": "2"
-      }
-    },
-    "node_modules/@jsonjoy.com/fs-node-builtins": {
-      "version": "4.57.2",
-      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node-builtins/-/fs-node-builtins-4.57.2.tgz",
-      "integrity": "sha512-xhiegylRmhw43Ki2HO1ZBL7DQ5ja/qpRsL29VtQ2xuUHiuDGbgf2uD4p9Qd8hJI5P6RCtGYD50IXHXVq/Ocjcg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=10.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/streamich"
-      },
-      "peerDependencies": {
-        "tslib": "2"
-      }
-    },
-    "node_modules/@jsonjoy.com/fs-node-to-fsa": {
-      "version": "4.57.2",
-      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node-to-fsa/-/fs-node-to-fsa-4.57.2.tgz",
-      "integrity": "sha512-18LmWTSONhoAPW+IWRuf8w/+zRolPFGPeGwMxlAhhfY11EKzX+5XHDBPAw67dBF5dxDErHJbl40U+3IXSDRXSQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@jsonjoy.com/fs-fsa": "4.57.2",
-        "@jsonjoy.com/fs-node-builtins": "4.57.2",
-        "@jsonjoy.com/fs-node-utils": "4.57.2"
-      },
-      "engines": {
-        "node": ">=10.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/streamich"
-      },
-      "peerDependencies": {
-        "tslib": "2"
-      }
-    },
-    "node_modules/@jsonjoy.com/fs-node-utils": {
-      "version": "4.57.2",
-      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node-utils/-/fs-node-utils-4.57.2.tgz",
-      "integrity": "sha512-rsPSJgekz43IlNbLyAM/Ab+ouYLWGp5DDBfYBNNEqDaSpsbXfthBn29Q4muFA9L0F+Z3mKo+CWlgSCXrf+mOyQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@jsonjoy.com/fs-node-builtins": "4.57.2"
-      },
-      "engines": {
-        "node": ">=10.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/streamich"
-      },
-      "peerDependencies": {
-        "tslib": "2"
-      }
-    },
-    "node_modules/@jsonjoy.com/fs-print": {
-      "version": "4.57.2",
-      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-print/-/fs-print-4.57.2.tgz",
-      "integrity": "sha512-wK9NSow48i4DbDl9F1CQE5TqnyZOJ04elU3WFG5aJ76p+YxO/ulyBBQvKsessPxdo381Bc2pcEoyPujMOhcRqQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@jsonjoy.com/fs-node-utils": "4.57.2",
-        "tree-dump": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=10.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/streamich"
-      },
-      "peerDependencies": {
-        "tslib": "2"
-      }
-    },
-    "node_modules/@jsonjoy.com/fs-snapshot": {
-      "version": "4.57.2",
-      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-snapshot/-/fs-snapshot-4.57.2.tgz",
-      "integrity": "sha512-GdduDZuoP5V/QCgJkx9+BZ6SC0EZ/smXAdTS7PfMqgMTGXLlt/bH/FqMYaqB9JmLf05sJPtO0XRbAwwkEEPbVw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@jsonjoy.com/buffers": "^17.65.0",
-        "@jsonjoy.com/fs-node-utils": "4.57.2",
-        "@jsonjoy.com/json-pack": "^17.65.0",
-        "@jsonjoy.com/util": "^17.65.0"
-      },
-      "engines": {
-        "node": ">=10.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/streamich"
-      },
-      "peerDependencies": {
-        "tslib": "2"
-      }
-    },
-    "node_modules/@jsonjoy.com/fs-snapshot/node_modules/@jsonjoy.com/base64": {
-      "version": "17.67.0",
-      "resolved": "https://registry.npmjs.org/@jsonjoy.com/base64/-/base64-17.67.0.tgz",
-      "integrity": "sha512-5SEsJGsm15aP8TQGkDfJvz9axgPwAEm98S5DxOuYe8e1EbfajcDmgeXXzccEjh+mLnjqEKrkBdjHWS5vFNwDdw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=10.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/streamich"
-      },
-      "peerDependencies": {
-        "tslib": "2"
-      }
-    },
-    "node_modules/@jsonjoy.com/fs-snapshot/node_modules/@jsonjoy.com/codegen": {
-      "version": "17.67.0",
-      "resolved": "https://registry.npmjs.org/@jsonjoy.com/codegen/-/codegen-17.67.0.tgz",
-      "integrity": "sha512-idnkUplROpdBOV0HMcwhsCUS5TRUi9poagdGs70A6S4ux9+/aPuKbh8+UYRTLYQHtXvAdNfQWXDqZEx5k4Dj2Q==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=10.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/streamich"
-      },
-      "peerDependencies": {
-        "tslib": "2"
-      }
-    },
-    "node_modules/@jsonjoy.com/fs-snapshot/node_modules/@jsonjoy.com/json-pack": {
-      "version": "17.67.0",
-      "resolved": "https://registry.npmjs.org/@jsonjoy.com/json-pack/-/json-pack-17.67.0.tgz",
-      "integrity": "sha512-t0ejURcGaZsn1ClbJ/3kFqSOjlryd92eQY465IYrezsXmPcfHPE/av4twRSxf6WE+TkZgLY+71vCZbiIiFKA/w==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@jsonjoy.com/base64": "17.67.0",
-        "@jsonjoy.com/buffers": "17.67.0",
-        "@jsonjoy.com/codegen": "17.67.0",
-        "@jsonjoy.com/json-pointer": "17.67.0",
-        "@jsonjoy.com/util": "17.67.0",
-        "hyperdyperid": "^1.2.0",
-        "thingies": "^2.5.0",
-        "tree-dump": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=10.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/streamich"
-      },
-      "peerDependencies": {
-        "tslib": "2"
-      }
-    },
-    "node_modules/@jsonjoy.com/fs-snapshot/node_modules/@jsonjoy.com/json-pointer": {
-      "version": "17.67.0",
-      "resolved": "https://registry.npmjs.org/@jsonjoy.com/json-pointer/-/json-pointer-17.67.0.tgz",
-      "integrity": "sha512-+iqOFInH+QZGmSuaybBUNdh7yvNrXvqR+h3wjXm0N/3JK1EyyFAeGJvqnmQL61d1ARLlk/wJdFKSL+LHJ1eaUA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@jsonjoy.com/util": "17.67.0"
-      },
-      "engines": {
-        "node": ">=10.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/streamich"
-      },
-      "peerDependencies": {
-        "tslib": "2"
-      }
-    },
-    "node_modules/@jsonjoy.com/fs-snapshot/node_modules/@jsonjoy.com/util": {
-      "version": "17.67.0",
-      "resolved": "https://registry.npmjs.org/@jsonjoy.com/util/-/util-17.67.0.tgz",
-      "integrity": "sha512-6+8xBaz1rLSohlGh68D1pdw3AwDi9xydm8QNlAFkvnavCJYSze+pxoW2VKP8p308jtlMRLs5NTHfPlZLd4w7ew==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@jsonjoy.com/buffers": "17.67.0",
-        "@jsonjoy.com/codegen": "17.67.0"
-      },
-      "engines": {
-        "node": ">=10.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/streamich"
-      },
-      "peerDependencies": {
-        "tslib": "2"
-      }
-    },
-    "node_modules/@jsonjoy.com/json-pack": {
-      "version": "1.21.0",
-      "resolved": "https://registry.npmjs.org/@jsonjoy.com/json-pack/-/json-pack-1.21.0.tgz",
-      "integrity": "sha512-+AKG+R2cfZMShzrF2uQw34v3zbeDYUqnQ+jg7ORic3BGtfw9p/+N6RJbq/kkV8JmYZaINknaEQ2m0/f693ZPpg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@jsonjoy.com/base64": "^1.1.2",
-        "@jsonjoy.com/buffers": "^1.2.0",
-        "@jsonjoy.com/codegen": "^1.0.0",
-        "@jsonjoy.com/json-pointer": "^1.0.2",
-        "@jsonjoy.com/util": "^1.9.0",
-        "hyperdyperid": "^1.2.0",
-        "thingies": "^2.5.0",
-        "tree-dump": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=10.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/streamich"
-      },
-      "peerDependencies": {
-        "tslib": "2"
-      }
-    },
-    "node_modules/@jsonjoy.com/json-pack/node_modules/@jsonjoy.com/buffers": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@jsonjoy.com/buffers/-/buffers-1.2.1.tgz",
-      "integrity": "sha512-12cdlDwX4RUM3QxmUbVJWqZ/mrK6dFQH4Zxq6+r1YXKXYBNgZXndx2qbCJwh3+WWkCSn67IjnlG3XYTvmvYtgA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=10.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/streamich"
-      },
-      "peerDependencies": {
-        "tslib": "2"
-      }
-    },
-    "node_modules/@jsonjoy.com/json-pointer": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@jsonjoy.com/json-pointer/-/json-pointer-1.0.2.tgz",
-      "integrity": "sha512-Fsn6wM2zlDzY1U+v4Nc8bo3bVqgfNTGcn6dMgs6FjrEnt4ZCe60o6ByKRjOGlI2gow0aE/Q41QOigdTqkyK5fg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@jsonjoy.com/codegen": "^1.0.0",
-        "@jsonjoy.com/util": "^1.9.0"
-      },
-      "engines": {
-        "node": ">=10.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/streamich"
-      },
-      "peerDependencies": {
-        "tslib": "2"
-      }
-    },
-    "node_modules/@jsonjoy.com/util": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@jsonjoy.com/util/-/util-1.9.0.tgz",
-      "integrity": "sha512-pLuQo+VPRnN8hfPqUTLTHk126wuYdXVxE6aDmjSeV4NCAgyxWbiOIeNJVtID3h1Vzpoi9m4jXezf73I6LgabgQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@jsonjoy.com/buffers": "^1.0.0",
-        "@jsonjoy.com/codegen": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=10.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/streamich"
-      },
-      "peerDependencies": {
-        "tslib": "2"
-      }
-    },
-    "node_modules/@jsonjoy.com/util/node_modules/@jsonjoy.com/buffers": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@jsonjoy.com/buffers/-/buffers-1.2.1.tgz",
-      "integrity": "sha512-12cdlDwX4RUM3QxmUbVJWqZ/mrK6dFQH4Zxq6+r1YXKXYBNgZXndx2qbCJwh3+WWkCSn67IjnlG3XYTvmvYtgA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=10.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/streamich"
-      },
-      "peerDependencies": {
-        "tslib": "2"
-      }
-    },
     "node_modules/@keyv/serialize": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@keyv/serialize/-/serialize-1.1.1.tgz",
       "integrity": "sha512-dXn3FZhPv0US+7dtJsIi2R+c7qWYiReoEh5zUntWCf4oSpMNib8FDhSoed6m3QyZdx5hK7iLFkYk3rNxwt8vTA==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@ljharb/resumer": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/@ljharb/resumer/-/resumer-0.1.3.tgz",
-      "integrity": "sha512-d+tsDgfkj9X5QTriqM4lKesCkMMJC3IrbPKHvayP00ELx2axdXvDfWkqjxrLXIzGcQzmj7VAUT1wopqARTvafw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@ljharb/through": "^2.3.13",
-        "call-bind": "^1.0.7"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/@ljharb/through": {
-      "version": "2.3.14",
-      "resolved": "https://registry.npmjs.org/@ljharb/through/-/through-2.3.14.tgz",
-      "integrity": "sha512-ajBvlKpWucBB17FuQYUShqpqy8GRgYEpJW0vWJbUu1CV9lWyrDCapy0lScU8T8Z6qn49sSwJB3+M+evYIdGg+A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.8"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
     },
     "node_modules/@mdx-js/react": {
       "version": "3.1.1",
@@ -3179,119 +2722,6 @@
       "peerDependencies": {
         "@types/react": ">=16",
         "react": ">=16"
-      }
-    },
-    "node_modules/@nightlycommit/rollup-plugin-package-manifest": {
-      "version": "1.0.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/@nightlycommit/rollup-plugin-package-manifest/-/rollup-plugin-package-manifest-1.0.0-alpha.2.tgz",
-      "integrity": "sha512-RlgDuWTBWiCjC5VKRKS4KJIv90yZM0Z9ghZ9kttxSCrwJDshXhR6NUwKKm1kD/RSaCxaxiLUIsn24pnEU+yrVQ==",
-      "dev": true,
-      "license": "MIT License",
-      "dependencies": {
-        "find-up": "^7.0.0",
-        "package-manifest-generator": "^1.0.0-beta.4"
-      }
-    },
-    "node_modules/@nightlycommit/rollup-plugin-package-manifest/node_modules/find-up": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-7.0.0.tgz",
-      "integrity": "sha512-YyZM99iHrqLKjmt4LJDj58KI+fYyufRLBSYcqycxf//KpBk9FoewoGX0450m9nB44qrZnovzC2oeP5hUibxc/g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "locate-path": "^7.2.0",
-        "path-exists": "^5.0.0",
-        "unicorn-magic": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@nightlycommit/rollup-plugin-package-manifest/node_modules/locate-path": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-7.2.0.tgz",
-      "integrity": "sha512-gvVijfZvn7R+2qyPX8mAuKcFGDf6Nc61GdvGafQsHL0sBIxfKzA+usWn4GFC/bk+QdwPUD4kWFJLhElipq+0VA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "p-locate": "^6.0.0"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@nightlycommit/rollup-plugin-package-manifest/node_modules/p-limit": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-4.0.0.tgz",
-      "integrity": "sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "yocto-queue": "^1.0.0"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@nightlycommit/rollup-plugin-package-manifest/node_modules/p-locate": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-6.0.0.tgz",
-      "integrity": "sha512-wPrq66Llhl7/4AGC6I+cqxT07LhXvWL08LNXz1fENOw0Ap4sRZZ/gZpTTJ5jpurzzzfS2W/Ge9BY3LgLjCShcw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "p-limit": "^4.0.0"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@nightlycommit/rollup-plugin-package-manifest/node_modules/path-exists": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-5.0.0.tgz",
-      "integrity": "sha512-RjhtfwJOxzcFmNOi6ltcbcu4Iu+FL3zEj83dk4kAS+fVpTxXLO1b38RvJgT/0QwvV/L3aY9TAnyv0EOqW4GoMQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      }
-    },
-    "node_modules/@nightlycommit/rollup-plugin-package-manifest/node_modules/unicorn-magic": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.1.0.tgz",
-      "integrity": "sha512-lRfVq8fE8gz6QMBuDM6a+LO3IAzTi05H6gCVaUpir2E1Rwpo4ZUog45KpNXKC/Mn3Yb9UDuHumeFTo9iV/D9FQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@nightlycommit/rollup-plugin-package-manifest/node_modules/yocto-queue": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.2.2.tgz",
-      "integrity": "sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12.20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -3427,42 +2857,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/@rollup/pluginutils": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.3.0.tgz",
-      "integrity": "sha512-5EdhGZtnu3V88ces7s53hhfK5KSASnJZv8Lulpc04cWO3REESroJXg73DFsOmgbU2BhwV0E20bu2IDZb3VKW4Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/estree": "^1.0.0",
-        "estree-walker": "^2.0.2",
-        "picomatch": "^4.0.2"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "peerDependencies": {
-        "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
-      },
-      "peerDependenciesMeta": {
-        "rollup": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@rollup/pluginutils/node_modules/picomatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
@@ -4402,18 +3796,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/tape": {
-      "version": "5.8.1",
-      "resolved": "https://registry.npmjs.org/@types/tape/-/tape-5.8.1.tgz",
-      "integrity": "sha512-vRjK+E1c+I4WRDSXcYfgepPjz2Knh+gulU3359LrR9H2KM8AyiMbNmX7W5aMlw7JFoXMpVOhq3bEIm78qakGbQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@ljharb/through": "*",
-        "@types/node": "*",
-        "mock-property": "*"
-      }
-    },
     "node_modules/@types/tough-cookie": {
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
@@ -4505,22 +3887,6 @@
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
-      }
-    },
-    "node_modules/@vitrail/rollup-plugin-typescript": {
-      "version": "1.0.4-beta.0",
-      "resolved": "https://registry.npmjs.org/@vitrail/rollup-plugin-typescript/-/rollup-plugin-typescript-1.0.4-beta.0.tgz",
-      "integrity": "sha512-Rm93FOQkVWq5+l26JpbcQ/yuOhK60r5Iris2Fp9yvyVyljXa5buXvnDyJ3g2Xo2Kqc8dZEQPCfUJbQX91otCEQ==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@rollup/pluginutils": "^5.1.0",
-        "memfs": "^4.6.0",
-        "typescript": "^5.3.3"
-      },
-      "peerDependencies": {
-        "tslib": "^2.6.2",
-        "typescript": "^5.3.3"
       }
     },
     "node_modules/@whitespace/storybook-addon-html": {
@@ -4661,84 +4027,6 @@
         "node": ">=6.0"
       }
     },
-    "node_modules/array-buffer-byte-length": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.2.tgz",
-      "integrity": "sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.3",
-        "is-array-buffer": "^3.0.5"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/array.prototype.every": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/array.prototype.every/-/array.prototype.every-1.1.7.tgz",
-      "integrity": "sha512-BIP72rKvrKd08ptbetLb4qvrlGjkv30yOKgKcTtOIbHyQt3shr/jyOzdApiCOh3LPYrpJo5M6i0zmVldOF2pUw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.2",
-        "define-properties": "^1.2.1",
-        "es-abstract": "^1.23.5",
-        "es-object-atoms": "^1.0.0",
-        "is-string": "^1.1.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/array.prototype.flatmap": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.3.3.tgz",
-      "integrity": "sha512-Y7Wt51eKJSyi80hFrJCePGGNo5ktJCslFuboqJsbf57CCPcm5zztluPlc4/aD8sWsKvlwatezpV4U1efk8kpjg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.8",
-        "define-properties": "^1.2.1",
-        "es-abstract": "^1.23.5",
-        "es-shim-unscopables": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/arraybuffer.prototype.slice": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.4.tgz",
-      "integrity": "sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "array-buffer-byte-length": "^1.0.1",
-        "call-bind": "^1.0.8",
-        "define-properties": "^1.2.1",
-        "es-abstract": "^1.23.5",
-        "es-errors": "^1.3.0",
-        "get-intrinsic": "^1.2.6",
-        "is-array-buffer": "^3.0.4"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/arrify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
@@ -4780,32 +4068,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/async-function": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/async-function/-/async-function-1.0.0.tgz",
-      "integrity": "sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/available-typed-arrays": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
-      "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "possible-typed-array-names": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/b4a": {
@@ -5218,56 +4480,6 @@
       "license": "MIT",
       "dependencies": {
         "@keyv/serialize": "^1.1.1"
-      }
-    },
-    "node_modules/call-bind": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
-      "integrity": "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind-apply-helpers": "^1.0.2",
-        "es-define-property": "^1.0.1",
-        "get-intrinsic": "^1.3.0",
-        "set-function-length": "^1.2.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/call-bind-apply-helpers": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
-      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "function-bind": "^1.1.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/call-bound": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
-      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind-apply-helpers": "^1.0.2",
-        "get-intrinsic": "^1.3.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/callsites": {
@@ -5734,60 +4946,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/data-view-buffer": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.2.tgz",
-      "integrity": "sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.3",
-        "es-errors": "^1.3.0",
-        "is-data-view": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/data-view-byte-length": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/data-view-byte-length/-/data-view-byte-length-1.0.2.tgz",
-      "integrity": "sha512-tuhGbE6CfTM9+5ANGf+oQb72Ky/0+s3xKUpHvShfiz2RxMFgFPjsXuRLBVMtvMs15awe45SRb83D6wH4ew6wlQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.3",
-        "es-errors": "^1.3.0",
-        "is-data-view": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/inspect-js"
-      }
-    },
-    "node_modules/data-view-byte-offset": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/data-view-byte-offset/-/data-view-byte-offset-1.0.1.tgz",
-      "integrity": "sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.2",
-        "es-errors": "^1.3.0",
-        "is-data-view": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -5882,39 +5040,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/deep-equal": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-2.2.3.tgz",
-      "integrity": "sha512-ZIwpnevOurS8bpT4192sqAowWM76JDKSHYzMLty3BZGSswgq6pBaH3DhCSW5xVAZICZyKdOBPjwww5wfgT/6PA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "array-buffer-byte-length": "^1.0.0",
-        "call-bind": "^1.0.5",
-        "es-get-iterator": "^1.1.3",
-        "get-intrinsic": "^1.2.2",
-        "is-arguments": "^1.1.1",
-        "is-array-buffer": "^3.0.2",
-        "is-date-object": "^1.0.5",
-        "is-regex": "^1.1.4",
-        "is-shared-array-buffer": "^1.0.2",
-        "isarray": "^2.0.5",
-        "object-is": "^1.1.5",
-        "object-keys": "^1.1.1",
-        "object.assign": "^4.1.4",
-        "regexp.prototype.flags": "^1.5.1",
-        "side-channel": "^1.0.4",
-        "which-boxed-primitive": "^1.0.2",
-        "which-collection": "^1.0.1",
-        "which-typed-array": "^1.1.13"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -5962,24 +5087,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/define-data-property": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
-      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "es-define-property": "^1.0.0",
-        "es-errors": "^1.3.0",
-        "gopd": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/define-lazy-prop": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
@@ -5991,34 +5098,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/define-properties": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
-      "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "define-data-property": "^1.0.1",
-        "has-property-descriptors": "^1.0.0",
-        "object-keys": "^1.1.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/defined": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.1.tgz",
-      "integrity": "sha512-hsBd2qSVCRE+5PmNdHt1uzyrFu5d3RwmFDKzyNZMFq/EwDNJF7Ee5+D5oEKF0hU6LhtoUF1macFvOe4AskQC1Q==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/degenerator": {
@@ -6105,69 +5184,16 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/dotignore": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/dotignore/-/dotignore-0.1.2.tgz",
-      "integrity": "sha512-UGGGWfSauusaVJC+8fgV+NVvBXkCTmVv7sk6nojDZZvuOUNGUy0Zk4UpHQD6EDjS0jpBwcACvH4eofvyzBcRDw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "minimatch": "^3.0.4"
-      },
-      "bin": {
-        "ignored": "bin/ignored"
-      }
-    },
-    "node_modules/dotignore/node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/dotignore/node_modules/brace-expansion": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "node_modules/dotignore/node_modules/minimatch": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/drupal-attribute": {
-      "version": "1.2.2",
-      "resolved": "git+ssh://git@gitlab.com/richardgaunt/drupal-attribute.git#8ba9e77760b35a68c34bf5795fecab1963759f4d",
+      "name": "@civictheme/drupal-attribute",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@civictheme/drupal-attribute/-/drupal-attribute-2.0.0.tgz",
+      "integrity": "sha512-Uj9BpGrHC5GM82amQ/8A5sn8bH+/9JpnkfZCaxnESkaKLCOUh5bEEcuUQqVf6gJ1tGBS1/kQVdjK2jIIPL88VA==",
       "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@nightlycommit/rollup-plugin-package-manifest": "^1.0.0-alpha.2",
-        "@types/node": "^16.18.126",
-        "@types/tape": "^5.8.1",
-        "@vitrail/rollup-plugin-typescript": "^1.0.4-beta.0",
-        "tape": "^5.9.0"
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=20"
       }
-    },
-    "node_modules/drupal-attribute/node_modules/@types/node": {
-      "version": "16.18.126",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.126.tgz",
-      "integrity": "sha512-OTcgaiwfGFBKacvfwuHzzn1KLxH/er8mluiy8/uM3sGXHaRe73RrSIj01jow9t4kJEW633Ov+cOexXeiApTyAw==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/drupal-twig-extensions": {
       "version": "1.0.0-beta.5",
@@ -6178,21 +5204,6 @@
         "drupal-attribute": "^1.0.2",
         "locutus": "^3.0.24",
         "lodash.clonedeep": "^4.5.0"
-      }
-    },
-    "node_modules/dunder-proto": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
-      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind-apply-helpers": "^1.0.1",
-        "es-errors": "^1.3.0",
-        "gopd": "^1.2.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
       }
     },
     "node_modules/electron-to-chromium": {
@@ -6265,85 +5276,6 @@
         "is-arrayish": "^0.2.1"
       }
     },
-    "node_modules/es-abstract": {
-      "version": "1.24.2",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.24.2.tgz",
-      "integrity": "sha512-2FpH9Q5i2RRwyEP1AylXe6nYLR5OhaJTZwmlcP0dL/+JCbgg7yyEo/sEK6HeGZRf3dFpWwThaRHVApXSkW3xeg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "array-buffer-byte-length": "^1.0.2",
-        "arraybuffer.prototype.slice": "^1.0.4",
-        "available-typed-arrays": "^1.0.7",
-        "call-bind": "^1.0.8",
-        "call-bound": "^1.0.4",
-        "data-view-buffer": "^1.0.2",
-        "data-view-byte-length": "^1.0.2",
-        "data-view-byte-offset": "^1.0.1",
-        "es-define-property": "^1.0.1",
-        "es-errors": "^1.3.0",
-        "es-object-atoms": "^1.1.1",
-        "es-set-tostringtag": "^2.1.0",
-        "es-to-primitive": "^1.3.0",
-        "function.prototype.name": "^1.1.8",
-        "get-intrinsic": "^1.3.0",
-        "get-proto": "^1.0.1",
-        "get-symbol-description": "^1.1.0",
-        "globalthis": "^1.0.4",
-        "gopd": "^1.2.0",
-        "has-property-descriptors": "^1.0.2",
-        "has-proto": "^1.2.0",
-        "has-symbols": "^1.1.0",
-        "hasown": "^2.0.2",
-        "internal-slot": "^1.1.0",
-        "is-array-buffer": "^3.0.5",
-        "is-callable": "^1.2.7",
-        "is-data-view": "^1.0.2",
-        "is-negative-zero": "^2.0.3",
-        "is-regex": "^1.2.1",
-        "is-set": "^2.0.3",
-        "is-shared-array-buffer": "^1.0.4",
-        "is-string": "^1.1.1",
-        "is-typed-array": "^1.1.15",
-        "is-weakref": "^1.1.1",
-        "math-intrinsics": "^1.1.0",
-        "object-inspect": "^1.13.4",
-        "object-keys": "^1.1.1",
-        "object.assign": "^4.1.7",
-        "own-keys": "^1.0.1",
-        "regexp.prototype.flags": "^1.5.4",
-        "safe-array-concat": "^1.1.3",
-        "safe-push-apply": "^1.0.0",
-        "safe-regex-test": "^1.1.0",
-        "set-proto": "^1.0.0",
-        "stop-iteration-iterator": "^1.1.0",
-        "string.prototype.trim": "^1.2.10",
-        "string.prototype.trimend": "^1.0.9",
-        "string.prototype.trimstart": "^1.0.8",
-        "typed-array-buffer": "^1.0.3",
-        "typed-array-byte-length": "^1.0.3",
-        "typed-array-byte-offset": "^1.0.4",
-        "typed-array-length": "^1.0.7",
-        "unbox-primitive": "^1.1.0",
-        "which-typed-array": "^1.1.19"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/es-define-property": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
-      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
     "node_modules/es-errors": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
@@ -6352,87 +5284,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
-      }
-    },
-    "node_modules/es-get-iterator": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/es-get-iterator/-/es-get-iterator-1.1.3.tgz",
-      "integrity": "sha512-sPZmqHBe6JIiTfN5q2pEi//TwxmAFHwj/XEuYjTuse78i8KxaqMTTzxPoFKuzRpDpTJ+0NAbpfenkmH2rePtuw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.2",
-        "get-intrinsic": "^1.1.3",
-        "has-symbols": "^1.0.3",
-        "is-arguments": "^1.1.1",
-        "is-map": "^2.0.2",
-        "is-set": "^2.0.2",
-        "is-string": "^1.0.7",
-        "isarray": "^2.0.5",
-        "stop-iteration-iterator": "^1.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/es-object-atoms": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
-      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/es-set-tostringtag": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
-      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "get-intrinsic": "^1.2.6",
-        "has-tostringtag": "^1.0.2",
-        "hasown": "^2.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/es-shim-unscopables": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/es-shim-unscopables/-/es-shim-unscopables-1.1.0.tgz",
-      "integrity": "sha512-d9T8ucsEhh8Bi1woXCf+TIKDIROLG5WCkxg8geBCbvk22kzwC5G2OnXVMO6FUsvQlgUUXQ2itephWDLqDzbeCw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "hasown": "^2.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/es-to-primitive": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.3.0.tgz",
-      "integrity": "sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-callable": "^1.2.7",
-        "is-date-object": "^1.0.5",
-        "is-symbol": "^1.0.4"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/esbuild": {
@@ -6693,13 +5544,6 @@
       "engines": {
         "node": ">=4.0"
       }
-    },
-    "node_modules/estree-walker": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
-      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/esutils": {
       "version": "2.0.3",
@@ -7021,45 +5865,12 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/for-each": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
-      "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-callable": "^1.2.7"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/foreachasync": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/foreachasync/-/foreachasync-3.0.0.tgz",
       "integrity": "sha512-J+ler7Ta54FwwNcx6wQRDhTIbNeyDcARMkOcguEqnEdtm0jKvN3Li3PDAb2Du3ubJYEWfYL83XMROXdsXAXycw==",
       "dev": true,
       "license": "Apache2"
-    },
-    "node_modules/foreground-child": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
-      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "cross-spawn": "^7.0.6",
-        "signal-exit": "^4.0.1"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
     },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
@@ -7091,47 +5902,6 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/function.prototype.name": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.8.tgz",
-      "integrity": "sha512-e5iwyodOHhbMr/yNrc7fDYG4qlbIvI5gajyzPnb5TCwyhjApznQh1BMFou9b30SevY43gCJKXycoCBjMbsuW0Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.8",
-        "call-bound": "^1.0.3",
-        "define-properties": "^1.2.1",
-        "functions-have-names": "^1.2.3",
-        "hasown": "^2.0.2",
-        "is-callable": "^1.2.7"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/functions-have-names": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
-      "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/generator-function": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/generator-function/-/generator-function-2.0.1.tgz",
-      "integrity": "sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
       }
     },
     "node_modules/gensync": {
@@ -7167,31 +5937,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/get-intrinsic": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
-      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind-apply-helpers": "^1.0.2",
-        "es-define-property": "^1.0.1",
-        "es-errors": "^1.3.0",
-        "es-object-atoms": "^1.1.1",
-        "function-bind": "^1.1.2",
-        "get-proto": "^1.0.1",
-        "gopd": "^1.2.0",
-        "has-symbols": "^1.1.0",
-        "hasown": "^2.0.2",
-        "math-intrinsics": "^1.1.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/get-package-type": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
@@ -7200,20 +5945,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8.0.0"
-      }
-    },
-    "node_modules/get-proto": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
-      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "dunder-proto": "^1.0.1",
-        "es-object-atoms": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
       }
     },
     "node_modules/get-stream": {
@@ -7227,24 +5958,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/get-symbol-description": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.1.0.tgz",
-      "integrity": "sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.3",
-        "es-errors": "^1.3.0",
-        "get-intrinsic": "^1.2.6"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/get-uri": {
@@ -7291,23 +6004,6 @@
       },
       "engines": {
         "node": ">=10.13.0"
-      }
-    },
-    "node_modules/glob-to-regex.js": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/glob-to-regex.js/-/glob-to-regex.js-1.2.0.tgz",
-      "integrity": "sha512-QMwlOQKU/IzqMUOAZWubUOT8Qft+Y0KQWnX9nK3ch0CJg0tTp4TvGZsTfudYKv2NzoQSyPcnA6TYeIQ3jGichQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=10.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/streamich"
-      },
-      "peerDependencies": {
-        "tslib": "2"
       }
     },
     "node_modules/global-modules": {
@@ -7364,23 +6060,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/globalthis": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
-      "integrity": "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "define-properties": "^1.2.1",
-        "gopd": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/globby": {
       "version": "14.1.0",
       "resolved": "https://registry.npmjs.org/globby/-/globby-14.1.0.tgz",
@@ -7432,19 +6111,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/gopd": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
-      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
@@ -7462,37 +6128,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/has-bigints": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.1.0.tgz",
-      "integrity": "sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/has-dynamic-import": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/has-dynamic-import/-/has-dynamic-import-2.1.1.tgz",
-      "integrity": "sha512-DuTCn6K/RW8S27npDMumGKsjG6HE7MxzedZka5tJP+9dqfxks+UMqKBmeCijHtIhsBEZPlbMg0qMHi2nKYVtKQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.8",
-        "call-bound": "^1.0.3",
-        "get-intrinsic": "^1.2.6"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -7501,64 +6136,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/has-property-descriptors": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
-      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "es-define-property": "^1.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/has-proto": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.2.0.tgz",
-      "integrity": "sha512-KIL7eQPfHQRC8+XluaIw7BHUwwqL19bQn4hzNgdr+1wXoU0KKj6rufu47lhY7KbJR2C6T6+PfyN0Ea7wkSS+qQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "dunder-proto": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/has-symbols": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
-      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/has-tostringtag": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
-      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "has-symbols": "^1.0.3"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/hashery": {
@@ -7712,16 +6289,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/typicode"
-      }
-    },
-    "node_modules/hyperdyperid": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/hyperdyperid/-/hyperdyperid-1.2.0.tgz",
-      "integrity": "sha512-Y93lCzHYgGWdrJ66yIktxiaGULYc6oGiABxhcO5AufBeOyoIdZF7bIfLaOrbM0iGIOXQQgxxRrFEnb+Y6w1n4A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.18"
       }
     },
     "node_modules/iconv-lite": {
@@ -7903,21 +6470,6 @@
         }
       }
     },
-    "node_modules/internal-slot": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.1.0.tgz",
-      "integrity": "sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "hasown": "^2.0.2",
-        "side-channel": "^1.1.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
     "node_modules/ip-address": {
       "version": "10.2.0",
       "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
@@ -7928,113 +6480,12 @@
         "node": ">= 12"
       }
     },
-    "node_modules/is-arguments": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.2.0.tgz",
-      "integrity": "sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.2",
-        "has-tostringtag": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-array-buffer": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.5.tgz",
-      "integrity": "sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.8",
-        "call-bound": "^1.0.3",
-        "get-intrinsic": "^1.2.6"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
       "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/is-async-function": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/is-async-function/-/is-async-function-2.1.1.tgz",
-      "integrity": "sha512-9dgM/cZBnNvjzaMYHVoxxfPj2QXt22Ev7SuuPrs+xav0ukGB0S6d4ydZdEiM48kLx5kDV+QBPrpVnFyefL8kkQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "async-function": "^1.0.0",
-        "call-bound": "^1.0.3",
-        "get-proto": "^1.0.1",
-        "has-tostringtag": "^1.0.2",
-        "safe-regex-test": "^1.1.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-bigint": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.1.0.tgz",
-      "integrity": "sha512-n4ZT37wG78iz03xPRKJrHTdZbe3IicyucEtdRsV5yglwc3GyUfbAfpSeD0FJ41NbUNSt5wbhqfp1fS+BgnvDFQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "has-bigints": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-boolean-object": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.2.2.tgz",
-      "integrity": "sha512-wa56o2/ElJMYqjCjGkXri7it5FbebW5usLw/nPmCMs5DeZ7eziSYZhSmPRn0txqeW4LnAmQQU7FgqLpsEFKM4A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.3",
-        "has-tostringtag": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-callable": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
-      "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
     },
     "node_modules/is-core-module": {
       "version": "2.16.2",
@@ -8044,41 +6495,6 @@
       "license": "MIT",
       "dependencies": {
         "hasown": "^2.0.3"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-data-view": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-data-view/-/is-data-view-1.0.2.tgz",
-      "integrity": "sha512-RKtWF8pGmS87i2D6gqQu/l7EYRlVdfzemCJN/P3UOs//x1QE7mfhvzHIApBTRf7axvT6DMGwSwBXYCT0nfB9xw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.2",
-        "get-intrinsic": "^1.2.6",
-        "is-typed-array": "^1.1.13"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-date-object": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.1.0.tgz",
-      "integrity": "sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.2",
-        "has-tostringtag": "^1.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -8113,22 +6529,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/is-finalizationregistry": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/is-finalizationregistry/-/is-finalizationregistry-1.1.1.tgz",
-      "integrity": "sha512-1pC6N8qWJbWoPtEjgcL2xyhQOP491EQjeUo3qTKcmV8YSDDJrOepfG8pcC7h/QgnQHYSv0mJ3Z/ZWxmatVrysg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.3"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
@@ -8147,26 +6547,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/is-generator-function": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.2.tgz",
-      "integrity": "sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.4",
-        "generator-function": "^2.0.0",
-        "get-proto": "^1.0.1",
-        "has-tostringtag": "^1.0.2",
-        "safe-regex-test": "^1.1.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-glob": {
@@ -8201,32 +6581,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/is-map": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.3.tgz",
-      "integrity": "sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-negative-zero": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.3.tgz",
-      "integrity": "sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -8235,23 +6589,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
-      }
-    },
-    "node_modules/is-number-object": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.1.1.tgz",
-      "integrity": "sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.3",
-        "has-tostringtag": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-path-cwd": {
@@ -8307,54 +6644,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/is-regex": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
-      "integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.2",
-        "gopd": "^1.2.0",
-        "has-tostringtag": "^1.0.2",
-        "hasown": "^2.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-set": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.3.tgz",
-      "integrity": "sha512-iPAjerrse27/ygGLxw+EBR9agv9Y6uLeYVJMu+QNCoouJ1/1ri0mGrcWpfCqFZuzzx3WjtwxG098X+n4OuRkPg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-shared-array-buffer": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.4.tgz",
-      "integrity": "sha512-ISWac8drv4ZGfwKl5slpHG9OwPNty4jOWPRIhBpxOoD+hqITiwuipOQ2bNthAzwA3B4fIjO4Nln74N0S9byq8A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.3"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/is-stream": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
@@ -8366,103 +6655,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/is-string": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.1.1.tgz",
-      "integrity": "sha512-BtEeSsoaQjlSPBemMQIrY1MY0uM6vnS1g5fmufYOtnxLGUZM2178PKbhsk7Ffv58IX+ZtcvoGwccYsh0PglkAA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.3",
-        "has-tostringtag": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-symbol": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.1.1.tgz",
-      "integrity": "sha512-9gGx6GTtCQM73BgmHQXfDmLtfjjTUDSyoxTCbp5WtoixAhfgsDirWIcVQ/IHpvI5Vgd5i/J5F7B9cN/WlVbC/w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.2",
-        "has-symbols": "^1.1.0",
-        "safe-regex-test": "^1.1.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-typed-array": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
-      "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "which-typed-array": "^1.1.16"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-weakmap": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.2.tgz",
-      "integrity": "sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-weakref": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.1.1.tgz",
-      "integrity": "sha512-6i9mGWSlqzNMEqpCp93KwRS1uUOodk2OJ6b+sq7ZPDSy2WuI5NFIxp/254TytR8ftefexkWn5xNiHUNpPOfSew==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.3"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-weakset": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.4.tgz",
-      "integrity": "sha512-mfcwb6IzQyOKTs84CQMrOwW4gQcaTOAWJ0zzJCl2WSPDrWk/OzDaImWFH3djXhb24g4eudZfLRozAvPGw4d9hQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.3",
-        "get-intrinsic": "^1.2.6"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-wsl": {
@@ -8480,13 +6672,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/isarray": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
-      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -8577,22 +6762,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/jackspeak": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.2.3.tgz",
-      "integrity": "sha512-ykkVRwrYvFm1nb2AJfKKYPr0emF6IiXDYUaFx4Zn9ZuIH7MrzEZ3sD5RlqGXNRpHtvUHJyOnCEFxOlNDtGo7wg==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "@isaacs/cliui": "^9.0.0"
-      },
-      "engines": {
-        "node": "20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/jest": {
@@ -9839,16 +8008,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/math-intrinsics": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
-      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
     "node_modules/mathml-tag-names": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/mathml-tag-names/-/mathml-tag-names-4.0.0.tgz",
@@ -9879,36 +8038,6 @@
       "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
       "dev": true,
       "license": "CC0-1.0"
-    },
-    "node_modules/memfs": {
-      "version": "4.57.2",
-      "resolved": "https://registry.npmjs.org/memfs/-/memfs-4.57.2.tgz",
-      "integrity": "sha512-2nWzSsJzrukurSDna4Z0WywuScK4Id3tSKejgu74u8KCdW4uNrseKRSIDg75C6Yw5ZRqBe0F0EtMNlTbUq8bAQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@jsonjoy.com/fs-core": "4.57.2",
-        "@jsonjoy.com/fs-fsa": "4.57.2",
-        "@jsonjoy.com/fs-node": "4.57.2",
-        "@jsonjoy.com/fs-node-builtins": "4.57.2",
-        "@jsonjoy.com/fs-node-to-fsa": "4.57.2",
-        "@jsonjoy.com/fs-node-utils": "4.57.2",
-        "@jsonjoy.com/fs-print": "4.57.2",
-        "@jsonjoy.com/fs-snapshot": "4.57.2",
-        "@jsonjoy.com/json-pack": "^1.11.0",
-        "@jsonjoy.com/util": "^1.9.0",
-        "glob-to-regex.js": "^1.0.1",
-        "thingies": "^2.5.0",
-        "tree-dump": "^1.0.3",
-        "tslib": "^2.0.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/streamich"
-      },
-      "peerDependencies": {
-        "tslib": "2"
-      }
     },
     "node_modules/meow": {
       "version": "9.0.0",
@@ -10050,16 +8179,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/minimist": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
-      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/minimist-options": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/minimist-options/-/minimist-options-4.1.0.tgz",
@@ -10103,28 +8222,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/mock-property": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/mock-property/-/mock-property-1.1.0.tgz",
-      "integrity": "sha512-1/JjbLoGwv87xVsutkX0XJc0M0W4kb40cZl/K41xtTViBOD9JuFPKfyMNTrLJ/ivYAd0aPqu/vduamXO0emTFQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "define-data-property": "^1.1.4",
-        "functions-have-names": "^1.2.3",
-        "gopd": "^1.0.1",
-        "has-property-descriptors": "^1.0.2",
-        "hasown": "^2.0.2",
-        "isarray": "^2.0.5",
-        "object-inspect": "^1.13.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/ms": {
@@ -10188,25 +8285,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4.0"
-      }
-    },
-    "node_modules/node-exports-info": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/node-exports-info/-/node-exports-info-1.6.0.tgz",
-      "integrity": "sha512-pyFS63ptit/P5WqUkt+UUfe+4oevH+bFeIiPPdfb0pFeYEu/1ELnJu5l+5EcTKYL5M7zaAa7S8ddywgXypqKCw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "array.prototype.flatmap": "^1.3.3",
-        "es-errors": "^1.3.0",
-        "object.entries": "^1.1.9",
-        "semver": "^6.3.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/node-int64": {
@@ -10282,83 +8360,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/object-inspect": {
-      "version": "1.13.4",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
-      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/object-is": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.6.tgz",
-      "integrity": "sha512-F8cZ+KfGlSGi09lJT7/Nd6KJZ9ygtvYC0/UYYLI9nmQKLMnydpB9yvbv9K1uSkEu7FU9vYPmVwLg328tX+ot3Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.7",
-        "define-properties": "^1.2.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/object-keys": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/object.assign": {
-      "version": "4.1.7",
-      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.7.tgz",
-      "integrity": "sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.8",
-        "call-bound": "^1.0.3",
-        "define-properties": "^1.2.1",
-        "es-object-atoms": "^1.0.0",
-        "has-symbols": "^1.1.0",
-        "object-keys": "^1.1.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/object.entries": {
-      "version": "1.1.9",
-      "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.9.tgz",
-      "integrity": "sha512-8u/hfXFRBD1O0hPUjioLhoWFHRmt6tKA4/vZPyckBr18l1KE9uHrFaFaUi8MDRTpi4uak2goyPTSNJLXX2k2Hw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.8",
-        "call-bound": "^1.0.4",
-        "define-properties": "^1.2.1",
-        "es-object-atoms": "^1.1.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -10420,24 +8421,6 @@
       },
       "engines": {
         "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/own-keys": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/own-keys/-/own-keys-1.0.1.tgz",
-      "integrity": "sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "get-intrinsic": "^1.2.6",
-        "object-keys": "^1.1.1",
-        "safe-push-apply": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/p-limit": {
@@ -10527,79 +8510,6 @@
       },
       "engines": {
         "node": ">= 14"
-      }
-    },
-    "node_modules/package-json-from-dist": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
-      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
-      "dev": true,
-      "license": "BlueOak-1.0.0"
-    },
-    "node_modules/package-manifest-generator": {
-      "version": "1.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/package-manifest-generator/-/package-manifest-generator-1.0.0-beta.4.tgz",
-      "integrity": "sha512-44+KZce77R4tz7EqLuLsPfYn6OE7PqgT4rD9PpF9DM1uxLgT2muaxeXQXjdLsv/Q/C/oUxulKmWikDXWdeGsAw==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "commander": "^12.1.0",
-        "find-up": "^5.0.0",
-        "glob": "^11.0.0",
-        "toml": "^3.0.0",
-        "typescript": "5.5"
-      },
-      "bin": {
-        "pmg": "pmg.mjs"
-      }
-    },
-    "node_modules/package-manifest-generator/node_modules/commander": {
-      "version": "12.1.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
-      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/package-manifest-generator/node_modules/glob": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-11.1.0.tgz",
-      "integrity": "sha512-vuNwKSaKiqm7g0THUBu2x7ckSs3XJLXE+2ssL7/MfTGPLLcrJQ/4Uq1CjPTtO5cCIiRxqvN6Twy1qOwhL0Xjcw==",
-      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "foreground-child": "^3.3.1",
-        "jackspeak": "^4.1.1",
-        "minimatch": "^10.1.1",
-        "minipass": "^7.1.2",
-        "package-json-from-dist": "^1.0.0",
-        "path-scurry": "^2.0.0"
-      },
-      "bin": {
-        "glob": "dist/esm/bin.mjs"
-      },
-      "engines": {
-        "node": "20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/package-manifest-generator/node_modules/typescript": {
-      "version": "5.5.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.4.tgz",
-      "integrity": "sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
       }
     },
     "node_modules/parent-module": {
@@ -10885,16 +8795,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=14.19.0"
-      }
-    },
-    "node_modules/possible-typed-array-names": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
-      "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
       }
     },
     "node_modules/postcss": {
@@ -11526,29 +9426,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/reflect.getprototypeof": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
-      "integrity": "sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.8",
-        "define-properties": "^1.2.1",
-        "es-abstract": "^1.23.9",
-        "es-errors": "^1.3.0",
-        "es-object-atoms": "^1.0.0",
-        "get-intrinsic": "^1.2.7",
-        "get-proto": "^1.0.1",
-        "which-builtin-type": "^1.2.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/reg-cli": {
       "version": "0.18.16",
       "resolved": "https://registry.npmjs.org/reg-cli/-/reg-cli-0.18.16.tgz",
@@ -11655,27 +9532,6 @@
       "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/regexp.prototype.flags": {
-      "version": "1.5.4",
-      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
-      "integrity": "sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.8",
-        "define-properties": "^1.2.1",
-        "es-errors": "^1.3.0",
-        "get-proto": "^1.0.1",
-        "gopd": "^1.2.0",
-        "set-function-name": "^2.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
     },
     "node_modules/require-directory": {
       "version": "2.1.1",
@@ -11877,61 +9733,6 @@
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.1.0"
-      }
-    },
-    "node_modules/safe-array-concat": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.4.tgz",
-      "integrity": "sha512-wtZlHyOje6OZTGqAoaDKxFkgRtkF9CnHAVnCHKfuj200wAgL+bSJhdsCD2l0Qx/2ekEXjPWcyKkfGb5CPboslg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.9",
-        "call-bound": "^1.0.4",
-        "get-intrinsic": "^1.3.0",
-        "has-symbols": "^1.1.0",
-        "isarray": "^2.0.5"
-      },
-      "engines": {
-        "node": ">=0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/safe-push-apply": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/safe-push-apply/-/safe-push-apply-1.0.0.tgz",
-      "integrity": "sha512-iKE9w/Z7xCzUMIZqdBsp6pEQvwuEebH4vdpjcDWnyzaI6yl6O9FHvVpmGelvEHNsoY6wGblkxR6Zty/h00WiSA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "isarray": "^2.0.5"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/safe-regex-test": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
-      "integrity": "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.2",
-        "es-errors": "^1.3.0",
-        "is-regex": "^1.2.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/safer-buffer": {
@@ -12399,55 +10200,6 @@
         "node": "*"
       }
     },
-    "node_modules/set-function-length": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
-      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "define-data-property": "^1.1.4",
-        "es-errors": "^1.3.0",
-        "function-bind": "^1.1.2",
-        "get-intrinsic": "^1.2.4",
-        "gopd": "^1.0.1",
-        "has-property-descriptors": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/set-function-name": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.2.tgz",
-      "integrity": "sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "define-data-property": "^1.1.4",
-        "es-errors": "^1.3.0",
-        "functions-have-names": "^1.2.3",
-        "has-property-descriptors": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/set-proto": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/set-proto/-/set-proto-1.0.0.tgz",
-      "integrity": "sha512-RJRdvCo6IAnPdsvP/7m6bsQqNnn1FCBX5ZNtFL98MmFF/4xAIJTIg1YbHW5DC2W5SKZanrC6i4HsJqlajw/dZw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "dunder-proto": "^1.0.1",
-        "es-errors": "^1.3.0",
-        "es-object-atoms": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -12469,82 +10221,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/side-channel": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
-      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3",
-        "side-channel-list": "^1.0.0",
-        "side-channel-map": "^1.0.1",
-        "side-channel-weakmap": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/side-channel-list": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
-      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.4"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/side-channel-map": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
-      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.2",
-        "es-errors": "^1.3.0",
-        "get-intrinsic": "^1.2.5",
-        "object-inspect": "^1.13.3"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/side-channel-weakmap": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
-      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.2",
-        "es-errors": "^1.3.0",
-        "get-intrinsic": "^1.2.5",
-        "object-inspect": "^1.13.3",
-        "side-channel-map": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/signal-exit": {
@@ -12733,20 +10409,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/stop-iteration-iterator": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.1.0.tgz",
-      "integrity": "sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "internal-slot": "^1.1.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
     "node_modules/storybook": {
       "version": "10.2.13",
       "resolved": "https://registry.npmjs.org/storybook/-/storybook-10.2.13.tgz",
@@ -12866,65 +10528,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
-      }
-    },
-    "node_modules/string.prototype.trim": {
-      "version": "1.2.10",
-      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.10.tgz",
-      "integrity": "sha512-Rs66F0P/1kedk5lyYyH9uBzuiI/kNRmwJAR9quK6VOtIpZ2G+hMZd+HQbbv25MgCA6gEffoMZYxlTod4WcdrKA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.8",
-        "call-bound": "^1.0.2",
-        "define-data-property": "^1.1.4",
-        "define-properties": "^1.2.1",
-        "es-abstract": "^1.23.5",
-        "es-object-atoms": "^1.0.0",
-        "has-property-descriptors": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/string.prototype.trimend": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.9.tgz",
-      "integrity": "sha512-G7Ok5C6E/j4SGfyLCloXTrngQIQU3PWtXGst3yM7Bea9FRURf1S42ZHlZZtsNque2FN2PoUhfZXYLNWwEr4dLQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.8",
-        "call-bound": "^1.0.2",
-        "define-properties": "^1.2.1",
-        "es-object-atoms": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/string.prototype.trimstart": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.8.tgz",
-      "integrity": "sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.7",
-        "define-properties": "^1.2.1",
-        "es-object-atoms": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/strip-ansi": {
@@ -13429,120 +11032,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/tape": {
-      "version": "5.9.0",
-      "resolved": "https://registry.npmjs.org/tape/-/tape-5.9.0.tgz",
-      "integrity": "sha512-czbGgxSVwRlbB3Ly/aqQrNwrDAzKHDW/kVXegp4hSFmR2c8qqm3hCgZbUy1+3QAQFGhPDG7J56UsV1uNilBFCA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@ljharb/resumer": "^0.1.3",
-        "@ljharb/through": "^2.3.13",
-        "array.prototype.every": "^1.1.6",
-        "call-bind": "^1.0.7",
-        "deep-equal": "^2.2.3",
-        "defined": "^1.0.1",
-        "dotignore": "^0.1.2",
-        "for-each": "^0.3.3",
-        "get-package-type": "^0.1.0",
-        "glob": "^7.2.3",
-        "has-dynamic-import": "^2.1.0",
-        "hasown": "^2.0.2",
-        "inherits": "^2.0.4",
-        "is-regex": "^1.1.4",
-        "minimist": "^1.2.8",
-        "mock-property": "^1.1.0",
-        "object-inspect": "^1.13.2",
-        "object-is": "^1.1.6",
-        "object-keys": "^1.1.1",
-        "object.assign": "^4.1.5",
-        "resolve": "^2.0.0-next.5",
-        "string.prototype.trim": "^1.2.9"
-      },
-      "bin": {
-        "tape": "bin/tape"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/tape/node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/tape/node_modules/brace-expansion": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "node_modules/tape/node_modules/glob": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.1.1",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/tape/node_modules/minimatch": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/tape/node_modules/resolve": {
-      "version": "2.0.0-next.6",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.6.tgz",
-      "integrity": "sha512-3JmVl5hMGtJ3kMmB3zi3DL25KfkCEyy3Tw7Gmw7z5w8M9WlwoPFnIvwChzu1+cF3iaK3sp18hhPz8ANeimdJfA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "is-core-module": "^2.16.1",
-        "node-exports-info": "^1.6.0",
-        "object-keys": "^1.1.1",
-        "path-parse": "^1.0.7",
-        "supports-preserve-symlinks-flag": "^1.0.0"
-      },
-      "bin": {
-        "resolve": "bin/resolve"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/tar-fs": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.2.tgz",
@@ -13657,23 +11146,6 @@
       "license": "Apache-2.0",
       "dependencies": {
         "b4a": "^1.6.4"
-      }
-    },
-    "node_modules/thingies": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/thingies/-/thingies-2.6.0.tgz",
-      "integrity": "sha512-rMHRjmlFLM1R96UYPvpmnc3LYtdFrT33JIB7L9hetGue1qAPfn1N2LJeEjxUSidu1Iku+haLZXDuEXUHNGO/lg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.18"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/streamich"
-      },
-      "peerDependencies": {
-        "tslib": "^2"
       }
     },
     "node_modules/tiny-invariant": {
@@ -13791,13 +11263,6 @@
         "node": ">=8.0"
       }
     },
-    "node_modules/toml": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/toml/-/toml-3.0.0.tgz",
-      "integrity": "sha512-y/mWCZinnvxjTKYhJ+pYxwD0mRLVvOtdS2Awbgxln6iEnt4rk0yBxeSBHkGJcPucRiG0e55mwWp+g/05rsrd6w==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/tough-cookie": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
@@ -13822,23 +11287,6 @@
       },
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/tree-dump": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/tree-dump/-/tree-dump-1.1.0.tgz",
-      "integrity": "sha512-rMuvhU4MCDbcbnleZTFezWsaZXRFemSqAM+7jPnzUl1fo9w3YEKOxAeui0fz3OI4EU4hf23iyA7uQRVko+UaBA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=10.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/streamich"
-      },
-      "peerDependencies": {
-        "tslib": "2"
       }
     },
     "node_modules/trim-newlines": {
@@ -13937,123 +11385,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/typed-array-buffer": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
-      "integrity": "sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.3",
-        "es-errors": "^1.3.0",
-        "is-typed-array": "^1.1.14"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/typed-array-byte-length": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/typed-array-byte-length/-/typed-array-byte-length-1.0.3.tgz",
-      "integrity": "sha512-BaXgOuIxz8n8pIq3e7Atg/7s+DpiYrxn4vdot3w9KbnBhcRQq6o3xemQdIfynqSeXeDrF32x+WvfzmOjPiY9lg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.8",
-        "for-each": "^0.3.3",
-        "gopd": "^1.2.0",
-        "has-proto": "^1.2.0",
-        "is-typed-array": "^1.1.14"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/typed-array-byte-offset": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/typed-array-byte-offset/-/typed-array-byte-offset-1.0.4.tgz",
-      "integrity": "sha512-bTlAFB/FBYMcuX81gbL4OcpH5PmlFHqlCCpAl8AlEzMz5k53oNDvN8p1PNOWLEmI2x4orp3raOFB51tv9X+MFQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "available-typed-arrays": "^1.0.7",
-        "call-bind": "^1.0.8",
-        "for-each": "^0.3.3",
-        "gopd": "^1.2.0",
-        "has-proto": "^1.2.0",
-        "is-typed-array": "^1.1.15",
-        "reflect.getprototypeof": "^1.0.9"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/typed-array-length": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/typed-array-length/-/typed-array-length-1.0.7.tgz",
-      "integrity": "sha512-3KS2b+kL7fsuk/eJZ7EQdnEmQoaho/r6KUef7hxvltNA5DR8NAUM+8wJMbJyZ4G9/7i3v5zPBIMN5aybAh2/Jg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.7",
-        "for-each": "^0.3.3",
-        "gopd": "^1.0.1",
-        "is-typed-array": "^1.1.13",
-        "possible-typed-array-names": "^1.0.0",
-        "reflect.getprototypeof": "^1.0.6"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/typed-query-selector": {
       "version": "2.12.2",
       "resolved": "https://registry.npmjs.org/typed-query-selector/-/typed-query-selector-2.12.2.tgz",
       "integrity": "sha512-EOPFbyIub4ngnEdqi2yOcNeDLaX/0jcE1JoAXQDDMIthap7FoN795lc/SHfIq2d416VufXpM8z/lD+WRm2gfOQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
-      }
-    },
-    "node_modules/unbox-primitive": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.1.0.tgz",
-      "integrity": "sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.3",
-        "has-bigints": "^1.0.2",
-        "has-symbols": "^1.1.0",
-        "which-boxed-primitive": "^1.1.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
     },
     "node_modules/undici-types": {
       "version": "7.19.2",
@@ -14271,19 +11608,26 @@
       }
     },
     "node_modules/vite-plugin-twig-drupal": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/vite-plugin-twig-drupal/-/vite-plugin-twig-drupal-1.6.2.tgz",
-      "integrity": "sha512-L32LgWxpAsTC97QFepbWZ9Zbm1GS4B7uWCbkhujIMYQ3Yu5F9UUioMQ3L3/N8JoFYOMmlFNM3xC4EGR20oHbOg==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/vite-plugin-twig-drupal/-/vite-plugin-twig-drupal-1.7.0.tgz",
+      "integrity": "sha512-yJI5JHm+COQObytCrxiuWanh5m6fZuy2MrIsPFJeeAIPG/OBW2wpdq2q7xLk5Nd+gfzT133j+L6zTmSyYWzOJw==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "drupal-attribute": "^1.0.2",
         "drupal-twig-extensions": "^1.0.0-beta.5",
-        "twig": "^1.16.0"
+        "twig": "^1.16.0 || ^2 || ^3"
       },
       "peerDependencies": {
-        "vite": "^4.4.11 || ^5 || ^6 || ^7"
+        "vite": "^4.4.11 || ^5 || ^6 || ^7 || ^8"
       }
+    },
+    "node_modules/vite-plugin-twig-drupal/node_modules/drupal-attribute": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/drupal-attribute/-/drupal-attribute-1.2.1.tgz",
+      "integrity": "sha512-SM0Htd9sBEM08X9/6uqIgm9PzWWKY/Bdef/xsuaTzzzmv6eKPuin1QgwY+Vsp3lX4uYWgrKzXehpp6vqFmpxDQ==",
+      "dev": true,
+      "license": "MIT License"
     },
     "node_modules/vite/node_modules/fdir": {
       "version": "6.5.0",
@@ -14438,95 +11782,6 @@
       },
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/which-boxed-primitive": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.1.1.tgz",
-      "integrity": "sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-bigint": "^1.1.0",
-        "is-boolean-object": "^1.2.1",
-        "is-number-object": "^1.1.1",
-        "is-string": "^1.1.1",
-        "is-symbol": "^1.1.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/which-builtin-type": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/which-builtin-type/-/which-builtin-type-1.2.1.tgz",
-      "integrity": "sha512-6iBczoX+kDQ7a3+YJBnh3T+KZRxM/iYNPXicqk66/Qfm1b93iu+yOImkg0zHbj5LNOcNv1TEADiZ0xa34B4q6Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.2",
-        "function.prototype.name": "^1.1.6",
-        "has-tostringtag": "^1.0.2",
-        "is-async-function": "^2.0.0",
-        "is-date-object": "^1.1.0",
-        "is-finalizationregistry": "^1.1.0",
-        "is-generator-function": "^1.0.10",
-        "is-regex": "^1.2.1",
-        "is-weakref": "^1.0.2",
-        "isarray": "^2.0.5",
-        "which-boxed-primitive": "^1.1.0",
-        "which-collection": "^1.0.2",
-        "which-typed-array": "^1.1.16"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/which-collection": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/which-collection/-/which-collection-1.0.2.tgz",
-      "integrity": "sha512-K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-map": "^2.0.3",
-        "is-set": "^2.0.3",
-        "is-weakmap": "^2.0.2",
-        "is-weakset": "^2.0.3"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/which-typed-array": {
-      "version": "1.1.20",
-      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.20.tgz",
-      "integrity": "sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "available-typed-arrays": "^1.0.7",
-        "call-bind": "^1.0.8",
-        "call-bound": "^1.0.4",
-        "for-each": "^0.3.5",
-        "get-proto": "^1.0.1",
-        "gopd": "^1.2.0",
-        "has-tostringtag": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/word-wrap": {
@@ -14792,6 +12047,7 @@
         "@popperjs/core": "^2.11.8"
       },
       "devDependencies": {
+        "@civictheme/drupal-attribute": "^2.0.0",
         "@civictheme/scss-variables-extractor": "^0.2.1",
         "@storybook/addon-docs": "10.2.13",
         "@storybook/addon-links": "10.2.13",
@@ -14808,7 +12064,7 @@
         "stylelint-config-standard-scss": "^17.0.0",
         "twig-testing-library": "^1.2.0",
         "vite": "^6.3.5",
-        "vite-plugin-twig-drupal": "^1.6.0"
+        "vite-plugin-twig-drupal": "^1.7.0"
       },
       "engines": {
         "node": ">=22.6.0"
@@ -14833,6 +12089,7 @@
         "@popperjs/core": "^2.11.8"
       },
       "devDependencies": {
+        "@civictheme/drupal-attribute": "^2.0.0",
         "@civictheme/scss-variables-extractor": "^0.2.1",
         "@storybook/addon-docs": "10.2.13",
         "@storybook/addon-links": "10.2.13",
@@ -14849,7 +12106,7 @@
         "stylelint-config-standard-scss": "^17.0.0",
         "twig-testing-library": "^1.2.0",
         "vite": "^6.3.5",
-        "vite-plugin-twig-drupal": "^1.6.0"
+        "vite-plugin-twig-drupal": "^1.7.0"
       },
       "engines": {
         "node": ">=22.6.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -11848,9 +11848,9 @@
       "license": "ISC"
     },
     "node_modules/ws": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
-      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "version": "8.21.2",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.2.tgz",
+      "integrity": "sha512-54dMVAo4WIe6SKy3vBgN+9bJZqqQ8IMRevAkOLQALhi49qkkQDQfWdAZ8KQlXiEabw88ARXXdUrlvtbKQX+aKw==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -763,9 +763,9 @@
       }
     },
     "node_modules/@civictheme/drupal-attribute": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@civictheme/drupal-attribute/-/drupal-attribute-2.0.0.tgz",
-      "integrity": "sha512-Uj9BpGrHC5GM82amQ/8A5sn8bH+/9JpnkfZCaxnESkaKLCOUh5bEEcuUQqVf6gJ1tGBS1/kQVdjK2jIIPL88VA==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@civictheme/drupal-attribute/-/drupal-attribute-2.0.1.tgz",
+      "integrity": "sha512-9ivuchfqO7n9MTwwUabi2UBZ3wmdC3IF1ylulR+Ore5bQUEgTLkTGh867WCNiCuhEjNeprVzRA9vyUaNDJXM+w==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -5186,9 +5186,9 @@
     },
     "node_modules/drupal-attribute": {
       "name": "@civictheme/drupal-attribute",
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@civictheme/drupal-attribute/-/drupal-attribute-2.0.0.tgz",
-      "integrity": "sha512-Uj9BpGrHC5GM82amQ/8A5sn8bH+/9JpnkfZCaxnESkaKLCOUh5bEEcuUQqVf6gJ1tGBS1/kQVdjK2jIIPL88VA==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@civictheme/drupal-attribute/-/drupal-attribute-2.0.1.tgz",
+      "integrity": "sha512-9ivuchfqO7n9MTwwUabi2UBZ3wmdC3IF1ylulR+Ore5bQUEgTLkTGh867WCNiCuhEjNeprVzRA9vyUaNDJXM+w==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -5197,7 +5197,7 @@
     },
     "node_modules/drupal-twig-extensions": {
       "version": "1.0.0-beta.5",
-      "resolved": "git+ssh://git@github.com/richardgaunt/drupal-twig-extensions.git#092058b870917ffd6e15ce07503e32a471484147",
+      "resolved": "git+ssh://git@github.com/civictheme/drupal-twig-extensions.git#092058b870917ffd6e15ce07503e32a471484147",
       "dev": true,
       "license": "(MIT OR GPL-2.0-only)",
       "dependencies": {
@@ -12047,7 +12047,7 @@
         "@popperjs/core": "^2.11.8"
       },
       "devDependencies": {
-        "@civictheme/drupal-attribute": "^2.0.0",
+        "@civictheme/drupal-attribute": "^2.0.1",
         "@civictheme/scss-variables-extractor": "^0.2.1",
         "@storybook/addon-docs": "10.2.13",
         "@storybook/addon-links": "10.2.13",
@@ -12089,7 +12089,7 @@
         "@popperjs/core": "^2.11.8"
       },
       "devDependencies": {
-        "@civictheme/drupal-attribute": "^2.0.0",
+        "@civictheme/drupal-attribute": "^2.0.1",
         "@civictheme/scss-variables-extractor": "^0.2.1",
         "@storybook/addon-docs": "10.2.13",
         "@storybook/addon-links": "10.2.13",

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
       "storybook": "^10.0.0"
     },
     "twig": "^3.0.0",
-    "drupal-attribute": "git+https://gitlab.com/richardgaunt/drupal-attribute.git#8ba9e77760b35a68c34bf5795fecab1963759f4d",
+    "drupal-attribute": "npm:@civictheme/drupal-attribute@^2.0.0",
     "drupal-twig-extensions": "git+https://github.com/richardgaunt/drupal-twig-extensions.git#092058b870917ffd6e15ce07503e32a471484147"
   }
 }

--- a/package.json
+++ b/package.json
@@ -95,6 +95,6 @@
     },
     "twig": "^3.0.0",
     "drupal-attribute": "npm:@civictheme/drupal-attribute@^2.0.1",
-    "drupal-twig-extensions": "git+https://github.com/civictheme/drupal-twig-extensions.git#092058b870917ffd6e15ce07503e32a471484147"
+    "drupal-twig-extensions": "git+https://github.com/civictheme/drupal-twig-extensions.git#semver:^1.0.0-beta.5.ct.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
       "storybook": "^10.0.0"
     },
     "twig": "^3.0.0",
-    "drupal-attribute": "npm:@civictheme/drupal-attribute@^2.0.0",
-    "drupal-twig-extensions": "git+https://github.com/richardgaunt/drupal-twig-extensions.git#092058b870917ffd6e15ce07503e32a471484147"
+    "drupal-attribute": "npm:@civictheme/drupal-attribute@^2.0.1",
+    "drupal-twig-extensions": "git+https://github.com/civictheme/drupal-twig-extensions.git#092058b870917ffd6e15ce07503e32a471484147"
   }
 }

--- a/packages/sdc/components/00-base/datetime/datetime.test.js
+++ b/packages/sdc/components/00-base/datetime/datetime.test.js
@@ -1,4 +1,4 @@
-import DrupalAttribute from 'drupal-attribute';
+import DrupalAttribute from '@civictheme/drupal-attribute';
 
 const template = 'components/00-base/datetime/datetime.twig';
 

--- a/packages/sdc/components/00-base/grid/grid.stories.js
+++ b/packages/sdc/components/00-base/grid/grid.stories.js
@@ -2,7 +2,7 @@
  * CivicTheme Grid component stories.
  */
 
-import DrupalAttribute from 'drupal-attribute';
+import DrupalAttribute from '@civictheme/drupal-attribute';
 import Component from './grid.twig';
 import { placeholder, code, generateItems } from '../storybook/storybook.generators.utils';
 

--- a/packages/sdc/components/00-base/grid/grid.test.js
+++ b/packages/sdc/components/00-base/grid/grid.test.js
@@ -1,4 +1,4 @@
-import DrupalAttribute from 'drupal-attribute';
+import DrupalAttribute from '@civictheme/drupal-attribute';
 import jestEach from 'jest-each';
 
 const each = jestEach.default;

--- a/packages/sdc/components/00-base/icon/icon.test.js
+++ b/packages/sdc/components/00-base/icon/icon.test.js
@@ -1,4 +1,4 @@
-import DrupalAttribute from 'drupal-attribute';
+import DrupalAttribute from '@civictheme/drupal-attribute';
 
 const template = 'components/00-base/icon/icon.twig';
 

--- a/packages/sdc/components/00-base/item-list/item-list.test.js
+++ b/packages/sdc/components/00-base/item-list/item-list.test.js
@@ -1,4 +1,4 @@
-import DrupalAttribute from 'drupal-attribute';
+import DrupalAttribute from '@civictheme/drupal-attribute';
 
 const template = 'components/00-base/item-list/item-list.twig';
 

--- a/packages/sdc/components/00-base/layout/layout.test.js
+++ b/packages/sdc/components/00-base/layout/layout.test.js
@@ -1,4 +1,4 @@
-import DrupalAttribute from 'drupal-attribute';
+import DrupalAttribute from '@civictheme/drupal-attribute';
 
 const template = 'components/00-base/layout/layout.twig';
 

--- a/packages/sdc/components/00-base/menu/menu.test.js
+++ b/packages/sdc/components/00-base/menu/menu.test.js
@@ -1,4 +1,4 @@
-import DrupalAttribute from 'drupal-attribute';
+import DrupalAttribute from '@civictheme/drupal-attribute';
 
 const template = 'components/00-base/menu/menu.twig';
 

--- a/packages/sdc/components/01-atoms/button/button.test.js
+++ b/packages/sdc/components/01-atoms/button/button.test.js
@@ -1,4 +1,4 @@
-import DrupalAttribute from 'drupal-attribute';
+import DrupalAttribute from '@civictheme/drupal-attribute';
 
 const template = 'components/01-atoms/button/button.twig';
 

--- a/packages/sdc/components/01-atoms/checkbox/checkbox.test.js
+++ b/packages/sdc/components/01-atoms/checkbox/checkbox.test.js
@@ -1,4 +1,4 @@
-import DrupalAttribute from 'drupal-attribute';
+import DrupalAttribute from '@civictheme/drupal-attribute';
 
 const template = 'components/01-atoms/checkbox/checkbox.twig';
 

--- a/packages/sdc/components/01-atoms/chip/chip.test.js
+++ b/packages/sdc/components/01-atoms/chip/chip.test.js
@@ -1,4 +1,4 @@
-import DrupalAttribute from 'drupal-attribute';
+import DrupalAttribute from '@civictheme/drupal-attribute';
 
 const template = 'components/01-atoms/chip/chip.twig';
 

--- a/packages/sdc/components/01-atoms/content-link/content-link.test.js
+++ b/packages/sdc/components/01-atoms/content-link/content-link.test.js
@@ -1,4 +1,4 @@
-import DrupalAttribute from 'drupal-attribute';
+import DrupalAttribute from '@civictheme/drupal-attribute';
 
 const template = 'components/01-atoms/content-link/content-link.twig';
 

--- a/packages/sdc/components/01-atoms/field-description/field-description.test.js
+++ b/packages/sdc/components/01-atoms/field-description/field-description.test.js
@@ -1,4 +1,4 @@
-import DrupalAttribute from 'drupal-attribute';
+import DrupalAttribute from '@civictheme/drupal-attribute';
 
 const template = 'components/01-atoms/field-description/field-description.twig';
 

--- a/packages/sdc/components/01-atoms/field-message/field-message.test.js
+++ b/packages/sdc/components/01-atoms/field-message/field-message.test.js
@@ -1,4 +1,4 @@
-import DrupalAttribute from 'drupal-attribute';
+import DrupalAttribute from '@civictheme/drupal-attribute';
 
 const template = 'components/01-atoms/field-message/field-message.twig';
 

--- a/packages/sdc/components/01-atoms/fieldset/fieldset.test.js
+++ b/packages/sdc/components/01-atoms/fieldset/fieldset.test.js
@@ -1,4 +1,4 @@
-import DrupalAttribute from 'drupal-attribute';
+import DrupalAttribute from '@civictheme/drupal-attribute';
 
 const template = 'components/01-atoms/fieldset/fieldset.twig';
 

--- a/packages/sdc/components/01-atoms/heading/heading.test.js
+++ b/packages/sdc/components/01-atoms/heading/heading.test.js
@@ -1,4 +1,4 @@
-import DrupalAttribute from 'drupal-attribute';
+import DrupalAttribute from '@civictheme/drupal-attribute';
 
 const template = 'components/01-atoms/heading/heading.twig';
 

--- a/packages/sdc/components/01-atoms/iframe/iframe.test.js
+++ b/packages/sdc/components/01-atoms/iframe/iframe.test.js
@@ -1,4 +1,4 @@
-import DrupalAttribute from 'drupal-attribute';
+import DrupalAttribute from '@civictheme/drupal-attribute';
 
 const template = 'components/01-atoms/iframe/iframe.twig';
 

--- a/packages/sdc/components/01-atoms/image/image.test.js
+++ b/packages/sdc/components/01-atoms/image/image.test.js
@@ -1,4 +1,4 @@
-import DrupalAttribute from 'drupal-attribute';
+import DrupalAttribute from '@civictheme/drupal-attribute';
 
 const template = 'components/01-atoms/image/image.twig';
 

--- a/packages/sdc/components/01-atoms/input/input.test.js
+++ b/packages/sdc/components/01-atoms/input/input.test.js
@@ -1,4 +1,4 @@
-import DrupalAttribute from 'drupal-attribute';
+import DrupalAttribute from '@civictheme/drupal-attribute';
 
 const template = 'components/01-atoms/input/input.twig';
 

--- a/packages/sdc/components/01-atoms/label/label.test.js
+++ b/packages/sdc/components/01-atoms/label/label.test.js
@@ -1,4 +1,4 @@
-import DrupalAttribute from 'drupal-attribute';
+import DrupalAttribute from '@civictheme/drupal-attribute';
 
 const template = 'components/01-atoms/label/label.twig';
 

--- a/packages/sdc/components/01-atoms/link/link.test.js
+++ b/packages/sdc/components/01-atoms/link/link.test.js
@@ -1,4 +1,4 @@
-import DrupalAttribute from 'drupal-attribute';
+import DrupalAttribute from '@civictheme/drupal-attribute';
 
 const template = 'components/01-atoms/link/link.twig';
 

--- a/packages/sdc/components/01-atoms/paragraph/paragraph.test.js
+++ b/packages/sdc/components/01-atoms/paragraph/paragraph.test.js
@@ -1,4 +1,4 @@
-import DrupalAttribute from 'drupal-attribute';
+import DrupalAttribute from '@civictheme/drupal-attribute';
 
 const template = 'components/01-atoms/paragraph/paragraph.twig';
 

--- a/packages/sdc/components/01-atoms/popover/__snapshots__/popover.test.js.snap
+++ b/packages/sdc/components/01-atoms/popover/__snapshots__/popover.test.js.snap
@@ -24,7 +24,6 @@ exports[`Popover Component renders with optional attributes 1`] = `
     
     
     <a
-      _keys="data-collapsible-trigger tabindex"
       class="ct-link ct-theme-dark     ct-popover__link"
       data-collapsible-trigger=""
       href="https://example.com"
@@ -85,7 +84,6 @@ exports[`Popover Component renders with required attributes 1`] = `
     
     
     <a
-      _keys="data-collapsible-trigger tabindex"
       class="ct-link ct-theme-light     ct-popover__link"
       data-collapsible-trigger=""
       tabindex="0"

--- a/packages/sdc/components/01-atoms/popover/popover.test.js
+++ b/packages/sdc/components/01-atoms/popover/popover.test.js
@@ -1,4 +1,4 @@
-import DrupalAttribute from 'drupal-attribute';
+import DrupalAttribute from '@civictheme/drupal-attribute';
 
 const template = 'components/01-atoms/popover/popover.twig';
 

--- a/packages/sdc/components/01-atoms/radio/radio.test.js
+++ b/packages/sdc/components/01-atoms/radio/radio.test.js
@@ -1,4 +1,4 @@
-import DrupalAttribute from 'drupal-attribute';
+import DrupalAttribute from '@civictheme/drupal-attribute';
 
 const template = 'components/01-atoms/radio/radio.twig';
 

--- a/packages/sdc/components/01-atoms/select/select.test.js
+++ b/packages/sdc/components/01-atoms/select/select.test.js
@@ -1,4 +1,4 @@
-import DrupalAttribute from 'drupal-attribute';
+import DrupalAttribute from '@civictheme/drupal-attribute';
 
 const template = 'components/01-atoms/select/select.twig';
 

--- a/packages/sdc/components/01-atoms/table/table.test.js
+++ b/packages/sdc/components/01-atoms/table/table.test.js
@@ -1,4 +1,4 @@
-import DrupalAttribute from 'drupal-attribute';
+import DrupalAttribute from '@civictheme/drupal-attribute';
 
 const template = 'components/01-atoms/table/table.twig';
 

--- a/packages/sdc/components/01-atoms/tag/tag.test.js
+++ b/packages/sdc/components/01-atoms/tag/tag.test.js
@@ -1,4 +1,4 @@
-import DrupalAttribute from 'drupal-attribute';
+import DrupalAttribute from '@civictheme/drupal-attribute';
 
 const template = 'components/01-atoms/tag/tag.twig';
 

--- a/packages/sdc/components/01-atoms/textarea/textarea.test.js
+++ b/packages/sdc/components/01-atoms/textarea/textarea.test.js
@@ -1,4 +1,4 @@
-import DrupalAttribute from 'drupal-attribute';
+import DrupalAttribute from '@civictheme/drupal-attribute';
 
 const template = 'components/01-atoms/textarea/textarea.twig';
 

--- a/packages/sdc/components/01-atoms/textfield/textfield.test.js
+++ b/packages/sdc/components/01-atoms/textfield/textfield.test.js
@@ -1,4 +1,4 @@
-import DrupalAttribute from 'drupal-attribute';
+import DrupalAttribute from '@civictheme/drupal-attribute';
 
 const template = 'components/01-atoms/textfield/textfield.twig';
 

--- a/packages/sdc/components/01-atoms/video/video.test.js
+++ b/packages/sdc/components/01-atoms/video/video.test.js
@@ -1,4 +1,4 @@
-import DrupalAttribute from 'drupal-attribute';
+import DrupalAttribute from '@civictheme/drupal-attribute';
 
 const template = 'components/01-atoms/video/video.twig';
 

--- a/packages/sdc/components/02-molecules/accordion/accordion.test.js
+++ b/packages/sdc/components/02-molecules/accordion/accordion.test.js
@@ -1,4 +1,4 @@
-import DrupalAttribute from 'drupal-attribute';
+import DrupalAttribute from '@civictheme/drupal-attribute';
 
 const template = 'components/02-molecules/accordion/accordion.twig';
 

--- a/packages/sdc/components/02-molecules/attachment/attachment.test.js
+++ b/packages/sdc/components/02-molecules/attachment/attachment.test.js
@@ -1,4 +1,4 @@
-import DrupalAttribute from 'drupal-attribute';
+import DrupalAttribute from '@civictheme/drupal-attribute';
 
 const template = 'components/02-molecules/attachment/attachment.twig';
 

--- a/packages/sdc/components/02-molecules/back-to-top/__snapshots__/back-to-top.test.js.snap
+++ b/packages/sdc/components/02-molecules/back-to-top/__snapshots__/back-to-top.test.js.snap
@@ -13,7 +13,6 @@ exports[`Back to Top Component button contains correct icon 1`] = `
 
   
     <a
-      _keys="data-skip-to-target"
       class="ct-button ct-theme-light  ct-button--link ct-button--regular   ct-back-to-top__button"
       data-component-name="button"
       data-skip-to-target=""
@@ -70,7 +69,6 @@ exports[`Back to Top Component renders button with correct attributes 1`] = `
 
   
     <a
-      _keys="data-skip-to-target"
       class="ct-button ct-theme-light  ct-button--link ct-button--regular   ct-back-to-top__button"
       data-component-name="button"
       data-skip-to-target=""
@@ -127,7 +125,6 @@ exports[`Back to Top Component renders correctly 1`] = `
 
   
     <a
-      _keys="data-skip-to-target"
       class="ct-button ct-theme-light  ct-button--link ct-button--regular   ct-back-to-top__button"
       data-component-name="button"
       data-skip-to-target=""

--- a/packages/sdc/components/02-molecules/basic-content/basic-content.test.js
+++ b/packages/sdc/components/02-molecules/basic-content/basic-content.test.js
@@ -1,4 +1,4 @@
-import DrupalAttribute from 'drupal-attribute';
+import DrupalAttribute from '@civictheme/drupal-attribute';
 
 const template = 'components/02-molecules/basic-content/basic-content.twig';
 

--- a/packages/sdc/components/02-molecules/breadcrumb/__snapshots__/breadcrumb.test.js.snap
+++ b/packages/sdc/components/02-molecules/breadcrumb/__snapshots__/breadcrumb.test.js.snap
@@ -342,7 +342,6 @@ exports[`Breadcrumb Component renders with optional attributes 1`] = `
         class="ct-item-list__item"
       >
         <a
-          _keys="aria-current"
           aria-current="location"
           class="ct-link ct-theme-dark  ct-link--active   ct-breadcrumb__links__link ct-breadcrumb__links__link--active"
           href="/category/subcategory"

--- a/packages/sdc/components/02-molecules/breadcrumb/breadcrumb.test.js
+++ b/packages/sdc/components/02-molecules/breadcrumb/breadcrumb.test.js
@@ -1,4 +1,4 @@
-import DrupalAttribute from 'drupal-attribute';
+import DrupalAttribute from '@civictheme/drupal-attribute';
 
 const template = 'components/02-molecules/breadcrumb/breadcrumb.twig';
 

--- a/packages/sdc/components/02-molecules/callout/callout.test.js
+++ b/packages/sdc/components/02-molecules/callout/callout.test.js
@@ -1,4 +1,4 @@
-import DrupalAttribute from 'drupal-attribute';
+import DrupalAttribute from '@civictheme/drupal-attribute';
 
 const template = 'components/02-molecules/callout/callout.twig';
 

--- a/packages/sdc/components/02-molecules/event-card/event-card.test.js
+++ b/packages/sdc/components/02-molecules/event-card/event-card.test.js
@@ -1,4 +1,4 @@
-import DrupalAttribute from 'drupal-attribute';
+import DrupalAttribute from '@civictheme/drupal-attribute';
 
 const template = 'components/02-molecules/event-card/event-card.twig';
 

--- a/packages/sdc/components/02-molecules/fast-fact-card/fast-fact-card.test.js
+++ b/packages/sdc/components/02-molecules/fast-fact-card/fast-fact-card.test.js
@@ -1,4 +1,4 @@
-import DrupalAttribute from 'drupal-attribute';
+import DrupalAttribute from '@civictheme/drupal-attribute';
 
 const template = 'components/02-molecules/fast-fact-card/fast-fact-card.twig';
 

--- a/packages/sdc/components/02-molecules/field/field.test.js
+++ b/packages/sdc/components/02-molecules/field/field.test.js
@@ -1,4 +1,4 @@
-import DrupalAttribute from 'drupal-attribute';
+import DrupalAttribute from '@civictheme/drupal-attribute';
 
 const template = 'components/02-molecules/field/field.twig';
 

--- a/packages/sdc/components/02-molecules/figure/figure.test.js
+++ b/packages/sdc/components/02-molecules/figure/figure.test.js
@@ -1,4 +1,4 @@
-import DrupalAttribute from 'drupal-attribute';
+import DrupalAttribute from '@civictheme/drupal-attribute';
 
 const template = 'components/02-molecules/figure/figure.twig';
 

--- a/packages/sdc/components/02-molecules/group-filter/__snapshots__/group-filter.test.js.snap
+++ b/packages/sdc/components/02-molecules/group-filter/__snapshots__/group-filter.test.js.snap
@@ -89,7 +89,6 @@ exports[`Group Filter Component renders with content top and bottom 1`] = `
 
   
                 <ul
-                  _keys="data-group-filter-filters"
                   class="ct-item-list ct-item-list--horizontal ct-item-list--large  ct-group-filter__filters"
                   data-group-filter-filters=""
                 >
@@ -111,7 +110,6 @@ exports[`Group Filter Component renders with content top and bottom 1`] = `
                       
     
                       <a
-                        _keys="data-collapsible-trigger tabindex"
                         class="ct-link ct-theme-light     ct-popover__link"
                         data-collapsible-trigger=""
                         tabindex="0"
@@ -166,7 +164,6 @@ exports[`Group Filter Component renders with content top and bottom 1`] = `
                       
     
                       <a
-                        _keys="data-collapsible-trigger tabindex"
                         class="ct-link ct-theme-light     ct-popover__link"
                         data-collapsible-trigger=""
                         tabindex="0"
@@ -228,7 +225,6 @@ exports[`Group Filter Component renders with content top and bottom 1`] = `
 
   
                 <button
-                  _keys="type"
                   class="ct-button ct-theme-light ct-button--primary ct-button--button ct-button--small   ct-group-filter__submit"
                   data-component-name="button"
                   type="submit"
@@ -382,7 +378,6 @@ exports[`Group Filter Component renders with custom attributes and classes 1`] =
 
   
                 <ul
-                  _keys="data-group-filter-filters"
                   class="ct-item-list ct-item-list--horizontal ct-item-list--large  ct-group-filter__filters"
                   data-group-filter-filters=""
                 >
@@ -404,7 +399,6 @@ exports[`Group Filter Component renders with custom attributes and classes 1`] =
                       
     
                       <a
-                        _keys="data-collapsible-trigger tabindex"
                         class="ct-link ct-theme-light     ct-popover__link"
                         data-collapsible-trigger=""
                         tabindex="0"
@@ -459,7 +453,6 @@ exports[`Group Filter Component renders with custom attributes and classes 1`] =
                       
     
                       <a
-                        _keys="data-collapsible-trigger tabindex"
                         class="ct-link ct-theme-light     ct-popover__link"
                         data-collapsible-trigger=""
                         tabindex="0"
@@ -521,7 +514,6 @@ exports[`Group Filter Component renders with custom attributes and classes 1`] =
 
   
                 <button
-                  _keys="type"
                   class="ct-button ct-theme-light ct-button--primary ct-button--button ct-button--small   ct-group-filter__submit"
                   data-component-name="button"
                   type="submit"
@@ -667,7 +659,6 @@ exports[`Group Filter Component renders with custom title and submit text 1`] = 
 
   
                 <ul
-                  _keys="data-group-filter-filters"
                   class="ct-item-list ct-item-list--horizontal ct-item-list--large  ct-group-filter__filters"
                   data-group-filter-filters=""
                 >
@@ -689,7 +680,6 @@ exports[`Group Filter Component renders with custom title and submit text 1`] = 
                       
     
                       <a
-                        _keys="data-collapsible-trigger tabindex"
                         class="ct-link ct-theme-light     ct-popover__link"
                         data-collapsible-trigger=""
                         tabindex="0"
@@ -744,7 +734,6 @@ exports[`Group Filter Component renders with custom title and submit text 1`] = 
                       
     
                       <a
-                        _keys="data-collapsible-trigger tabindex"
                         class="ct-link ct-theme-light     ct-popover__link"
                         data-collapsible-trigger=""
                         tabindex="0"
@@ -806,7 +795,6 @@ exports[`Group Filter Component renders with custom title and submit text 1`] = 
 
   
                 <button
-                  _keys="type"
                   class="ct-button ct-theme-light ct-button--primary ct-button--button ct-button--small   ct-group-filter__submit"
                   data-component-name="button"
                   type="submit"
@@ -952,7 +940,6 @@ exports[`Group Filter Component renders with default values 1`] = `
 
   
                 <ul
-                  _keys="data-group-filter-filters"
                   class="ct-item-list ct-item-list--horizontal ct-item-list--large  ct-group-filter__filters"
                   data-group-filter-filters=""
                 >
@@ -974,7 +961,6 @@ exports[`Group Filter Component renders with default values 1`] = `
                       
     
                       <a
-                        _keys="data-collapsible-trigger tabindex"
                         class="ct-link ct-theme-light     ct-popover__link"
                         data-collapsible-trigger=""
                         tabindex="0"
@@ -1029,7 +1015,6 @@ exports[`Group Filter Component renders with default values 1`] = `
                       
     
                       <a
-                        _keys="data-collapsible-trigger tabindex"
                         class="ct-link ct-theme-light     ct-popover__link"
                         data-collapsible-trigger=""
                         tabindex="0"
@@ -1091,7 +1076,6 @@ exports[`Group Filter Component renders with default values 1`] = `
 
   
                 <button
-                  _keys="type"
                   class="ct-button ct-theme-light ct-button--primary ct-button--button ct-button--small   ct-group-filter__submit"
                   data-component-name="button"
                   type="submit"
@@ -1244,7 +1228,6 @@ exports[`Group Filter Component renders with form attributes and hidden fields 1
 
   
                   <ul
-                    _keys="data-group-filter-filters"
                     class="ct-item-list ct-item-list--horizontal ct-item-list--large  ct-group-filter__filters"
                     data-group-filter-filters=""
                   >
@@ -1266,7 +1249,6 @@ exports[`Group Filter Component renders with form attributes and hidden fields 1
                         
     
                         <a
-                          _keys="data-collapsible-trigger tabindex"
                           class="ct-link ct-theme-light     ct-popover__link"
                           data-collapsible-trigger=""
                           tabindex="0"
@@ -1321,7 +1303,6 @@ exports[`Group Filter Component renders with form attributes and hidden fields 1
                         
     
                         <a
-                          _keys="data-collapsible-trigger tabindex"
                           class="ct-link ct-theme-light     ct-popover__link"
                           data-collapsible-trigger=""
                           tabindex="0"
@@ -1383,7 +1364,6 @@ exports[`Group Filter Component renders with form attributes and hidden fields 1
 
   
                   <button
-                    _keys="type"
                     class="ct-button ct-theme-light ct-button--primary ct-button--button ct-button--small   ct-group-filter__submit"
                     data-component-name="button"
                     type="submit"

--- a/packages/sdc/components/02-molecules/group-filter/group-filter.test.js
+++ b/packages/sdc/components/02-molecules/group-filter/group-filter.test.js
@@ -1,4 +1,4 @@
-import DrupalAttribute from 'drupal-attribute';
+import DrupalAttribute from '@civictheme/drupal-attribute';
 
 const template = 'components/02-molecules/group-filter/group-filter.twig';
 

--- a/packages/sdc/components/02-molecules/logo/logo.test.js
+++ b/packages/sdc/components/02-molecules/logo/logo.test.js
@@ -1,4 +1,4 @@
-import DrupalAttribute from 'drupal-attribute';
+import DrupalAttribute from '@civictheme/drupal-attribute';
 
 const template = 'components/02-molecules/logo/logo.twig';
 

--- a/packages/sdc/components/02-molecules/map/__snapshots__/map.test.js.snap
+++ b/packages/sdc/components/02-molecules/map/__snapshots__/map.test.js.snap
@@ -43,7 +43,6 @@ exports[`Map Component renders with default view text 1`] = `
 
 
             <iframe
-              _keys="allowfullscreen data-chromatic"
               allowfullscreen=""
               class="ct-iframe ct-theme-light   ct-map__iframe"
               data-chromatic="ignore"
@@ -162,7 +161,6 @@ exports[`Map Component renders with optional attributes 1`] = `
 
 
             <iframe
-              _keys="allowfullscreen data-chromatic"
               allowfullscreen=""
               class="ct-iframe ct-theme-light   ct-map__iframe"
               data-chromatic="ignore"
@@ -281,7 +279,6 @@ exports[`Map Component renders with required attributes 1`] = `
 
 
             <iframe
-              _keys="allowfullscreen data-chromatic"
               allowfullscreen=""
               class="ct-iframe ct-theme-light   ct-map__iframe"
               data-chromatic="ignore"

--- a/packages/sdc/components/02-molecules/map/map.test.js
+++ b/packages/sdc/components/02-molecules/map/map.test.js
@@ -1,4 +1,4 @@
-import DrupalAttribute from 'drupal-attribute';
+import DrupalAttribute from '@civictheme/drupal-attribute';
 
 const template = 'components/02-molecules/map/map.twig';
 

--- a/packages/sdc/components/02-molecules/navigation-card/navigation-card.test.js
+++ b/packages/sdc/components/02-molecules/navigation-card/navigation-card.test.js
@@ -1,4 +1,4 @@
-import DrupalAttribute from 'drupal-attribute';
+import DrupalAttribute from '@civictheme/drupal-attribute';
 
 const template = 'components/02-molecules/navigation-card/navigation-card.twig';
 

--- a/packages/sdc/components/02-molecules/next-step/next-step.test.js
+++ b/packages/sdc/components/02-molecules/next-step/next-step.test.js
@@ -1,4 +1,4 @@
-import DrupalAttribute from 'drupal-attribute';
+import DrupalAttribute from '@civictheme/drupal-attribute';
 
 const template = 'components/02-molecules/next-step/next-step.twig';
 

--- a/packages/sdc/components/02-molecules/pagination/__snapshots__/pagination.test.js.snap
+++ b/packages/sdc/components/02-molecules/pagination/__snapshots__/pagination.test.js.snap
@@ -42,7 +42,6 @@ exports[`Pagination Component renders current page correctly 1`] = `
         
         
         <a
-          _keys="title"
           class="ct-link ct-theme-light     ct-pagination__link"
           href="#previous"
           title="Go to previous page - page 1"
@@ -97,7 +96,6 @@ exports[`Pagination Component renders current page correctly 1`] = `
         
           
         <a
-          _keys="title"
           class="ct-link ct-theme-light     ct-pagination__item__link"
           href="#1"
           title="Go to page 1 of 3"
@@ -121,7 +119,6 @@ exports[`Pagination Component renders current page correctly 1`] = `
         
           
         <a
-          _keys="title"
           class="ct-link ct-theme-light  ct-link--active   ct-pagination__item__link"
           href="#2"
           title="Current page"
@@ -145,7 +142,6 @@ exports[`Pagination Component renders current page correctly 1`] = `
         
           
         <a
-          _keys="title"
           class="ct-link ct-theme-light     ct-pagination__item__link"
           href="#3"
           title="Go to page 3 of 3"
@@ -169,7 +165,6 @@ exports[`Pagination Component renders current page correctly 1`] = `
         
         
         <a
-          _keys="title"
           class="ct-link ct-theme-light   ct-link--disabled  ct-pagination__link"
           disabled=""
           href="#next"
@@ -341,7 +336,6 @@ exports[`Pagination Component renders with optional attributes 1`] = `
         
           
         <a
-          _keys="title"
           class="ct-link ct-theme-dark     ct-pagination__link"
           href="#first"
           title="Go to first page"
@@ -395,7 +389,6 @@ exports[`Pagination Component renders with optional attributes 1`] = `
         
         
         <a
-          _keys="title"
           class="ct-link ct-theme-dark     ct-pagination__link"
           href="#previous"
           title="Go to previous page - page 1"
@@ -450,7 +443,6 @@ exports[`Pagination Component renders with optional attributes 1`] = `
         
           
         <a
-          _keys="title"
           class="ct-link ct-theme-dark     ct-pagination__item__link"
           href="#1"
           title="Go to page 1 of 3"
@@ -474,7 +466,6 @@ exports[`Pagination Component renders with optional attributes 1`] = `
         
           
         <a
-          _keys="title"
           class="ct-link ct-theme-dark  ct-link--active   ct-pagination__item__link"
           href="#2"
           title="Current page"
@@ -508,7 +499,6 @@ exports[`Pagination Component renders with optional attributes 1`] = `
         
           
         <a
-          _keys="title"
           class="ct-link ct-theme-dark     ct-pagination__item__link"
           href="#3"
           title="Go to page 3 of 3"
@@ -532,7 +522,6 @@ exports[`Pagination Component renders with optional attributes 1`] = `
         
         
         <a
-          _keys="title"
           class="ct-link ct-theme-dark   ct-link--disabled  ct-pagination__link"
           disabled=""
           href="#next"
@@ -587,7 +576,6 @@ exports[`Pagination Component renders with optional attributes 1`] = `
         
           
         <a
-          _keys="title"
           class="ct-link ct-theme-dark   ct-link--disabled  ct-pagination__link"
           disabled=""
           href="#last"
@@ -677,7 +665,6 @@ exports[`Pagination Component renders with required attributes 1`] = `
         
         
         <a
-          _keys="title"
           class="ct-link ct-theme-light     ct-pagination__link"
           href="#previous"
           title="Go to previous page - page 1"
@@ -732,7 +719,6 @@ exports[`Pagination Component renders with required attributes 1`] = `
         
           
         <a
-          _keys="title"
           class="ct-link ct-theme-light     ct-pagination__item__link"
           href="#1"
           title="Go to page 1 of 3"
@@ -756,7 +742,6 @@ exports[`Pagination Component renders with required attributes 1`] = `
         
           
         <a
-          _keys="title"
           class="ct-link ct-theme-light  ct-link--active   ct-pagination__item__link"
           href="#2"
           title="Current page"
@@ -780,7 +765,6 @@ exports[`Pagination Component renders with required attributes 1`] = `
         
           
         <a
-          _keys="title"
           class="ct-link ct-theme-light     ct-pagination__item__link"
           href="#3"
           title="Go to page 3 of 3"
@@ -804,7 +788,6 @@ exports[`Pagination Component renders with required attributes 1`] = `
         
         
         <a
-          _keys="title"
           class="ct-link ct-theme-light   ct-link--disabled  ct-pagination__link"
           disabled=""
           href="#next"

--- a/packages/sdc/components/02-molecules/pagination/pagination.test.js
+++ b/packages/sdc/components/02-molecules/pagination/pagination.test.js
@@ -1,4 +1,4 @@
-import DrupalAttribute from 'drupal-attribute';
+import DrupalAttribute from '@civictheme/drupal-attribute';
 
 const template = 'components/02-molecules/pagination/pagination.twig';
 

--- a/packages/sdc/components/02-molecules/promo-card/promo-card.test.js
+++ b/packages/sdc/components/02-molecules/promo-card/promo-card.test.js
@@ -1,4 +1,4 @@
-import DrupalAttribute from 'drupal-attribute';
+import DrupalAttribute from '@civictheme/drupal-attribute';
 
 const template = 'components/02-molecules/promo-card/promo-card.twig';
 

--- a/packages/sdc/components/02-molecules/publication-card/publication-card.test.js
+++ b/packages/sdc/components/02-molecules/publication-card/publication-card.test.js
@@ -1,4 +1,4 @@
-import DrupalAttribute from 'drupal-attribute';
+import DrupalAttribute from '@civictheme/drupal-attribute';
 
 const template = 'components/02-molecules/publication-card/publication-card.twig';
 

--- a/packages/sdc/components/02-molecules/search/search.test.js
+++ b/packages/sdc/components/02-molecules/search/search.test.js
@@ -1,4 +1,4 @@
-import DrupalAttribute from 'drupal-attribute';
+import DrupalAttribute from '@civictheme/drupal-attribute';
 
 const template = 'components/02-molecules/search/search.twig';
 

--- a/packages/sdc/components/02-molecules/service-card/service-card.test.js
+++ b/packages/sdc/components/02-molecules/service-card/service-card.test.js
@@ -1,4 +1,4 @@
-import DrupalAttribute from 'drupal-attribute';
+import DrupalAttribute from '@civictheme/drupal-attribute';
 
 const template = 'components/02-molecules/service-card/service-card.twig';
 

--- a/packages/sdc/components/02-molecules/single-filter/__snapshots__/single-filter.test.js.snap
+++ b/packages/sdc/components/02-molecules/single-filter/__snapshots__/single-filter.test.js.snap
@@ -201,7 +201,6 @@ exports[`Single Filter Component renders with multiple selection enabled 1`] = `
 
   
               <button
-                _keys="type"
                 class="ct-button ct-theme-light ct-button--primary ct-button--button ct-button--small   ct-single-filter__submit"
                 data-component-name="button"
                 type="submit"
@@ -408,7 +407,6 @@ exports[`Single Filter Component renders with optional attributes 1`] = `
 
   
               <button
-                _keys="type"
                 class="ct-button ct-theme-dark ct-button--primary ct-button--button ct-button--small   ct-single-filter__submit"
                 data-component-name="button"
                 type="submit"
@@ -456,7 +454,6 @@ exports[`Single Filter Component renders with optional attributes 1`] = `
 
   
               <input
-                _keys="type"
                 class="ct-button ct-theme-dark ct-button--secondary ct-button--reset ct-button--small   ct-single-filter__submit"
                 data-component-name="button"
                 type="reset"
@@ -624,7 +621,6 @@ exports[`Single Filter Component renders with required attributes 1`] = `
 
   
               <button
-                _keys="type"
                 class="ct-button ct-theme-light ct-button--primary ct-button--button ct-button--small   ct-single-filter__submit"
                 data-component-name="button"
                 type="submit"

--- a/packages/sdc/components/02-molecules/single-filter/single-filter.test.js
+++ b/packages/sdc/components/02-molecules/single-filter/single-filter.test.js
@@ -1,4 +1,4 @@
-import DrupalAttribute from 'drupal-attribute';
+import DrupalAttribute from '@civictheme/drupal-attribute';
 
 const template = 'components/02-molecules/single-filter/single-filter.twig';
 

--- a/packages/sdc/components/02-molecules/snippet/snippet.test.js
+++ b/packages/sdc/components/02-molecules/snippet/snippet.test.js
@@ -1,4 +1,4 @@
-import DrupalAttribute from 'drupal-attribute';
+import DrupalAttribute from '@civictheme/drupal-attribute';
 
 const template = 'components/02-molecules/snippet/snippet.twig';
 

--- a/packages/sdc/components/02-molecules/social-links/__snapshots__/social-links.test.js.snap
+++ b/packages/sdc/components/02-molecules/social-links/__snapshots__/social-links.test.js.snap
@@ -34,7 +34,6 @@ exports[`Social Links Component renders with icon HTML 1`] = `
 
   
         <a
-          _keys="title"
           class="ct-button ct-theme-light ct-button--tertiary ct-button--link ct-button--regular   ct-social-links__button"
           data-component-name="button"
           href="https://facebook.com"
@@ -65,7 +64,6 @@ exports[`Social Links Component renders with icon HTML 1`] = `
 
   
         <a
-          _keys="title"
           class="ct-button ct-theme-light ct-button--tertiary ct-button--link ct-button--regular   ct-social-links__button"
           data-component-name="button"
           href="https://twitter.com"
@@ -126,7 +124,6 @@ exports[`Social Links Component renders with optional attributes 1`] = `
 
   
         <a
-          _keys="title"
           class="ct-button ct-theme-dark ct-button--tertiary ct-button--link ct-button--regular   ct-social-links__button"
           data-component-name="button"
           href="https://facebook.com"
@@ -157,7 +154,6 @@ exports[`Social Links Component renders with optional attributes 1`] = `
 
   
         <a
-          _keys="title"
           class="ct-button ct-theme-dark ct-button--tertiary ct-button--link ct-button--regular   ct-social-links__button"
           data-component-name="button"
           href="https://twitter.com"
@@ -217,7 +213,6 @@ exports[`Social Links Component renders with required attributes 1`] = `
 
   
         <a
-          _keys="title"
           class="ct-button ct-theme-light ct-button--tertiary ct-button--link ct-button--regular   ct-social-links__button"
           data-component-name="button"
           href="https://facebook.com"
@@ -262,7 +257,6 @@ exports[`Social Links Component renders with required attributes 1`] = `
 
   
         <a
-          _keys="title"
           class="ct-button ct-theme-light ct-button--tertiary ct-button--link ct-button--regular   ct-social-links__button"
           data-component-name="button"
           href="https://twitter.com"

--- a/packages/sdc/components/02-molecules/social-links/social-links.test.js
+++ b/packages/sdc/components/02-molecules/social-links/social-links.test.js
@@ -1,4 +1,4 @@
-import DrupalAttribute from 'drupal-attribute';
+import DrupalAttribute from '@civictheme/drupal-attribute';
 
 const template = 'components/02-molecules/social-links/social-links.twig';
 

--- a/packages/sdc/components/02-molecules/subject-card/subject-card.test.js
+++ b/packages/sdc/components/02-molecules/subject-card/subject-card.test.js
@@ -1,4 +1,4 @@
-import DrupalAttribute from 'drupal-attribute';
+import DrupalAttribute from '@civictheme/drupal-attribute';
 
 const template = 'components/02-molecules/subject-card/subject-card.twig';
 

--- a/packages/sdc/components/02-molecules/tabs/__snapshots__/tabs.test.js.snap
+++ b/packages/sdc/components/02-molecules/tabs/__snapshots__/tabs.test.js.snap
@@ -37,7 +37,6 @@ exports[`Tabs Component renders with generated links from panels 1`] = `
       >
                 
         <a
-          _keys="role id aria-controls"
           aria-controls="tab1"
           class="ct-link ct-theme-light"
           data-tabs-tab=""
@@ -60,7 +59,6 @@ exports[`Tabs Component renders with generated links from panels 1`] = `
       >
                 
         <a
-          _keys="role id aria-controls"
           aria-controls="tab2"
           class="ct-link ct-theme-light"
           data-tabs-tab=""
@@ -149,7 +147,6 @@ exports[`Tabs Component renders with optional attributes 1`] = `
       >
                 
         <a
-          _keys="role id aria-controls"
           aria-controls="tab1"
           class="ct-link ct-theme-dark"
           data-tabs-tab=""
@@ -172,7 +169,6 @@ exports[`Tabs Component renders with optional attributes 1`] = `
       >
                 
         <a
-          _keys="role id aria-controls"
           aria-controls="tab2"
           class="ct-link ct-theme-dark"
           data-tabs-tab=""
@@ -260,7 +256,6 @@ exports[`Tabs Component renders with required attributes 1`] = `
       >
                 
         <a
-          _keys="role id aria-controls"
           aria-controls="tab1"
           class="ct-link ct-theme-light"
           data-tabs-tab=""
@@ -283,7 +278,6 @@ exports[`Tabs Component renders with required attributes 1`] = `
       >
                 
         <a
-          _keys="role id aria-controls"
           aria-controls="tab2"
           class="ct-link ct-theme-light"
           data-tabs-tab=""

--- a/packages/sdc/components/02-molecules/tabs/tabs.stories.js
+++ b/packages/sdc/components/02-molecules/tabs/tabs.stories.js
@@ -2,7 +2,7 @@
  * CivicTheme Tabs component stories.
  */
 
-import DrupalAttribute from 'drupal-attribute';
+import DrupalAttribute from '@civictheme/drupal-attribute';
 import Component from './tabs.twig';
 
 const meta = {

--- a/packages/sdc/components/02-molecules/tabs/tabs.test.js
+++ b/packages/sdc/components/02-molecules/tabs/tabs.test.js
@@ -1,4 +1,4 @@
-import DrupalAttribute from 'drupal-attribute';
+import DrupalAttribute from '@civictheme/drupal-attribute';
 
 const template = 'components/02-molecules/tabs/tabs.twig';
 

--- a/packages/sdc/components/02-molecules/tag-list/tag-list.test.js
+++ b/packages/sdc/components/02-molecules/tag-list/tag-list.test.js
@@ -1,4 +1,4 @@
-import DrupalAttribute from 'drupal-attribute';
+import DrupalAttribute from '@civictheme/drupal-attribute';
 
 const template = 'components/02-molecules/tag-list/tag-list.twig';
 

--- a/packages/sdc/components/02-molecules/tooltip/tooltip.test.js
+++ b/packages/sdc/components/02-molecules/tooltip/tooltip.test.js
@@ -1,4 +1,4 @@
-import DrupalAttribute from 'drupal-attribute';
+import DrupalAttribute from '@civictheme/drupal-attribute';
 
 const template = 'components/02-molecules/tooltip/tooltip.twig';
 

--- a/packages/sdc/components/03-organisms/alert/__snapshots__/alert.test.js.snap
+++ b/packages/sdc/components/03-organisms/alert/__snapshots__/alert.test.js.snap
@@ -80,7 +80,6 @@ exports[`Alert Component renders with correct icon for alert type 1`] = `
 
   
           <button
-            _keys="id data-alert-dismiss-trigger title"
             class="ct-button ct-theme-light ct-button--tertiary ct-button--button ct-button--regular   ct-alert__dismiss-button"
             data-alert-dismiss-trigger=""
             data-component-name="button"
@@ -196,7 +195,6 @@ exports[`Alert Component renders with optional attributes 1`] = `
 
   
           <button
-            _keys="id data-alert-dismiss-trigger title"
             class="ct-button ct-theme-dark ct-button--tertiary ct-button--button ct-button--regular   ct-alert__dismiss-button"
             data-alert-dismiss-trigger=""
             data-component-name="button"
@@ -311,7 +309,6 @@ exports[`Alert Component renders with required attributes 1`] = `
 
   
           <button
-            _keys="id data-alert-dismiss-trigger title"
             class="ct-button ct-theme-light ct-button--tertiary ct-button--button ct-button--regular   ct-alert__dismiss-button"
             data-alert-dismiss-trigger=""
             data-component-name="button"

--- a/packages/sdc/components/03-organisms/alert/alert.test.js
+++ b/packages/sdc/components/03-organisms/alert/alert.test.js
@@ -1,4 +1,4 @@
-import DrupalAttribute from 'drupal-attribute';
+import DrupalAttribute from '@civictheme/drupal-attribute';
 
 const template = 'components/03-organisms/alert/alert.twig';
 

--- a/packages/sdc/components/03-organisms/banner/__snapshots__/banner.test.js.snap
+++ b/packages/sdc/components/03-organisms/banner/__snapshots__/banner.test.js.snap
@@ -200,7 +200,6 @@ exports[`Banner Component renders with all attributes provided 1`] = `
                     class="ct-item-list__item"
                   >
                     <a
-                      _keys="aria-current"
                       aria-current="location"
                       class="ct-link ct-theme-dark  ct-link--active   ct-breadcrumb__links__link ct-breadcrumb__links__link--active"
                       href="/section"

--- a/packages/sdc/components/03-organisms/banner/banner.test.js
+++ b/packages/sdc/components/03-organisms/banner/banner.test.js
@@ -1,4 +1,4 @@
-import DrupalAttribute from 'drupal-attribute';
+import DrupalAttribute from '@civictheme/drupal-attribute';
 
 const template = 'components/03-organisms/banner/banner.twig';
 

--- a/packages/sdc/components/03-organisms/campaign/campaign.test.js
+++ b/packages/sdc/components/03-organisms/campaign/campaign.test.js
@@ -1,4 +1,4 @@
-import DrupalAttribute from 'drupal-attribute';
+import DrupalAttribute from '@civictheme/drupal-attribute';
 
 const template = 'components/03-organisms/campaign/campaign.twig';
 

--- a/packages/sdc/components/03-organisms/list/list.test.js
+++ b/packages/sdc/components/03-organisms/list/list.test.js
@@ -1,4 +1,4 @@
-import DrupalAttribute from 'drupal-attribute';
+import DrupalAttribute from '@civictheme/drupal-attribute';
 
 const template = 'components/03-organisms/list/list.twig';
 

--- a/packages/sdc/components/03-organisms/navigation/__snapshots__/navigation.test.js.snap
+++ b/packages/sdc/components/03-organisms/navigation/__snapshots__/navigation.test.js.snap
@@ -51,7 +51,6 @@ exports[`Navigation Component renders correctly when items have submenus 1`] = `
                                             
       
         <li
-          _keys="data-collapsible data-collapsible-collapsed data-collapsible-icon-group data-collapsible-group data-collapsible-duration"
           class="ct-menu__item ct-menu__item--level-0 ct-menu__item--has-children  ct-navigation__has-dropdown ct-navigation__dropdown-columns--2 "
           data-collapsible=""
           data-collapsible-collapsed=""
@@ -132,7 +131,6 @@ exports[`Navigation Component renders correctly when items have submenus 1`] = `
                                             
       
         <li
-          _keys="data-collapsible data-collapsible-collapsed data-collapsible-icon-group data-collapsible-group data-collapsible-duration"
           class="ct-menu__item ct-menu__item--level-0 ct-menu__item--has-children  ct-navigation__has-dropdown ct-navigation__dropdown-columns--2 "
           data-collapsible=""
           data-collapsible-collapsed=""

--- a/packages/sdc/components/03-organisms/promo/promo.test.js
+++ b/packages/sdc/components/03-organisms/promo/promo.test.js
@@ -1,4 +1,4 @@
-import DrupalAttribute from 'drupal-attribute';
+import DrupalAttribute from '@civictheme/drupal-attribute';
 
 const template = 'components/03-organisms/promo/promo.twig';
 

--- a/packages/sdc/components/03-organisms/side-navigation/__snapshots__/side-navigation.test.js.snap
+++ b/packages/sdc/components/03-organisms/side-navigation/__snapshots__/side-navigation.test.js.snap
@@ -28,7 +28,6 @@ exports[`Side Navigation Component renders with all attributes provided 1`] = `
       
     
       <a
-        _keys="data-platform"
         class="ct-link ct-theme-dark     ct-skip-link__link ct-visually-hidden"
         data-platform=""
         href="#main-content"
@@ -209,7 +208,6 @@ exports[`Side Navigation Component renders with only required attributes 1`] = `
       
     
       <a
-        _keys="data-platform"
         class="ct-link ct-theme-light     ct-skip-link__link ct-visually-hidden"
         data-platform=""
         href="#main-content"
@@ -296,7 +294,6 @@ exports[`Side Navigation Component renders with some attributes missing 1`] = `
       
     
       <a
-        _keys="data-platform"
         class="ct-link ct-theme-light     ct-skip-link__link ct-visually-hidden"
         data-platform=""
         href="#main-content"

--- a/packages/sdc/components/03-organisms/side-navigation/side-navigation.test.js
+++ b/packages/sdc/components/03-organisms/side-navigation/side-navigation.test.js
@@ -1,4 +1,4 @@
-import DrupalAttribute from 'drupal-attribute';
+import DrupalAttribute from '@civictheme/drupal-attribute';
 
 const template = 'components/03-organisms/side-navigation/side-navigation.twig';
 

--- a/packages/sdc/components/03-organisms/skip-link/__snapshots__/skip-link.test.js.snap
+++ b/packages/sdc/components/03-organisms/skip-link/__snapshots__/skip-link.test.js.snap
@@ -12,7 +12,6 @@ exports[`Skip Link Component renders with all attributes provided 1`] = `
     
     
     <a
-      _keys="data-platform"
       class="ct-link ct-theme-dark     ct-skip-link__link ct-visually-hidden"
       data-platform=""
       href="#main-content"
@@ -43,7 +42,6 @@ exports[`Skip Link Component renders with default text when text is empty 1`] = 
     
     
     <a
-      _keys="data-platform"
       class="ct-link ct-theme-light     ct-skip-link__link ct-visually-hidden"
       data-platform=""
       href="#main-content"
@@ -74,7 +72,6 @@ exports[`Skip Link Component renders with only required attributes 1`] = `
     
     
     <a
-      _keys="data-platform"
       class="ct-link ct-theme-light     ct-skip-link__link ct-visually-hidden"
       data-platform=""
       href="#main-content"

--- a/packages/sdc/components/03-organisms/slider/__snapshots__/slide.test.js.snap
+++ b/packages/sdc/components/03-organisms/slider/__snapshots__/slide.test.js.snap
@@ -92,7 +92,6 @@ exports[`Slide Component renders with default heading level (h3) 1`] = `
 
   
           <h3
-            _keys="data-toc-exclude"
             class="ct-heading ct-theme-light ct-slide__title"
             data-toc-exclude=""
           >
@@ -161,7 +160,6 @@ exports[`Slide Component renders with heading level 2 when heading_level is 2 1`
 
   
           <h2
-            _keys="data-toc-exclude"
             class="ct-heading ct-theme-light ct-slide__title"
             data-toc-exclude=""
           >
@@ -230,7 +228,6 @@ exports[`Slide Component renders with heading level 3 when heading_level is 3 1`
 
   
           <h3
-            _keys="data-toc-exclude"
             class="ct-heading ct-theme-light ct-slide__title"
             data-toc-exclude=""
           >

--- a/packages/sdc/components/03-organisms/slider/__snapshots__/slider.test.js.snap
+++ b/packages/sdc/components/03-organisms/slider/__snapshots__/slider.test.js.snap
@@ -102,7 +102,6 @@ exports[`Slider Component renders with all attributes provided 1`] = `
 
   
                 <button
-                  _keys="data-slider-previous"
                   class="ct-button ct-theme-dark ct-button--secondary ct-button--button ct-button--regular   ct-slider__controls__previous"
                   data-component-name="button"
                   data-slider-previous=""
@@ -140,7 +139,6 @@ exports[`Slider Component renders with all attributes provided 1`] = `
 
   
                 <button
-                  _keys="data-slider-next"
                   class="ct-button ct-theme-dark ct-button--secondary ct-button--button ct-button--regular   ct-slider__controls__next"
                   data-component-name="button"
                   data-slider-next=""
@@ -194,7 +192,6 @@ exports[`Slider Component renders with all attributes provided 1`] = `
   
     
               <span
-                _keys="aria-live data-slider-progress"
                 aria-live="polite"
                 class="ct-tag ct-theme-dark ct-tag--primary    ct-slider__controls__progress-indicator"
                 data-slider-progress=""
@@ -303,7 +300,6 @@ exports[`Slider Component renders with only required attributes 1`] = `
 
   
                 <button
-                  _keys="data-slider-previous"
                   class="ct-button ct-theme-light ct-button--secondary ct-button--button ct-button--regular   ct-slider__controls__previous"
                   data-component-name="button"
                   data-slider-previous=""
@@ -341,7 +337,6 @@ exports[`Slider Component renders with only required attributes 1`] = `
 
   
                 <button
-                  _keys="data-slider-next"
                   class="ct-button ct-theme-light ct-button--secondary ct-button--button ct-button--regular   ct-slider__controls__next"
                   data-component-name="button"
                   data-slider-next=""
@@ -395,7 +390,6 @@ exports[`Slider Component renders with only required attributes 1`] = `
   
     
               <span
-                _keys="aria-live data-slider-progress"
                 aria-live="polite"
                 class="ct-tag ct-theme-light ct-tag--primary    ct-slider__controls__progress-indicator"
                 data-slider-progress=""
@@ -514,7 +508,6 @@ exports[`Slider Component renders without some attributes 1`] = `
 
   
                 <button
-                  _keys="data-slider-previous"
                   class="ct-button ct-theme-light ct-button--secondary ct-button--button ct-button--regular   ct-slider__controls__previous"
                   data-component-name="button"
                   data-slider-previous=""
@@ -552,7 +545,6 @@ exports[`Slider Component renders without some attributes 1`] = `
 
   
                 <button
-                  _keys="data-slider-next"
                   class="ct-button ct-theme-light ct-button--secondary ct-button--button ct-button--regular   ct-slider__controls__next"
                   data-component-name="button"
                   data-slider-next=""
@@ -606,7 +598,6 @@ exports[`Slider Component renders without some attributes 1`] = `
   
     
               <span
-                _keys="aria-live data-slider-progress"
                 aria-live="polite"
                 class="ct-tag ct-theme-light ct-tag--primary    ct-slider__controls__progress-indicator"
                 data-slider-progress=""

--- a/packages/sdc/components/03-organisms/slider/slider.test.js
+++ b/packages/sdc/components/03-organisms/slider/slider.test.js
@@ -1,4 +1,4 @@
-import DrupalAttribute from 'drupal-attribute';
+import DrupalAttribute from '@civictheme/drupal-attribute';
 
 const template = 'components/03-organisms/slider/slider.twig';
 

--- a/packages/sdc/components/03-organisms/webform/webform.test.js
+++ b/packages/sdc/components/03-organisms/webform/webform.test.js
@@ -1,4 +1,4 @@
-import DrupalAttribute from 'drupal-attribute';
+import DrupalAttribute from '@civictheme/drupal-attribute';
 
 const template = 'components/03-organisms/webform/webform.twig';
 

--- a/packages/sdc/components/04-templates/page/__snapshots__/page.test.js.snap
+++ b/packages/sdc/components/04-templates/page/__snapshots__/page.test.js.snap
@@ -590,7 +590,6 @@ exports[`Page Component renders all blocks with complex attributes and classes 1
 
   
       <a
-        _keys="data-skip-to-target"
         class="ct-button ct-theme-light  ct-button--link ct-button--regular   ct-back-to-top__button"
         data-component-name="button"
         data-skip-to-target=""
@@ -757,7 +756,6 @@ exports[`Page Component renders content block with permutations: {
 
   
       <a
-        _keys="data-skip-to-target"
         class="ct-button ct-theme-light  ct-button--link ct-button--regular   ct-back-to-top__button"
         data-component-name="button"
         data-skip-to-target=""
@@ -910,7 +908,6 @@ exports[`Page Component renders content block with permutations: {
 
   
       <a
-        _keys="data-skip-to-target"
         class="ct-button ct-theme-light  ct-button--link ct-button--regular   ct-back-to-top__button"
         data-component-name="button"
         data-skip-to-target=""
@@ -1063,7 +1060,6 @@ exports[`Page Component renders content block with permutations: {
 
   
       <a
-        _keys="data-skip-to-target"
         class="ct-button ct-theme-light  ct-button--link ct-button--regular   ct-back-to-top__button"
         data-component-name="button"
         data-skip-to-target=""
@@ -1202,7 +1198,6 @@ exports[`Page Component renders content block with permutations: {
 
   
       <a
-        _keys="data-skip-to-target"
         class="ct-button ct-theme-light  ct-button--link ct-button--regular   ct-back-to-top__button"
         data-component-name="button"
         data-skip-to-target=""
@@ -1305,7 +1300,6 @@ exports[`Page Component renders with custom theme and attributes 1`] = `
 
   
       <a
-        _keys="data-skip-to-target"
         class="ct-button ct-theme-light  ct-button--link ct-button--regular   ct-back-to-top__button"
         data-component-name="button"
         data-skip-to-target=""
@@ -1407,7 +1401,6 @@ exports[`Page Component renders with default values 1`] = `
 
   
       <a
-        _keys="data-skip-to-target"
         class="ct-button ct-theme-light  ct-button--link ct-button--regular   ct-back-to-top__button"
         data-component-name="button"
         data-skip-to-target=""
@@ -1510,7 +1503,6 @@ exports[`Page Component strips HTML tags from attributes 1`] = `
 
   
       <a
-        _keys="data-skip-to-target"
         class="ct-button ct-theme-light  ct-button--link ct-button--regular   ct-back-to-top__button"
         data-component-name="button"
         data-skip-to-target=""

--- a/packages/sdc/components/04-templates/page/page.test.js
+++ b/packages/sdc/components/04-templates/page/page.test.js
@@ -1,5 +1,5 @@
 import jestEach from 'jest-each';
-import DrupalAttribute from 'drupal-attribute';
+import DrupalAttribute from '@civictheme/drupal-attribute';
 
 const each = jestEach.default;
 

--- a/packages/sdc/package.json
+++ b/packages/sdc/package.json
@@ -47,6 +47,7 @@
     "update-twig": "node scripts/generate-twig-headers.js"
   },
   "devDependencies": {
+    "@civictheme/drupal-attribute": "^2.0.0",
     "@civictheme/scss-variables-extractor": "^0.2.1",
     "@storybook/addon-docs": "10.2.13",
     "@storybook/addon-links": "10.2.13",
@@ -63,7 +64,7 @@
     "stylelint-config-standard-scss": "^17.0.0",
     "twig-testing-library": "^1.2.0",
     "vite": "^6.3.5",
-    "vite-plugin-twig-drupal": "^1.6.0"
+    "vite-plugin-twig-drupal": "^1.7.0"
   },
   "dependencies": {
     "@popperjs/core": "^2.11.8"

--- a/packages/sdc/package.json
+++ b/packages/sdc/package.json
@@ -64,7 +64,7 @@
     "stylelint-config-standard-scss": "^17.0.0",
     "twig-testing-library": "^1.2.0",
     "vite": "^6.3.5",
-    "vite-plugin-twig-drupal": "^1.7.0"
+    "vite-plugin-twig-drupal": "git+https://github.com/civictheme/vite-plugin-twig-drupal.git#semver:^1.7.1-ct.1"
   },
   "dependencies": {
     "@popperjs/core": "^2.11.8"

--- a/packages/sdc/package.json
+++ b/packages/sdc/package.json
@@ -47,7 +47,7 @@
     "update-twig": "node scripts/generate-twig-headers.js"
   },
   "devDependencies": {
-    "@civictheme/drupal-attribute": "^2.0.0",
+    "@civictheme/drupal-attribute": "^2.0.1",
     "@civictheme/scss-variables-extractor": "^0.2.1",
     "@storybook/addon-docs": "10.2.13",
     "@storybook/addon-links": "10.2.13",

--- a/packages/sdc/tests/jest.helpers.js
+++ b/packages/sdc/tests/jest.helpers.js
@@ -1,4 +1,5 @@
 import { render, Twig } from 'twig-testing-library';
+import { createAttribute } from '@civictheme/drupal-attribute';
 import * as fs from 'node:fs';
 import { globSync } from 'glob';
 
@@ -33,6 +34,15 @@ const wrappedRender = async (template, props = {}, namespaces = {}, twigCallback
     TwigInstance.twig = function (options) {
       options.autoescape = false;
       options.allowInlineIncludes = true;
+      // twig-testing-library registers create_attribute as
+      // `new DrupalAttribute(Object.entries(value))`, which carries twig.js's
+      // `_keys` bookkeeping property into the markup as an attribute. It does so
+      // inside loadTemplate, which runs after this callback, so registering at
+      // module scope or directly here would be overwritten. loadTemplate only
+      // reassigns twigAsync, and twigAsync calls twig() - so this wrapper is the
+      // first hook that runs after its registration. createAttribute drops
+      // `_keys` and uses it to order the remaining attributes.
+      TwigInstance.extendFunction('create_attribute', createAttribute);
       return originalTwig(options);
     };
     twigCallback(TwigInstance);

--- a/packages/sdc/tests/jest.helpers.js
+++ b/packages/sdc/tests/jest.helpers.js
@@ -1,5 +1,4 @@
 import { render, Twig } from 'twig-testing-library';
-import { createAttribute } from '@civictheme/drupal-attribute';
 import * as fs from 'node:fs';
 import { globSync } from 'glob';
 
@@ -34,15 +33,6 @@ const wrappedRender = async (template, props = {}, namespaces = {}, twigCallback
     TwigInstance.twig = function (options) {
       options.autoescape = false;
       options.allowInlineIncludes = true;
-      // twig-testing-library registers create_attribute as
-      // `new DrupalAttribute(Object.entries(value))`, which carries twig.js's
-      // `_keys` bookkeeping property into the markup as an attribute. It does so
-      // inside loadTemplate, which runs after this callback, so registering at
-      // module scope or directly here would be overwritten. loadTemplate only
-      // reassigns twigAsync, and twigAsync calls twig() - so this wrapper is the
-      // first hook that runs after its registration. createAttribute drops
-      // `_keys` and uses it to order the remaining attributes.
-      TwigInstance.extendFunction('create_attribute', createAttribute);
       return originalTwig(options);
     };
     twigCallback(TwigInstance);

--- a/packages/twig/components/00-base/datetime/datetime.test.js
+++ b/packages/twig/components/00-base/datetime/datetime.test.js
@@ -1,4 +1,4 @@
-import DrupalAttribute from 'drupal-attribute';
+import DrupalAttribute from '@civictheme/drupal-attribute';
 
 const template = 'components/00-base/datetime/datetime.twig';
 

--- a/packages/twig/components/00-base/grid/grid.stories.js
+++ b/packages/twig/components/00-base/grid/grid.stories.js
@@ -2,7 +2,7 @@
  * CivicTheme Grid component stories.
  */
 
-import DrupalAttribute from 'drupal-attribute';
+import DrupalAttribute from '@civictheme/drupal-attribute';
 import Component from './grid.twig';
 import { placeholder, code, generateItems } from '../storybook/storybook.generators.utils';
 

--- a/packages/twig/components/00-base/grid/grid.test.js
+++ b/packages/twig/components/00-base/grid/grid.test.js
@@ -1,4 +1,4 @@
-import DrupalAttribute from 'drupal-attribute';
+import DrupalAttribute from '@civictheme/drupal-attribute';
 import jestEach from 'jest-each';
 
 const each = jestEach.default;

--- a/packages/twig/components/00-base/icon/icon.test.js
+++ b/packages/twig/components/00-base/icon/icon.test.js
@@ -1,4 +1,4 @@
-import DrupalAttribute from 'drupal-attribute';
+import DrupalAttribute from '@civictheme/drupal-attribute';
 
 const template = 'components/00-base/icon/icon.twig';
 

--- a/packages/twig/components/00-base/item-list/item-list.test.js
+++ b/packages/twig/components/00-base/item-list/item-list.test.js
@@ -1,4 +1,4 @@
-import DrupalAttribute from 'drupal-attribute';
+import DrupalAttribute from '@civictheme/drupal-attribute';
 
 const template = 'components/00-base/item-list/item-list.twig';
 

--- a/packages/twig/components/00-base/layout/layout.test.js
+++ b/packages/twig/components/00-base/layout/layout.test.js
@@ -1,4 +1,4 @@
-import DrupalAttribute from 'drupal-attribute';
+import DrupalAttribute from '@civictheme/drupal-attribute';
 
 const template = 'components/00-base/layout/layout.twig';
 

--- a/packages/twig/components/00-base/menu/menu.test.js
+++ b/packages/twig/components/00-base/menu/menu.test.js
@@ -1,4 +1,4 @@
-import DrupalAttribute from 'drupal-attribute';
+import DrupalAttribute from '@civictheme/drupal-attribute';
 
 const template = 'components/00-base/menu/menu.twig';
 

--- a/packages/twig/components/01-atoms/button/button.test.js
+++ b/packages/twig/components/01-atoms/button/button.test.js
@@ -1,4 +1,4 @@
-import DrupalAttribute from 'drupal-attribute';
+import DrupalAttribute from '@civictheme/drupal-attribute';
 
 const template = 'components/01-atoms/button/button.twig';
 

--- a/packages/twig/components/01-atoms/checkbox/checkbox.test.js
+++ b/packages/twig/components/01-atoms/checkbox/checkbox.test.js
@@ -1,4 +1,4 @@
-import DrupalAttribute from 'drupal-attribute';
+import DrupalAttribute from '@civictheme/drupal-attribute';
 
 const template = 'components/01-atoms/checkbox/checkbox.twig';
 

--- a/packages/twig/components/01-atoms/chip/chip.test.js
+++ b/packages/twig/components/01-atoms/chip/chip.test.js
@@ -1,4 +1,4 @@
-import DrupalAttribute from 'drupal-attribute';
+import DrupalAttribute from '@civictheme/drupal-attribute';
 
 const template = 'components/01-atoms/chip/chip.twig';
 

--- a/packages/twig/components/01-atoms/content-link/content-link.test.js
+++ b/packages/twig/components/01-atoms/content-link/content-link.test.js
@@ -1,4 +1,4 @@
-import DrupalAttribute from 'drupal-attribute';
+import DrupalAttribute from '@civictheme/drupal-attribute';
 
 const template = 'components/01-atoms/content-link/content-link.twig';
 

--- a/packages/twig/components/01-atoms/field-description/field-description.test.js
+++ b/packages/twig/components/01-atoms/field-description/field-description.test.js
@@ -1,4 +1,4 @@
-import DrupalAttribute from 'drupal-attribute';
+import DrupalAttribute from '@civictheme/drupal-attribute';
 
 const template = 'components/01-atoms/field-description/field-description.twig';
 

--- a/packages/twig/components/01-atoms/field-message/field-message.test.js
+++ b/packages/twig/components/01-atoms/field-message/field-message.test.js
@@ -1,4 +1,4 @@
-import DrupalAttribute from 'drupal-attribute';
+import DrupalAttribute from '@civictheme/drupal-attribute';
 
 const template = 'components/01-atoms/field-message/field-message.twig';
 

--- a/packages/twig/components/01-atoms/fieldset/fieldset.test.js
+++ b/packages/twig/components/01-atoms/fieldset/fieldset.test.js
@@ -1,4 +1,4 @@
-import DrupalAttribute from 'drupal-attribute';
+import DrupalAttribute from '@civictheme/drupal-attribute';
 
 const template = 'components/01-atoms/fieldset/fieldset.twig';
 

--- a/packages/twig/components/01-atoms/heading/heading.test.js
+++ b/packages/twig/components/01-atoms/heading/heading.test.js
@@ -1,4 +1,4 @@
-import DrupalAttribute from 'drupal-attribute';
+import DrupalAttribute from '@civictheme/drupal-attribute';
 
 const template = 'components/01-atoms/heading/heading.twig';
 

--- a/packages/twig/components/01-atoms/iframe/iframe.test.js
+++ b/packages/twig/components/01-atoms/iframe/iframe.test.js
@@ -1,4 +1,4 @@
-import DrupalAttribute from 'drupal-attribute';
+import DrupalAttribute from '@civictheme/drupal-attribute';
 
 const template = 'components/01-atoms/iframe/iframe.twig';
 

--- a/packages/twig/components/01-atoms/image/image.test.js
+++ b/packages/twig/components/01-atoms/image/image.test.js
@@ -1,4 +1,4 @@
-import DrupalAttribute from 'drupal-attribute';
+import DrupalAttribute from '@civictheme/drupal-attribute';
 
 const template = 'components/01-atoms/image/image.twig';
 

--- a/packages/twig/components/01-atoms/input/input.test.js
+++ b/packages/twig/components/01-atoms/input/input.test.js
@@ -1,4 +1,4 @@
-import DrupalAttribute from 'drupal-attribute';
+import DrupalAttribute from '@civictheme/drupal-attribute';
 
 const template = 'components/01-atoms/input/input.twig';
 

--- a/packages/twig/components/01-atoms/label/label.test.js
+++ b/packages/twig/components/01-atoms/label/label.test.js
@@ -1,4 +1,4 @@
-import DrupalAttribute from 'drupal-attribute';
+import DrupalAttribute from '@civictheme/drupal-attribute';
 
 const template = 'components/01-atoms/label/label.twig';
 

--- a/packages/twig/components/01-atoms/link/link.test.js
+++ b/packages/twig/components/01-atoms/link/link.test.js
@@ -1,4 +1,4 @@
-import DrupalAttribute from 'drupal-attribute';
+import DrupalAttribute from '@civictheme/drupal-attribute';
 
 const template = 'components/01-atoms/link/link.twig';
 

--- a/packages/twig/components/01-atoms/paragraph/paragraph.test.js
+++ b/packages/twig/components/01-atoms/paragraph/paragraph.test.js
@@ -1,4 +1,4 @@
-import DrupalAttribute from 'drupal-attribute';
+import DrupalAttribute from '@civictheme/drupal-attribute';
 
 const template = 'components/01-atoms/paragraph/paragraph.twig';
 

--- a/packages/twig/components/01-atoms/popover/__snapshots__/popover.test.js.snap
+++ b/packages/twig/components/01-atoms/popover/__snapshots__/popover.test.js.snap
@@ -24,7 +24,6 @@ exports[`Popover Component renders with optional attributes 1`] = `
     
     
     <a
-      _keys="data-collapsible-trigger tabindex"
       class="ct-link ct-theme-dark     ct-popover__link"
       data-collapsible-trigger=""
       href="https://example.com"
@@ -85,7 +84,6 @@ exports[`Popover Component renders with required attributes 1`] = `
     
     
     <a
-      _keys="data-collapsible-trigger tabindex"
       class="ct-link ct-theme-light     ct-popover__link"
       data-collapsible-trigger=""
       tabindex="0"

--- a/packages/twig/components/01-atoms/popover/popover.test.js
+++ b/packages/twig/components/01-atoms/popover/popover.test.js
@@ -1,4 +1,4 @@
-import DrupalAttribute from 'drupal-attribute';
+import DrupalAttribute from '@civictheme/drupal-attribute';
 
 const template = 'components/01-atoms/popover/popover.twig';
 

--- a/packages/twig/components/01-atoms/radio/radio.test.js
+++ b/packages/twig/components/01-atoms/radio/radio.test.js
@@ -1,4 +1,4 @@
-import DrupalAttribute from 'drupal-attribute';
+import DrupalAttribute from '@civictheme/drupal-attribute';
 
 const template = 'components/01-atoms/radio/radio.twig';
 

--- a/packages/twig/components/01-atoms/select/select.test.js
+++ b/packages/twig/components/01-atoms/select/select.test.js
@@ -1,4 +1,4 @@
-import DrupalAttribute from 'drupal-attribute';
+import DrupalAttribute from '@civictheme/drupal-attribute';
 
 const template = 'components/01-atoms/select/select.twig';
 

--- a/packages/twig/components/01-atoms/table/table.test.js
+++ b/packages/twig/components/01-atoms/table/table.test.js
@@ -1,4 +1,4 @@
-import DrupalAttribute from 'drupal-attribute';
+import DrupalAttribute from '@civictheme/drupal-attribute';
 
 const template = 'components/01-atoms/table/table.twig';
 

--- a/packages/twig/components/01-atoms/tag/tag.test.js
+++ b/packages/twig/components/01-atoms/tag/tag.test.js
@@ -1,4 +1,4 @@
-import DrupalAttribute from 'drupal-attribute';
+import DrupalAttribute from '@civictheme/drupal-attribute';
 
 const template = 'components/01-atoms/tag/tag.twig';
 

--- a/packages/twig/components/01-atoms/textarea/textarea.test.js
+++ b/packages/twig/components/01-atoms/textarea/textarea.test.js
@@ -1,4 +1,4 @@
-import DrupalAttribute from 'drupal-attribute';
+import DrupalAttribute from '@civictheme/drupal-attribute';
 
 const template = 'components/01-atoms/textarea/textarea.twig';
 

--- a/packages/twig/components/01-atoms/textfield/textfield.test.js
+++ b/packages/twig/components/01-atoms/textfield/textfield.test.js
@@ -1,4 +1,4 @@
-import DrupalAttribute from 'drupal-attribute';
+import DrupalAttribute from '@civictheme/drupal-attribute';
 
 const template = 'components/01-atoms/textfield/textfield.twig';
 

--- a/packages/twig/components/01-atoms/video/video.test.js
+++ b/packages/twig/components/01-atoms/video/video.test.js
@@ -1,4 +1,4 @@
-import DrupalAttribute from 'drupal-attribute';
+import DrupalAttribute from '@civictheme/drupal-attribute';
 
 const template = 'components/01-atoms/video/video.twig';
 

--- a/packages/twig/components/02-molecules/accordion/accordion.test.js
+++ b/packages/twig/components/02-molecules/accordion/accordion.test.js
@@ -1,4 +1,4 @@
-import DrupalAttribute from 'drupal-attribute';
+import DrupalAttribute from '@civictheme/drupal-attribute';
 
 const template = 'components/02-molecules/accordion/accordion.twig';
 

--- a/packages/twig/components/02-molecules/attachment/attachment.test.js
+++ b/packages/twig/components/02-molecules/attachment/attachment.test.js
@@ -1,4 +1,4 @@
-import DrupalAttribute from 'drupal-attribute';
+import DrupalAttribute from '@civictheme/drupal-attribute';
 
 const template = 'components/02-molecules/attachment/attachment.twig';
 

--- a/packages/twig/components/02-molecules/back-to-top/__snapshots__/back-to-top.test.js.snap
+++ b/packages/twig/components/02-molecules/back-to-top/__snapshots__/back-to-top.test.js.snap
@@ -13,7 +13,6 @@ exports[`Back to Top Component button contains correct icon 1`] = `
 
   
     <a
-      _keys="data-skip-to-target"
       class="ct-button ct-theme-light  ct-button--link ct-button--regular   ct-back-to-top__button"
       data-component-name="button"
       data-skip-to-target=""
@@ -70,7 +69,6 @@ exports[`Back to Top Component renders button with correct attributes 1`] = `
 
   
     <a
-      _keys="data-skip-to-target"
       class="ct-button ct-theme-light  ct-button--link ct-button--regular   ct-back-to-top__button"
       data-component-name="button"
       data-skip-to-target=""
@@ -127,7 +125,6 @@ exports[`Back to Top Component renders correctly 1`] = `
 
   
     <a
-      _keys="data-skip-to-target"
       class="ct-button ct-theme-light  ct-button--link ct-button--regular   ct-back-to-top__button"
       data-component-name="button"
       data-skip-to-target=""

--- a/packages/twig/components/02-molecules/basic-content/basic-content.test.js
+++ b/packages/twig/components/02-molecules/basic-content/basic-content.test.js
@@ -1,4 +1,4 @@
-import DrupalAttribute from 'drupal-attribute';
+import DrupalAttribute from '@civictheme/drupal-attribute';
 
 const template = 'components/02-molecules/basic-content/basic-content.twig';
 

--- a/packages/twig/components/02-molecules/breadcrumb/__snapshots__/breadcrumb.test.js.snap
+++ b/packages/twig/components/02-molecules/breadcrumb/__snapshots__/breadcrumb.test.js.snap
@@ -342,7 +342,6 @@ exports[`Breadcrumb Component renders with optional attributes 1`] = `
         class="ct-item-list__item"
       >
         <a
-          _keys="aria-current"
           aria-current="location"
           class="ct-link ct-theme-dark  ct-link--active   ct-breadcrumb__links__link ct-breadcrumb__links__link--active"
           href="/category/subcategory"

--- a/packages/twig/components/02-molecules/breadcrumb/breadcrumb.test.js
+++ b/packages/twig/components/02-molecules/breadcrumb/breadcrumb.test.js
@@ -1,4 +1,4 @@
-import DrupalAttribute from 'drupal-attribute';
+import DrupalAttribute from '@civictheme/drupal-attribute';
 
 const template = 'components/02-molecules/breadcrumb/breadcrumb.twig';
 

--- a/packages/twig/components/02-molecules/callout/callout.test.js
+++ b/packages/twig/components/02-molecules/callout/callout.test.js
@@ -1,4 +1,4 @@
-import DrupalAttribute from 'drupal-attribute';
+import DrupalAttribute from '@civictheme/drupal-attribute';
 
 const template = 'components/02-molecules/callout/callout.twig';
 

--- a/packages/twig/components/02-molecules/event-card/event-card.test.js
+++ b/packages/twig/components/02-molecules/event-card/event-card.test.js
@@ -1,4 +1,4 @@
-import DrupalAttribute from 'drupal-attribute';
+import DrupalAttribute from '@civictheme/drupal-attribute';
 
 const template = 'components/02-molecules/event-card/event-card.twig';
 

--- a/packages/twig/components/02-molecules/fast-fact-card/fast-fact-card.test.js
+++ b/packages/twig/components/02-molecules/fast-fact-card/fast-fact-card.test.js
@@ -1,4 +1,4 @@
-import DrupalAttribute from 'drupal-attribute';
+import DrupalAttribute from '@civictheme/drupal-attribute';
 
 const template = 'components/02-molecules/fast-fact-card/fast-fact-card.twig';
 

--- a/packages/twig/components/02-molecules/field/field.test.js
+++ b/packages/twig/components/02-molecules/field/field.test.js
@@ -1,4 +1,4 @@
-import DrupalAttribute from 'drupal-attribute';
+import DrupalAttribute from '@civictheme/drupal-attribute';
 
 const template = 'components/02-molecules/field/field.twig';
 

--- a/packages/twig/components/02-molecules/figure/figure.test.js
+++ b/packages/twig/components/02-molecules/figure/figure.test.js
@@ -1,4 +1,4 @@
-import DrupalAttribute from 'drupal-attribute';
+import DrupalAttribute from '@civictheme/drupal-attribute';
 
 const template = 'components/02-molecules/figure/figure.twig';
 

--- a/packages/twig/components/02-molecules/group-filter/__snapshots__/group-filter.test.js.snap
+++ b/packages/twig/components/02-molecules/group-filter/__snapshots__/group-filter.test.js.snap
@@ -89,7 +89,6 @@ exports[`Group Filter Component renders with content top and bottom 1`] = `
 
   
                 <ul
-                  _keys="data-group-filter-filters"
                   class="ct-item-list ct-item-list--horizontal ct-item-list--large  ct-group-filter__filters"
                   data-group-filter-filters=""
                 >
@@ -111,7 +110,6 @@ exports[`Group Filter Component renders with content top and bottom 1`] = `
                       
     
                       <a
-                        _keys="data-collapsible-trigger tabindex"
                         class="ct-link ct-theme-light     ct-popover__link"
                         data-collapsible-trigger=""
                         tabindex="0"
@@ -166,7 +164,6 @@ exports[`Group Filter Component renders with content top and bottom 1`] = `
                       
     
                       <a
-                        _keys="data-collapsible-trigger tabindex"
                         class="ct-link ct-theme-light     ct-popover__link"
                         data-collapsible-trigger=""
                         tabindex="0"
@@ -228,7 +225,6 @@ exports[`Group Filter Component renders with content top and bottom 1`] = `
 
   
                 <button
-                  _keys="type"
                   class="ct-button ct-theme-light ct-button--primary ct-button--button ct-button--small   ct-group-filter__submit"
                   data-component-name="button"
                   type="submit"
@@ -382,7 +378,6 @@ exports[`Group Filter Component renders with custom attributes and classes 1`] =
 
   
                 <ul
-                  _keys="data-group-filter-filters"
                   class="ct-item-list ct-item-list--horizontal ct-item-list--large  ct-group-filter__filters"
                   data-group-filter-filters=""
                 >
@@ -404,7 +399,6 @@ exports[`Group Filter Component renders with custom attributes and classes 1`] =
                       
     
                       <a
-                        _keys="data-collapsible-trigger tabindex"
                         class="ct-link ct-theme-light     ct-popover__link"
                         data-collapsible-trigger=""
                         tabindex="0"
@@ -459,7 +453,6 @@ exports[`Group Filter Component renders with custom attributes and classes 1`] =
                       
     
                       <a
-                        _keys="data-collapsible-trigger tabindex"
                         class="ct-link ct-theme-light     ct-popover__link"
                         data-collapsible-trigger=""
                         tabindex="0"
@@ -521,7 +514,6 @@ exports[`Group Filter Component renders with custom attributes and classes 1`] =
 
   
                 <button
-                  _keys="type"
                   class="ct-button ct-theme-light ct-button--primary ct-button--button ct-button--small   ct-group-filter__submit"
                   data-component-name="button"
                   type="submit"
@@ -667,7 +659,6 @@ exports[`Group Filter Component renders with custom title and submit text 1`] = 
 
   
                 <ul
-                  _keys="data-group-filter-filters"
                   class="ct-item-list ct-item-list--horizontal ct-item-list--large  ct-group-filter__filters"
                   data-group-filter-filters=""
                 >
@@ -689,7 +680,6 @@ exports[`Group Filter Component renders with custom title and submit text 1`] = 
                       
     
                       <a
-                        _keys="data-collapsible-trigger tabindex"
                         class="ct-link ct-theme-light     ct-popover__link"
                         data-collapsible-trigger=""
                         tabindex="0"
@@ -744,7 +734,6 @@ exports[`Group Filter Component renders with custom title and submit text 1`] = 
                       
     
                       <a
-                        _keys="data-collapsible-trigger tabindex"
                         class="ct-link ct-theme-light     ct-popover__link"
                         data-collapsible-trigger=""
                         tabindex="0"
@@ -806,7 +795,6 @@ exports[`Group Filter Component renders with custom title and submit text 1`] = 
 
   
                 <button
-                  _keys="type"
                   class="ct-button ct-theme-light ct-button--primary ct-button--button ct-button--small   ct-group-filter__submit"
                   data-component-name="button"
                   type="submit"
@@ -952,7 +940,6 @@ exports[`Group Filter Component renders with default values 1`] = `
 
   
                 <ul
-                  _keys="data-group-filter-filters"
                   class="ct-item-list ct-item-list--horizontal ct-item-list--large  ct-group-filter__filters"
                   data-group-filter-filters=""
                 >
@@ -974,7 +961,6 @@ exports[`Group Filter Component renders with default values 1`] = `
                       
     
                       <a
-                        _keys="data-collapsible-trigger tabindex"
                         class="ct-link ct-theme-light     ct-popover__link"
                         data-collapsible-trigger=""
                         tabindex="0"
@@ -1029,7 +1015,6 @@ exports[`Group Filter Component renders with default values 1`] = `
                       
     
                       <a
-                        _keys="data-collapsible-trigger tabindex"
                         class="ct-link ct-theme-light     ct-popover__link"
                         data-collapsible-trigger=""
                         tabindex="0"
@@ -1091,7 +1076,6 @@ exports[`Group Filter Component renders with default values 1`] = `
 
   
                 <button
-                  _keys="type"
                   class="ct-button ct-theme-light ct-button--primary ct-button--button ct-button--small   ct-group-filter__submit"
                   data-component-name="button"
                   type="submit"
@@ -1244,7 +1228,6 @@ exports[`Group Filter Component renders with form attributes and hidden fields 1
 
   
                   <ul
-                    _keys="data-group-filter-filters"
                     class="ct-item-list ct-item-list--horizontal ct-item-list--large  ct-group-filter__filters"
                     data-group-filter-filters=""
                   >
@@ -1266,7 +1249,6 @@ exports[`Group Filter Component renders with form attributes and hidden fields 1
                         
     
                         <a
-                          _keys="data-collapsible-trigger tabindex"
                           class="ct-link ct-theme-light     ct-popover__link"
                           data-collapsible-trigger=""
                           tabindex="0"
@@ -1321,7 +1303,6 @@ exports[`Group Filter Component renders with form attributes and hidden fields 1
                         
     
                         <a
-                          _keys="data-collapsible-trigger tabindex"
                           class="ct-link ct-theme-light     ct-popover__link"
                           data-collapsible-trigger=""
                           tabindex="0"
@@ -1383,7 +1364,6 @@ exports[`Group Filter Component renders with form attributes and hidden fields 1
 
   
                   <button
-                    _keys="type"
                     class="ct-button ct-theme-light ct-button--primary ct-button--button ct-button--small   ct-group-filter__submit"
                     data-component-name="button"
                     type="submit"

--- a/packages/twig/components/02-molecules/group-filter/group-filter.test.js
+++ b/packages/twig/components/02-molecules/group-filter/group-filter.test.js
@@ -1,4 +1,4 @@
-import DrupalAttribute from 'drupal-attribute';
+import DrupalAttribute from '@civictheme/drupal-attribute';
 
 const template = 'components/02-molecules/group-filter/group-filter.twig';
 

--- a/packages/twig/components/02-molecules/logo/logo.test.js
+++ b/packages/twig/components/02-molecules/logo/logo.test.js
@@ -1,4 +1,4 @@
-import DrupalAttribute from 'drupal-attribute';
+import DrupalAttribute from '@civictheme/drupal-attribute';
 
 const template = 'components/02-molecules/logo/logo.twig';
 

--- a/packages/twig/components/02-molecules/map/__snapshots__/map.test.js.snap
+++ b/packages/twig/components/02-molecules/map/__snapshots__/map.test.js.snap
@@ -43,7 +43,6 @@ exports[`Map Component renders with default view text 1`] = `
 
 
             <iframe
-              _keys="allowfullscreen data-chromatic"
               allowfullscreen=""
               class="ct-iframe ct-theme-light   ct-map__iframe"
               data-chromatic="ignore"
@@ -162,7 +161,6 @@ exports[`Map Component renders with optional attributes 1`] = `
 
 
             <iframe
-              _keys="allowfullscreen data-chromatic"
               allowfullscreen=""
               class="ct-iframe ct-theme-light   ct-map__iframe"
               data-chromatic="ignore"
@@ -281,7 +279,6 @@ exports[`Map Component renders with required attributes 1`] = `
 
 
             <iframe
-              _keys="allowfullscreen data-chromatic"
               allowfullscreen=""
               class="ct-iframe ct-theme-light   ct-map__iframe"
               data-chromatic="ignore"

--- a/packages/twig/components/02-molecules/map/map.test.js
+++ b/packages/twig/components/02-molecules/map/map.test.js
@@ -1,4 +1,4 @@
-import DrupalAttribute from 'drupal-attribute';
+import DrupalAttribute from '@civictheme/drupal-attribute';
 
 const template = 'components/02-molecules/map/map.twig';
 

--- a/packages/twig/components/02-molecules/navigation-card/navigation-card.test.js
+++ b/packages/twig/components/02-molecules/navigation-card/navigation-card.test.js
@@ -1,4 +1,4 @@
-import DrupalAttribute from 'drupal-attribute';
+import DrupalAttribute from '@civictheme/drupal-attribute';
 
 const template = 'components/02-molecules/navigation-card/navigation-card.twig';
 

--- a/packages/twig/components/02-molecules/next-step/next-step.test.js
+++ b/packages/twig/components/02-molecules/next-step/next-step.test.js
@@ -1,4 +1,4 @@
-import DrupalAttribute from 'drupal-attribute';
+import DrupalAttribute from '@civictheme/drupal-attribute';
 
 const template = 'components/02-molecules/next-step/next-step.twig';
 

--- a/packages/twig/components/02-molecules/pagination/__snapshots__/pagination.test.js.snap
+++ b/packages/twig/components/02-molecules/pagination/__snapshots__/pagination.test.js.snap
@@ -42,7 +42,6 @@ exports[`Pagination Component renders current page correctly 1`] = `
         
         
         <a
-          _keys="title"
           class="ct-link ct-theme-light     ct-pagination__link"
           href="#previous"
           title="Go to previous page - page 1"
@@ -97,7 +96,6 @@ exports[`Pagination Component renders current page correctly 1`] = `
         
           
         <a
-          _keys="title"
           class="ct-link ct-theme-light     ct-pagination__item__link"
           href="#1"
           title="Go to page 1 of 3"
@@ -121,7 +119,6 @@ exports[`Pagination Component renders current page correctly 1`] = `
         
           
         <a
-          _keys="title"
           class="ct-link ct-theme-light  ct-link--active   ct-pagination__item__link"
           href="#2"
           title="Current page"
@@ -145,7 +142,6 @@ exports[`Pagination Component renders current page correctly 1`] = `
         
           
         <a
-          _keys="title"
           class="ct-link ct-theme-light     ct-pagination__item__link"
           href="#3"
           title="Go to page 3 of 3"
@@ -169,7 +165,6 @@ exports[`Pagination Component renders current page correctly 1`] = `
         
         
         <a
-          _keys="title"
           class="ct-link ct-theme-light   ct-link--disabled  ct-pagination__link"
           disabled=""
           href="#next"
@@ -341,7 +336,6 @@ exports[`Pagination Component renders with optional attributes 1`] = `
         
           
         <a
-          _keys="title"
           class="ct-link ct-theme-dark     ct-pagination__link"
           href="#first"
           title="Go to first page"
@@ -395,7 +389,6 @@ exports[`Pagination Component renders with optional attributes 1`] = `
         
         
         <a
-          _keys="title"
           class="ct-link ct-theme-dark     ct-pagination__link"
           href="#previous"
           title="Go to previous page - page 1"
@@ -450,7 +443,6 @@ exports[`Pagination Component renders with optional attributes 1`] = `
         
           
         <a
-          _keys="title"
           class="ct-link ct-theme-dark     ct-pagination__item__link"
           href="#1"
           title="Go to page 1 of 3"
@@ -474,7 +466,6 @@ exports[`Pagination Component renders with optional attributes 1`] = `
         
           
         <a
-          _keys="title"
           class="ct-link ct-theme-dark  ct-link--active   ct-pagination__item__link"
           href="#2"
           title="Current page"
@@ -508,7 +499,6 @@ exports[`Pagination Component renders with optional attributes 1`] = `
         
           
         <a
-          _keys="title"
           class="ct-link ct-theme-dark     ct-pagination__item__link"
           href="#3"
           title="Go to page 3 of 3"
@@ -532,7 +522,6 @@ exports[`Pagination Component renders with optional attributes 1`] = `
         
         
         <a
-          _keys="title"
           class="ct-link ct-theme-dark   ct-link--disabled  ct-pagination__link"
           disabled=""
           href="#next"
@@ -587,7 +576,6 @@ exports[`Pagination Component renders with optional attributes 1`] = `
         
           
         <a
-          _keys="title"
           class="ct-link ct-theme-dark   ct-link--disabled  ct-pagination__link"
           disabled=""
           href="#last"
@@ -677,7 +665,6 @@ exports[`Pagination Component renders with required attributes 1`] = `
         
         
         <a
-          _keys="title"
           class="ct-link ct-theme-light     ct-pagination__link"
           href="#previous"
           title="Go to previous page - page 1"
@@ -732,7 +719,6 @@ exports[`Pagination Component renders with required attributes 1`] = `
         
           
         <a
-          _keys="title"
           class="ct-link ct-theme-light     ct-pagination__item__link"
           href="#1"
           title="Go to page 1 of 3"
@@ -756,7 +742,6 @@ exports[`Pagination Component renders with required attributes 1`] = `
         
           
         <a
-          _keys="title"
           class="ct-link ct-theme-light  ct-link--active   ct-pagination__item__link"
           href="#2"
           title="Current page"
@@ -780,7 +765,6 @@ exports[`Pagination Component renders with required attributes 1`] = `
         
           
         <a
-          _keys="title"
           class="ct-link ct-theme-light     ct-pagination__item__link"
           href="#3"
           title="Go to page 3 of 3"
@@ -804,7 +788,6 @@ exports[`Pagination Component renders with required attributes 1`] = `
         
         
         <a
-          _keys="title"
           class="ct-link ct-theme-light   ct-link--disabled  ct-pagination__link"
           disabled=""
           href="#next"

--- a/packages/twig/components/02-molecules/pagination/pagination.test.js
+++ b/packages/twig/components/02-molecules/pagination/pagination.test.js
@@ -1,4 +1,4 @@
-import DrupalAttribute from 'drupal-attribute';
+import DrupalAttribute from '@civictheme/drupal-attribute';
 
 const template = 'components/02-molecules/pagination/pagination.twig';
 

--- a/packages/twig/components/02-molecules/promo-card/promo-card.test.js
+++ b/packages/twig/components/02-molecules/promo-card/promo-card.test.js
@@ -1,4 +1,4 @@
-import DrupalAttribute from 'drupal-attribute';
+import DrupalAttribute from '@civictheme/drupal-attribute';
 
 const template = 'components/02-molecules/promo-card/promo-card.twig';
 

--- a/packages/twig/components/02-molecules/publication-card/publication-card.test.js
+++ b/packages/twig/components/02-molecules/publication-card/publication-card.test.js
@@ -1,4 +1,4 @@
-import DrupalAttribute from 'drupal-attribute';
+import DrupalAttribute from '@civictheme/drupal-attribute';
 
 const template = 'components/02-molecules/publication-card/publication-card.twig';
 

--- a/packages/twig/components/02-molecules/search/search.test.js
+++ b/packages/twig/components/02-molecules/search/search.test.js
@@ -1,4 +1,4 @@
-import DrupalAttribute from 'drupal-attribute';
+import DrupalAttribute from '@civictheme/drupal-attribute';
 
 const template = 'components/02-molecules/search/search.twig';
 

--- a/packages/twig/components/02-molecules/service-card/service-card.test.js
+++ b/packages/twig/components/02-molecules/service-card/service-card.test.js
@@ -1,4 +1,4 @@
-import DrupalAttribute from 'drupal-attribute';
+import DrupalAttribute from '@civictheme/drupal-attribute';
 
 const template = 'components/02-molecules/service-card/service-card.twig';
 

--- a/packages/twig/components/02-molecules/single-filter/__snapshots__/single-filter.test.js.snap
+++ b/packages/twig/components/02-molecules/single-filter/__snapshots__/single-filter.test.js.snap
@@ -201,7 +201,6 @@ exports[`Single Filter Component renders with multiple selection enabled 1`] = `
 
   
               <button
-                _keys="type"
                 class="ct-button ct-theme-light ct-button--primary ct-button--button ct-button--small   ct-single-filter__submit"
                 data-component-name="button"
                 type="submit"
@@ -408,7 +407,6 @@ exports[`Single Filter Component renders with optional attributes 1`] = `
 
   
               <button
-                _keys="type"
                 class="ct-button ct-theme-dark ct-button--primary ct-button--button ct-button--small   ct-single-filter__submit"
                 data-component-name="button"
                 type="submit"
@@ -456,7 +454,6 @@ exports[`Single Filter Component renders with optional attributes 1`] = `
 
   
               <input
-                _keys="type"
                 class="ct-button ct-theme-dark ct-button--secondary ct-button--reset ct-button--small   ct-single-filter__submit"
                 data-component-name="button"
                 type="reset"
@@ -624,7 +621,6 @@ exports[`Single Filter Component renders with required attributes 1`] = `
 
   
               <button
-                _keys="type"
                 class="ct-button ct-theme-light ct-button--primary ct-button--button ct-button--small   ct-single-filter__submit"
                 data-component-name="button"
                 type="submit"

--- a/packages/twig/components/02-molecules/single-filter/single-filter.test.js
+++ b/packages/twig/components/02-molecules/single-filter/single-filter.test.js
@@ -1,4 +1,4 @@
-import DrupalAttribute from 'drupal-attribute';
+import DrupalAttribute from '@civictheme/drupal-attribute';
 
 const template = 'components/02-molecules/single-filter/single-filter.twig';
 

--- a/packages/twig/components/02-molecules/snippet/snippet.test.js
+++ b/packages/twig/components/02-molecules/snippet/snippet.test.js
@@ -1,4 +1,4 @@
-import DrupalAttribute from 'drupal-attribute';
+import DrupalAttribute from '@civictheme/drupal-attribute';
 
 const template = 'components/02-molecules/snippet/snippet.twig';
 

--- a/packages/twig/components/02-molecules/social-links/__snapshots__/social-links.test.js.snap
+++ b/packages/twig/components/02-molecules/social-links/__snapshots__/social-links.test.js.snap
@@ -34,7 +34,6 @@ exports[`Social Links Component renders with icon HTML 1`] = `
 
   
         <a
-          _keys="title"
           class="ct-button ct-theme-light ct-button--tertiary ct-button--link ct-button--regular   ct-social-links__button"
           data-component-name="button"
           href="https://facebook.com"
@@ -65,7 +64,6 @@ exports[`Social Links Component renders with icon HTML 1`] = `
 
   
         <a
-          _keys="title"
           class="ct-button ct-theme-light ct-button--tertiary ct-button--link ct-button--regular   ct-social-links__button"
           data-component-name="button"
           href="https://twitter.com"
@@ -126,7 +124,6 @@ exports[`Social Links Component renders with optional attributes 1`] = `
 
   
         <a
-          _keys="title"
           class="ct-button ct-theme-dark ct-button--tertiary ct-button--link ct-button--regular   ct-social-links__button"
           data-component-name="button"
           href="https://facebook.com"
@@ -157,7 +154,6 @@ exports[`Social Links Component renders with optional attributes 1`] = `
 
   
         <a
-          _keys="title"
           class="ct-button ct-theme-dark ct-button--tertiary ct-button--link ct-button--regular   ct-social-links__button"
           data-component-name="button"
           href="https://twitter.com"
@@ -217,7 +213,6 @@ exports[`Social Links Component renders with required attributes 1`] = `
 
   
         <a
-          _keys="title"
           class="ct-button ct-theme-light ct-button--tertiary ct-button--link ct-button--regular   ct-social-links__button"
           data-component-name="button"
           href="https://facebook.com"
@@ -262,7 +257,6 @@ exports[`Social Links Component renders with required attributes 1`] = `
 
   
         <a
-          _keys="title"
           class="ct-button ct-theme-light ct-button--tertiary ct-button--link ct-button--regular   ct-social-links__button"
           data-component-name="button"
           href="https://twitter.com"

--- a/packages/twig/components/02-molecules/social-links/social-links.test.js
+++ b/packages/twig/components/02-molecules/social-links/social-links.test.js
@@ -1,4 +1,4 @@
-import DrupalAttribute from 'drupal-attribute';
+import DrupalAttribute from '@civictheme/drupal-attribute';
 
 const template = 'components/02-molecules/social-links/social-links.twig';
 

--- a/packages/twig/components/02-molecules/subject-card/subject-card.test.js
+++ b/packages/twig/components/02-molecules/subject-card/subject-card.test.js
@@ -1,4 +1,4 @@
-import DrupalAttribute from 'drupal-attribute';
+import DrupalAttribute from '@civictheme/drupal-attribute';
 
 const template = 'components/02-molecules/subject-card/subject-card.twig';
 

--- a/packages/twig/components/02-molecules/tabs/__snapshots__/tabs.test.js.snap
+++ b/packages/twig/components/02-molecules/tabs/__snapshots__/tabs.test.js.snap
@@ -37,7 +37,6 @@ exports[`Tabs Component renders with generated links from panels 1`] = `
       >
                 
         <a
-          _keys="role id aria-controls"
           aria-controls="tab1"
           class="ct-link ct-theme-light"
           data-tabs-tab=""
@@ -60,7 +59,6 @@ exports[`Tabs Component renders with generated links from panels 1`] = `
       >
                 
         <a
-          _keys="role id aria-controls"
           aria-controls="tab2"
           class="ct-link ct-theme-light"
           data-tabs-tab=""
@@ -149,7 +147,6 @@ exports[`Tabs Component renders with optional attributes 1`] = `
       >
                 
         <a
-          _keys="role id aria-controls"
           aria-controls="tab1"
           class="ct-link ct-theme-dark"
           data-tabs-tab=""
@@ -172,7 +169,6 @@ exports[`Tabs Component renders with optional attributes 1`] = `
       >
                 
         <a
-          _keys="role id aria-controls"
           aria-controls="tab2"
           class="ct-link ct-theme-dark"
           data-tabs-tab=""
@@ -260,7 +256,6 @@ exports[`Tabs Component renders with required attributes 1`] = `
       >
                 
         <a
-          _keys="role id aria-controls"
           aria-controls="tab1"
           class="ct-link ct-theme-light"
           data-tabs-tab=""
@@ -283,7 +278,6 @@ exports[`Tabs Component renders with required attributes 1`] = `
       >
                 
         <a
-          _keys="role id aria-controls"
           aria-controls="tab2"
           class="ct-link ct-theme-light"
           data-tabs-tab=""

--- a/packages/twig/components/02-molecules/tabs/tabs.stories.js
+++ b/packages/twig/components/02-molecules/tabs/tabs.stories.js
@@ -2,7 +2,7 @@
  * CivicTheme Tabs component stories.
  */
 
-import DrupalAttribute from 'drupal-attribute';
+import DrupalAttribute from '@civictheme/drupal-attribute';
 import Component from './tabs.twig';
 
 const meta = {

--- a/packages/twig/components/02-molecules/tabs/tabs.test.js
+++ b/packages/twig/components/02-molecules/tabs/tabs.test.js
@@ -1,4 +1,4 @@
-import DrupalAttribute from 'drupal-attribute';
+import DrupalAttribute from '@civictheme/drupal-attribute';
 
 const template = 'components/02-molecules/tabs/tabs.twig';
 

--- a/packages/twig/components/02-molecules/tag-list/tag-list.test.js
+++ b/packages/twig/components/02-molecules/tag-list/tag-list.test.js
@@ -1,4 +1,4 @@
-import DrupalAttribute from 'drupal-attribute';
+import DrupalAttribute from '@civictheme/drupal-attribute';
 
 const template = 'components/02-molecules/tag-list/tag-list.twig';
 

--- a/packages/twig/components/02-molecules/tooltip/tooltip.test.js
+++ b/packages/twig/components/02-molecules/tooltip/tooltip.test.js
@@ -1,4 +1,4 @@
-import DrupalAttribute from 'drupal-attribute';
+import DrupalAttribute from '@civictheme/drupal-attribute';
 
 const template = 'components/02-molecules/tooltip/tooltip.twig';
 

--- a/packages/twig/components/03-organisms/alert/__snapshots__/alert.test.js.snap
+++ b/packages/twig/components/03-organisms/alert/__snapshots__/alert.test.js.snap
@@ -80,7 +80,6 @@ exports[`Alert Component renders with correct icon for alert type 1`] = `
 
   
           <button
-            _keys="id data-alert-dismiss-trigger title"
             class="ct-button ct-theme-light ct-button--tertiary ct-button--button ct-button--regular   ct-alert__dismiss-button"
             data-alert-dismiss-trigger=""
             data-component-name="button"
@@ -196,7 +195,6 @@ exports[`Alert Component renders with optional attributes 1`] = `
 
   
           <button
-            _keys="id data-alert-dismiss-trigger title"
             class="ct-button ct-theme-dark ct-button--tertiary ct-button--button ct-button--regular   ct-alert__dismiss-button"
             data-alert-dismiss-trigger=""
             data-component-name="button"
@@ -311,7 +309,6 @@ exports[`Alert Component renders with required attributes 1`] = `
 
   
           <button
-            _keys="id data-alert-dismiss-trigger title"
             class="ct-button ct-theme-light ct-button--tertiary ct-button--button ct-button--regular   ct-alert__dismiss-button"
             data-alert-dismiss-trigger=""
             data-component-name="button"

--- a/packages/twig/components/03-organisms/alert/alert.test.js
+++ b/packages/twig/components/03-organisms/alert/alert.test.js
@@ -1,4 +1,4 @@
-import DrupalAttribute from 'drupal-attribute';
+import DrupalAttribute from '@civictheme/drupal-attribute';
 
 const template = 'components/03-organisms/alert/alert.twig';
 

--- a/packages/twig/components/03-organisms/banner/__snapshots__/banner.test.js.snap
+++ b/packages/twig/components/03-organisms/banner/__snapshots__/banner.test.js.snap
@@ -200,7 +200,6 @@ exports[`Banner Component renders with all attributes provided 1`] = `
                     class="ct-item-list__item"
                   >
                     <a
-                      _keys="aria-current"
                       aria-current="location"
                       class="ct-link ct-theme-dark  ct-link--active   ct-breadcrumb__links__link ct-breadcrumb__links__link--active"
                       href="/section"

--- a/packages/twig/components/03-organisms/banner/banner.test.js
+++ b/packages/twig/components/03-organisms/banner/banner.test.js
@@ -1,4 +1,4 @@
-import DrupalAttribute from 'drupal-attribute';
+import DrupalAttribute from '@civictheme/drupal-attribute';
 
 const template = 'components/03-organisms/banner/banner.twig';
 

--- a/packages/twig/components/03-organisms/campaign/campaign.test.js
+++ b/packages/twig/components/03-organisms/campaign/campaign.test.js
@@ -1,4 +1,4 @@
-import DrupalAttribute from 'drupal-attribute';
+import DrupalAttribute from '@civictheme/drupal-attribute';
 
 const template = 'components/03-organisms/campaign/campaign.twig';
 

--- a/packages/twig/components/03-organisms/list/list.test.js
+++ b/packages/twig/components/03-organisms/list/list.test.js
@@ -1,4 +1,4 @@
-import DrupalAttribute from 'drupal-attribute';
+import DrupalAttribute from '@civictheme/drupal-attribute';
 
 const template = 'components/03-organisms/list/list.twig';
 

--- a/packages/twig/components/03-organisms/navigation/__snapshots__/navigation.test.js.snap
+++ b/packages/twig/components/03-organisms/navigation/__snapshots__/navigation.test.js.snap
@@ -51,7 +51,6 @@ exports[`Navigation Component renders correctly when items have submenus 1`] = `
                                             
       
         <li
-          _keys="data-collapsible data-collapsible-collapsed data-collapsible-icon-group data-collapsible-group data-collapsible-duration"
           class="ct-menu__item ct-menu__item--level-0 ct-menu__item--has-children  ct-navigation__has-dropdown ct-navigation__dropdown-columns--2 "
           data-collapsible=""
           data-collapsible-collapsed=""
@@ -132,7 +131,6 @@ exports[`Navigation Component renders correctly when items have submenus 1`] = `
                                             
       
         <li
-          _keys="data-collapsible data-collapsible-collapsed data-collapsible-icon-group data-collapsible-group data-collapsible-duration"
           class="ct-menu__item ct-menu__item--level-0 ct-menu__item--has-children  ct-navigation__has-dropdown ct-navigation__dropdown-columns--2 "
           data-collapsible=""
           data-collapsible-collapsed=""

--- a/packages/twig/components/03-organisms/promo/promo.test.js
+++ b/packages/twig/components/03-organisms/promo/promo.test.js
@@ -1,4 +1,4 @@
-import DrupalAttribute from 'drupal-attribute';
+import DrupalAttribute from '@civictheme/drupal-attribute';
 
 const template = 'components/03-organisms/promo/promo.twig';
 

--- a/packages/twig/components/03-organisms/side-navigation/__snapshots__/side-navigation.test.js.snap
+++ b/packages/twig/components/03-organisms/side-navigation/__snapshots__/side-navigation.test.js.snap
@@ -28,7 +28,6 @@ exports[`Side Navigation Component renders with all attributes provided 1`] = `
       
     
       <a
-        _keys="data-platform"
         class="ct-link ct-theme-dark     ct-skip-link__link ct-visually-hidden"
         data-platform=""
         href="#main-content"
@@ -209,7 +208,6 @@ exports[`Side Navigation Component renders with only required attributes 1`] = `
       
     
       <a
-        _keys="data-platform"
         class="ct-link ct-theme-light     ct-skip-link__link ct-visually-hidden"
         data-platform=""
         href="#main-content"
@@ -296,7 +294,6 @@ exports[`Side Navigation Component renders with some attributes missing 1`] = `
       
     
       <a
-        _keys="data-platform"
         class="ct-link ct-theme-light     ct-skip-link__link ct-visually-hidden"
         data-platform=""
         href="#main-content"

--- a/packages/twig/components/03-organisms/side-navigation/side-navigation.test.js
+++ b/packages/twig/components/03-organisms/side-navigation/side-navigation.test.js
@@ -1,4 +1,4 @@
-import DrupalAttribute from 'drupal-attribute';
+import DrupalAttribute from '@civictheme/drupal-attribute';
 
 const template = 'components/03-organisms/side-navigation/side-navigation.twig';
 

--- a/packages/twig/components/03-organisms/skip-link/__snapshots__/skip-link.test.js.snap
+++ b/packages/twig/components/03-organisms/skip-link/__snapshots__/skip-link.test.js.snap
@@ -12,7 +12,6 @@ exports[`Skip Link Component renders with all attributes provided 1`] = `
     
     
     <a
-      _keys="data-platform"
       class="ct-link ct-theme-dark     ct-skip-link__link ct-visually-hidden"
       data-platform=""
       href="#main-content"
@@ -43,7 +42,6 @@ exports[`Skip Link Component renders with default text when text is empty 1`] = 
     
     
     <a
-      _keys="data-platform"
       class="ct-link ct-theme-light     ct-skip-link__link ct-visually-hidden"
       data-platform=""
       href="#main-content"
@@ -74,7 +72,6 @@ exports[`Skip Link Component renders with only required attributes 1`] = `
     
     
     <a
-      _keys="data-platform"
       class="ct-link ct-theme-light     ct-skip-link__link ct-visually-hidden"
       data-platform=""
       href="#main-content"

--- a/packages/twig/components/03-organisms/slider/__snapshots__/slide.test.js.snap
+++ b/packages/twig/components/03-organisms/slider/__snapshots__/slide.test.js.snap
@@ -92,7 +92,6 @@ exports[`Slide Component renders with default heading level (h3) 1`] = `
 
   
           <h3
-            _keys="data-toc-exclude"
             class="ct-heading ct-theme-light ct-slide__title"
             data-toc-exclude=""
           >
@@ -161,7 +160,6 @@ exports[`Slide Component renders with heading level 2 when heading_level is 2 1`
 
   
           <h2
-            _keys="data-toc-exclude"
             class="ct-heading ct-theme-light ct-slide__title"
             data-toc-exclude=""
           >
@@ -230,7 +228,6 @@ exports[`Slide Component renders with heading level 3 when heading_level is 3 1`
 
   
           <h3
-            _keys="data-toc-exclude"
             class="ct-heading ct-theme-light ct-slide__title"
             data-toc-exclude=""
           >

--- a/packages/twig/components/03-organisms/slider/__snapshots__/slider.test.js.snap
+++ b/packages/twig/components/03-organisms/slider/__snapshots__/slider.test.js.snap
@@ -102,7 +102,6 @@ exports[`Slider Component renders with all attributes provided 1`] = `
 
   
                 <button
-                  _keys="data-slider-previous"
                   class="ct-button ct-theme-dark ct-button--secondary ct-button--button ct-button--regular   ct-slider__controls__previous"
                   data-component-name="button"
                   data-slider-previous=""
@@ -140,7 +139,6 @@ exports[`Slider Component renders with all attributes provided 1`] = `
 
   
                 <button
-                  _keys="data-slider-next"
                   class="ct-button ct-theme-dark ct-button--secondary ct-button--button ct-button--regular   ct-slider__controls__next"
                   data-component-name="button"
                   data-slider-next=""
@@ -194,7 +192,6 @@ exports[`Slider Component renders with all attributes provided 1`] = `
   
     
               <span
-                _keys="aria-live data-slider-progress"
                 aria-live="polite"
                 class="ct-tag ct-theme-dark ct-tag--primary    ct-slider__controls__progress-indicator"
                 data-slider-progress=""
@@ -303,7 +300,6 @@ exports[`Slider Component renders with only required attributes 1`] = `
 
   
                 <button
-                  _keys="data-slider-previous"
                   class="ct-button ct-theme-light ct-button--secondary ct-button--button ct-button--regular   ct-slider__controls__previous"
                   data-component-name="button"
                   data-slider-previous=""
@@ -341,7 +337,6 @@ exports[`Slider Component renders with only required attributes 1`] = `
 
   
                 <button
-                  _keys="data-slider-next"
                   class="ct-button ct-theme-light ct-button--secondary ct-button--button ct-button--regular   ct-slider__controls__next"
                   data-component-name="button"
                   data-slider-next=""
@@ -395,7 +390,6 @@ exports[`Slider Component renders with only required attributes 1`] = `
   
     
               <span
-                _keys="aria-live data-slider-progress"
                 aria-live="polite"
                 class="ct-tag ct-theme-light ct-tag--primary    ct-slider__controls__progress-indicator"
                 data-slider-progress=""
@@ -514,7 +508,6 @@ exports[`Slider Component renders without some attributes 1`] = `
 
   
                 <button
-                  _keys="data-slider-previous"
                   class="ct-button ct-theme-light ct-button--secondary ct-button--button ct-button--regular   ct-slider__controls__previous"
                   data-component-name="button"
                   data-slider-previous=""
@@ -552,7 +545,6 @@ exports[`Slider Component renders without some attributes 1`] = `
 
   
                 <button
-                  _keys="data-slider-next"
                   class="ct-button ct-theme-light ct-button--secondary ct-button--button ct-button--regular   ct-slider__controls__next"
                   data-component-name="button"
                   data-slider-next=""
@@ -606,7 +598,6 @@ exports[`Slider Component renders without some attributes 1`] = `
   
     
               <span
-                _keys="aria-live data-slider-progress"
                 aria-live="polite"
                 class="ct-tag ct-theme-light ct-tag--primary    ct-slider__controls__progress-indicator"
                 data-slider-progress=""

--- a/packages/twig/components/03-organisms/slider/slider.test.js
+++ b/packages/twig/components/03-organisms/slider/slider.test.js
@@ -1,4 +1,4 @@
-import DrupalAttribute from 'drupal-attribute';
+import DrupalAttribute from '@civictheme/drupal-attribute';
 
 const template = 'components/03-organisms/slider/slider.twig';
 

--- a/packages/twig/components/03-organisms/webform/webform.test.js
+++ b/packages/twig/components/03-organisms/webform/webform.test.js
@@ -1,4 +1,4 @@
-import DrupalAttribute from 'drupal-attribute';
+import DrupalAttribute from '@civictheme/drupal-attribute';
 
 const template = 'components/03-organisms/webform/webform.twig';
 

--- a/packages/twig/components/04-templates/page/__snapshots__/page.test.js.snap
+++ b/packages/twig/components/04-templates/page/__snapshots__/page.test.js.snap
@@ -590,7 +590,6 @@ exports[`Page Component renders all blocks with complex attributes and classes 1
 
   
       <a
-        _keys="data-skip-to-target"
         class="ct-button ct-theme-light  ct-button--link ct-button--regular   ct-back-to-top__button"
         data-component-name="button"
         data-skip-to-target=""
@@ -757,7 +756,6 @@ exports[`Page Component renders content block with permutations: {
 
   
       <a
-        _keys="data-skip-to-target"
         class="ct-button ct-theme-light  ct-button--link ct-button--regular   ct-back-to-top__button"
         data-component-name="button"
         data-skip-to-target=""
@@ -910,7 +908,6 @@ exports[`Page Component renders content block with permutations: {
 
   
       <a
-        _keys="data-skip-to-target"
         class="ct-button ct-theme-light  ct-button--link ct-button--regular   ct-back-to-top__button"
         data-component-name="button"
         data-skip-to-target=""
@@ -1063,7 +1060,6 @@ exports[`Page Component renders content block with permutations: {
 
   
       <a
-        _keys="data-skip-to-target"
         class="ct-button ct-theme-light  ct-button--link ct-button--regular   ct-back-to-top__button"
         data-component-name="button"
         data-skip-to-target=""
@@ -1202,7 +1198,6 @@ exports[`Page Component renders content block with permutations: {
 
   
       <a
-        _keys="data-skip-to-target"
         class="ct-button ct-theme-light  ct-button--link ct-button--regular   ct-back-to-top__button"
         data-component-name="button"
         data-skip-to-target=""
@@ -1305,7 +1300,6 @@ exports[`Page Component renders with custom theme and attributes 1`] = `
 
   
       <a
-        _keys="data-skip-to-target"
         class="ct-button ct-theme-light  ct-button--link ct-button--regular   ct-back-to-top__button"
         data-component-name="button"
         data-skip-to-target=""
@@ -1407,7 +1401,6 @@ exports[`Page Component renders with default values 1`] = `
 
   
       <a
-        _keys="data-skip-to-target"
         class="ct-button ct-theme-light  ct-button--link ct-button--regular   ct-back-to-top__button"
         data-component-name="button"
         data-skip-to-target=""
@@ -1510,7 +1503,6 @@ exports[`Page Component strips HTML tags from attributes 1`] = `
 
   
       <a
-        _keys="data-skip-to-target"
         class="ct-button ct-theme-light  ct-button--link ct-button--regular   ct-back-to-top__button"
         data-component-name="button"
         data-skip-to-target=""

--- a/packages/twig/components/04-templates/page/page.test.js
+++ b/packages/twig/components/04-templates/page/page.test.js
@@ -1,5 +1,5 @@
 import jestEach from 'jest-each';
-import DrupalAttribute from 'drupal-attribute';
+import DrupalAttribute from '@civictheme/drupal-attribute';
 
 const each = jestEach.default;
 

--- a/packages/twig/package.json
+++ b/packages/twig/package.json
@@ -62,7 +62,7 @@
     "stylelint-config-standard-scss": "^17.0.0",
     "twig-testing-library": "^1.2.0",
     "vite": "^6.3.5",
-    "vite-plugin-twig-drupal": "^1.7.0"
+    "vite-plugin-twig-drupal": "git+https://github.com/civictheme/vite-plugin-twig-drupal.git#semver:^1.7.1-ct.1"
   },
   "dependencies": {
     "@popperjs/core": "^2.11.8"

--- a/packages/twig/package.json
+++ b/packages/twig/package.json
@@ -45,6 +45,7 @@
     "lint:fix": "eslint ./components ./.storybook --fix"
   },
   "devDependencies": {
+    "@civictheme/drupal-attribute": "^2.0.0",
     "@civictheme/scss-variables-extractor": "^0.2.1",
     "@storybook/addon-docs": "10.2.13",
     "@storybook/addon-links": "10.2.13",
@@ -61,7 +62,7 @@
     "stylelint-config-standard-scss": "^17.0.0",
     "twig-testing-library": "^1.2.0",
     "vite": "^6.3.5",
-    "vite-plugin-twig-drupal": "^1.6.0"
+    "vite-plugin-twig-drupal": "^1.7.0"
   },
   "dependencies": {
     "@popperjs/core": "^2.11.8"

--- a/packages/twig/package.json
+++ b/packages/twig/package.json
@@ -45,7 +45,7 @@
     "lint:fix": "eslint ./components ./.storybook --fix"
   },
   "devDependencies": {
-    "@civictheme/drupal-attribute": "^2.0.0",
+    "@civictheme/drupal-attribute": "^2.0.1",
     "@civictheme/scss-variables-extractor": "^0.2.1",
     "@storybook/addon-docs": "10.2.13",
     "@storybook/addon-links": "10.2.13",

--- a/packages/twig/tests/jest.helpers.js
+++ b/packages/twig/tests/jest.helpers.js
@@ -1,5 +1,4 @@
 import { render, Twig } from 'twig-testing-library';
-import { createAttribute } from '@civictheme/drupal-attribute';
 import * as fs from 'node:fs';
 
 const dir = new URL('.', import.meta.url).pathname;
@@ -20,15 +19,6 @@ const wrappedRender = async (template, props = {}, namespaces = {}, twigCallback
     TwigInstance.twig = function (options) {
       options.autoescape = false;
       options.allowInlineIncludes = true;
-      // twig-testing-library registers create_attribute as
-      // `new DrupalAttribute(Object.entries(value))`, which carries twig.js's
-      // `_keys` bookkeeping property into the markup as an attribute. It does so
-      // inside loadTemplate, which runs after this callback, so registering at
-      // module scope or directly here would be overwritten. loadTemplate only
-      // reassigns twigAsync, and twigAsync calls twig() - so this wrapper is the
-      // first hook that runs after its registration. createAttribute drops
-      // `_keys` and uses it to order the remaining attributes.
-      TwigInstance.extendFunction('create_attribute', createAttribute);
       return originalTwig(options);
     };
     twigCallback(TwigInstance);

--- a/packages/twig/tests/jest.helpers.js
+++ b/packages/twig/tests/jest.helpers.js
@@ -1,4 +1,5 @@
 import { render, Twig } from 'twig-testing-library';
+import { createAttribute } from '@civictheme/drupal-attribute';
 import * as fs from 'node:fs';
 
 const dir = new URL('.', import.meta.url).pathname;
@@ -19,6 +20,15 @@ const wrappedRender = async (template, props = {}, namespaces = {}, twigCallback
     TwigInstance.twig = function (options) {
       options.autoescape = false;
       options.allowInlineIncludes = true;
+      // twig-testing-library registers create_attribute as
+      // `new DrupalAttribute(Object.entries(value))`, which carries twig.js's
+      // `_keys` bookkeeping property into the markup as an attribute. It does so
+      // inside loadTemplate, which runs after this callback, so registering at
+      // module scope or directly here would be overwritten. loadTemplate only
+      // reassigns twigAsync, and twigAsync calls twig() - so this wrapper is the
+      // first hook that runs after its registration. createAttribute drops
+      // `_keys` and uses it to order the remaining attributes.
+      TwigInstance.extendFunction('create_attribute', createAttribute);
       return originalTwig(options);
     };
     twigCallback(TwigInstance);


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have formatted the subject to include the issue number
  as `[#123] Verb in past tense with a period at the end.`
- [x] I have provided information in the `Changed` section about WHY something was
  done if this was a bespoke implementation.
- [x] I have performed a self-review of my code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have run new and existing relevant tests locally with my changes,
  and they have passed.
- [ ] I have provided screenshots, where applicable.


## Changed

1. Moved `drupal-attribute` from the GitLab git dependency to the published
   `@civictheme/drupal-attribute@2.0.1`, as a devDependency in both packages,
   with the 130 test/story imports updated. The root override is repointed
   rather than removed, so the toolchain packages that import bare
   `drupal-attribute` stay on the same version we do.

2. Bumped `vite-plugin-twig-drupal` to 1.7.0 — it widens `twig` to
   `^1.16.0 || ^2 || ^3`, and the root override already forces twig 3.

3. `_keys` no longer renders as an HTML attribute. Fixed in 2.0.1, not here;
   snapshots regenerated across 34 files, deletions only.

4. Moved the `drupal-twig-extensions` override to
   `civictheme/drupal-twig-extensions` — same commit, namespace only.

5. Allowed the `symfony/runtime` Composer plugin, which Drupal core 11.4 added
   and `drupal/recommended-project:11.1` doesn't list. This unblocks
   `test-drupal-sdc`, which was already failing on `main`.

The large lockfile deletion is the git dependency's build toolchain (161
entries) no longer being needed.
