### PR TITLE
Fixed event card tag items being documented as "text" instead of "content".

### DIFF
--- a/packages/sdc/components/02-molecules/event-card/__snapshots__/event-card.test.js.snap
+++ b/packages/sdc/components/02-molecules/event-card/__snapshots__/event-card.test.js.snap
@@ -1,5 +1,116 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Event Card Component renders tags provided as objects 1`] = `
+<div>
+  
+
+  
+  <div
+    class="ct-event-card ct-theme-light    "
+  >
+    
+              
+          
+    <div
+      class="ct-event-card__content"
+    >
+      
+                          
+                          
+                                          
+      <div
+        class="ct-event-card__title"
+      >
+                                      Event Title
+                          
+      </div>
+      
+                  
+                          
+                          
+                          
+                              
+      <div
+        class="ct-event-card__tags"
+      >
+        
+                              
+
+  
+        <div
+          class="ct-tag-list ct-theme-light  "
+        >
+          
+              
+                                                                                          
+
+  
+          <ul
+            class="ct-item-list ct-item-list--horizontal ct-item-list--small  ct-tag-list__content"
+          >
+            
+                  
+            <li
+              class="ct-item-list__item"
+            >
+                                      
+
+  
+  
+  
+    
+              <a
+                class="ct-tag ct-theme-light ct-tag--primary    "
+                href="https://example.com/tag-1"
+                title="Tag 1"
+              >
+                    Tag 1  
+              </a>
+              
+          
+            </li>
+            
+                        
+            <li
+              class="ct-item-list__item"
+            >
+                                      
+
+  
+  
+  
+    
+              <span
+                class="ct-tag ct-theme-light ct-tag--primary    "
+              >
+                    Tag 2  
+              </span>
+              
+          
+            </li>
+            
+            
+          </ul>
+          
+          
+                
+        </div>
+        
+              
+                          
+      </div>
+      
+                  
+                                
+    </div>
+    
+      
+  </div>
+  
+
+</div>
+`;
+
 exports[`Event Card Component renders with optional attributes 1`] = `
 <div>
   

--- a/packages/sdc/components/02-molecules/event-card/event-card.component.yml
+++ b/packages/sdc/components/02-molecules/event-card/event-card.component.yml
@@ -65,7 +65,7 @@ props:
       items:
         type: object
         properties:
-          text:
+          content:
             type: string
             title: Text
             description: Tag text.

--- a/packages/sdc/components/02-molecules/event-card/event-card.test.js
+++ b/packages/sdc/components/02-molecules/event-card/event-card.test.js
@@ -71,4 +71,22 @@ describe('Event Card Component', () => {
 
     assertUniqueCssClasses(c);
   });
+
+  test('renders tags provided as objects', async () => {
+    const c = await dom(template, {
+      title: 'Event Title',
+      tags: [
+        { content: 'Tag 1', url: 'https://example.com/tag-1' },
+        { content: 'Tag 2' },
+      ],
+    });
+
+    const tags = c.querySelectorAll('.ct-event-card__tags .ct-tag');
+    expect(tags).toHaveLength(2);
+    expect(tags[0].textContent.trim()).toEqual('Tag 1');
+    expect(tags[0].getAttribute('href')).toEqual('https://example.com/tag-1');
+    expect(tags[1].textContent.trim()).toEqual('Tag 2');
+
+    assertUniqueCssClasses(c);
+  });
 });

--- a/packages/sdc/components/02-molecules/event-card/event-card.twig
+++ b/packages/sdc/components/02-molecules/event-card/event-card.twig
@@ -20,7 +20,7 @@
  *   - is_new_window: [boolean] Whether to open in a new window.
  * - tags: [array] Event tags:
  *   Each item contains:
- *   - text: [string] Tag text.
+ *   - content: [string] Tag text.
  *   - url: [string] Tag URL.
  *   - is_new_window: [boolean] Whether to open tag in a new window.
  * - modifier_class: [string] Additional CSS classes.

--- a/packages/twig/components/02-molecules/event-card/__snapshots__/event-card.test.js.snap
+++ b/packages/twig/components/02-molecules/event-card/__snapshots__/event-card.test.js.snap
@@ -1,5 +1,116 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Event Card Component renders tags provided as objects 1`] = `
+<div>
+  
+
+  
+  <div
+    class="ct-event-card ct-theme-light    "
+  >
+    
+              
+          
+    <div
+      class="ct-event-card__content"
+    >
+      
+                          
+                          
+                                          
+      <div
+        class="ct-event-card__title"
+      >
+                                      Event Title
+                          
+      </div>
+      
+                  
+                          
+                          
+                          
+                              
+      <div
+        class="ct-event-card__tags"
+      >
+        
+                              
+
+  
+        <div
+          class="ct-tag-list ct-theme-light  "
+        >
+          
+              
+                                                                                          
+
+  
+          <ul
+            class="ct-item-list ct-item-list--horizontal ct-item-list--small  ct-tag-list__content"
+          >
+            
+                  
+            <li
+              class="ct-item-list__item"
+            >
+                                      
+
+  
+  
+  
+    
+              <a
+                class="ct-tag ct-theme-light ct-tag--primary    "
+                href="https://example.com/tag-1"
+                title="Tag 1"
+              >
+                    Tag 1  
+              </a>
+              
+          
+            </li>
+            
+                        
+            <li
+              class="ct-item-list__item"
+            >
+                                      
+
+  
+  
+  
+    
+              <span
+                class="ct-tag ct-theme-light ct-tag--primary    "
+              >
+                    Tag 2  
+              </span>
+              
+          
+            </li>
+            
+            
+          </ul>
+          
+          
+                
+        </div>
+        
+              
+                          
+      </div>
+      
+                  
+                                
+    </div>
+    
+      
+  </div>
+  
+
+</div>
+`;
+
 exports[`Event Card Component renders with optional attributes 1`] = `
 <div>
   

--- a/packages/twig/components/02-molecules/event-card/event-card.test.js
+++ b/packages/twig/components/02-molecules/event-card/event-card.test.js
@@ -71,4 +71,22 @@ describe('Event Card Component', () => {
 
     assertUniqueCssClasses(c);
   });
+
+  test('renders tags provided as objects', async () => {
+    const c = await dom(template, {
+      title: 'Event Title',
+      tags: [
+        { content: 'Tag 1', url: 'https://example.com/tag-1' },
+        { content: 'Tag 2' },
+      ],
+    });
+
+    const tags = c.querySelectorAll('.ct-event-card__tags .ct-tag');
+    expect(tags).toHaveLength(2);
+    expect(tags[0].textContent.trim()).toEqual('Tag 1');
+    expect(tags[0].getAttribute('href')).toEqual('https://example.com/tag-1');
+    expect(tags[1].textContent.trim()).toEqual('Tag 2');
+
+    assertUniqueCssClasses(c);
+  });
 });

--- a/packages/twig/components/02-molecules/event-card/event-card.twig
+++ b/packages/twig/components/02-molecules/event-card/event-card.twig
@@ -20,7 +20,7 @@
  *   - is_new_window: [boolean] Whether to open in a new window.
  * - tags: [array] Event tags:
  *   Each item contains:
- *   - text: [string] Tag text.
+ *   - content: [string] Tag text.
  *   - url: [string] Tag URL.
  *   - is_new_window: [boolean] Whether to open tag in a new window.
  * - modifier_class: [string] Additional CSS classes.


### PR DESCRIPTION
## Checklist before requesting a review

- [ ] I have formatted the subject to include the issue number
  as `[#123] Verb in past tense with a period at the end.` — no issue raised
- [x] I have provided information in the `Changed` section about WHY something was
  done if this was a bespoke implementation.
- [x] I have performed a self-review of my code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have run new and existing relevant tests locally with my changes,
  and they have passed.
- [ ] I have provided screenshots, where applicable. — no visual change to working usage

## Changed

1. Renamed the event card's tag item property from `text` to `content` in
   `event-card.component.yml`, and propagated the docblock via `components:update`.
2. `event-card.twig` forwards `tags` untouched to `tag-list`, which merges each item into
   `tag.twig`. That component reads `content` and skips rendering when it is empty, so the
   documented `text` key produced no tag at all.
3. `event-card` was the only one of four components passing tags this way to get it wrong;
   `promo-card`, `campaign` and `slide` already use `content`.
4. Added a test for the object form of `tags`; every existing test and story passed plain
   strings, which `tag-list` converts itself.

## Screenshots

N/A
