### PR TITLE
Added build-time validation of icon references.

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "test:ci": "npm run test:ci --workspaces",
     "lint": "npm run lint --workspaces && eslint ./tools/visual-diff/**/*.mjs ./tools/scripts/**/*.js && npm run validate",
     "lint:fix": "npm run lint:fix --workspaces && eslint ./tools/visual-diff/**/*.mjs ./tools/scripts/**/*.js --fix",
-    "validate": "node tools/scripts/validate-theme-variables.js && node tools/scripts/validate-component-enums.js",
+    "validate": "node tools/scripts/validate-theme-variables.js && node tools/scripts/validate-component-enums.js && node tools/scripts/validate-icons.js",
     "diff": "node tools/visual-diff/index.mjs interactive",
     "diff:command": "node tools/visual-diff/index.mjs",
     "diff:snapshot": "./tools/scripts/snapshot-diff.sh",

--- a/tools/scripts/validate-icons.js
+++ b/tools/scripts/validate-icons.js
@@ -1,0 +1,152 @@
+#!/usr/bin/env node
+
+/**
+ * Validates that every icon referenced by name actually exists.
+ *
+ * The icon component inlines its SVG through Twig's source() with
+ * ignore_missing set, and is wrapped in `{% if source is not empty %}`. A name
+ * that does not resolve therefore renders nothing at all, raises no error and
+ * fails no test — a mistyped icon is invisible until someone looks at the page.
+ *
+ * This catches those references at build time instead, where a name is written
+ * as a literal in a template, story or test.
+ */
+
+import fs from 'fs';
+import path from 'path';
+
+const PACKAGES = [
+  path.join(import.meta.dirname, '../../packages/sdc'),
+  path.join(import.meta.dirname, '../../packages/twig'),
+];
+
+const SCANNED_EXTENSIONS = ['.twig', '.js'];
+
+// Matches `icon: 'name'` and `symbol: "name"` where the value is a literal.
+// The negative lookbehind keeps `icon_placement:` and `icon_class:` out, and a
+// non-literal value such as `symbol: icon` simply does not match.
+const REFERENCE_PATTERN = /(?<![\w-])(icon|symbol)\s*:\s*(['"])([^'"]*)\2/g;
+
+// ANSI color codes for terminal output.
+const colors = {
+  red: '\x1b[31m',
+  green: '\x1b[32m',
+  yellow: '\x1b[33m',
+  blue: '\x1b[34m',
+  reset: '\x1b[0m',
+};
+
+/**
+ * Returns the set of icon names available to a package.
+ */
+function availableIcons(packageDir) {
+  const iconsDir = path.join(packageDir, 'assets/icons');
+  if (!fs.existsSync(iconsDir)) {
+    return null;
+  }
+
+  return new Set(
+    fs.readdirSync(iconsDir)
+      .filter((entry) => entry.endsWith('.svg'))
+      .map((entry) => path.basename(entry, '.svg')),
+  );
+}
+
+/**
+ * Recursively find files worth scanning under a directory.
+ */
+function findFiles(dir) {
+  const results = [];
+
+  if (!fs.existsSync(dir)) {
+    return results;
+  }
+
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (entry.name !== '__snapshots__') {
+        results.push(...findFiles(fullPath));
+      }
+    } else if (SCANNED_EXTENSIONS.includes(path.extname(entry.name))) {
+      results.push(fullPath);
+    }
+  }
+
+  return results;
+}
+
+/**
+ * Collects unknown icon references from a single file.
+ */
+function validateFile(filePath, icons) {
+  const errors = [];
+  const content = fs.readFileSync(filePath, 'utf8');
+  const lines = content.split('\n');
+
+  lines.forEach((line, index) => {
+    for (const match of line.matchAll(REFERENCE_PATTERN)) {
+      const [, property, , name] = match;
+
+      // An empty value is how templates opt out of rendering an icon.
+      if (name === '') {
+        continue;
+      }
+
+      if (!icons.has(name)) {
+        errors.push({
+          filePath,
+          line: index + 1,
+          message: `${property}: '${name}' does not match any icon in assets/icons`,
+        });
+      }
+    }
+  });
+
+  return errors;
+}
+
+/**
+ * Main validation function.
+ */
+function validate() {
+  console.log(`${colors.blue}Validating icon references...${colors.reset}\n`);
+
+  const rootDir = path.join(import.meta.dirname, '../..');
+  const allErrors = [];
+
+  for (const packageDir of PACKAGES) {
+    const icons = availableIcons(packageDir);
+    if (icons === null) {
+      continue;
+    }
+
+    const files = findFiles(path.join(packageDir, 'components')).sort();
+    const relDir = path.relative(rootDir, packageDir);
+    console.log(`${colors.blue}Scanning ${relDir} (${files.length} files, ${icons.size} icons available)${colors.reset}`);
+
+    for (const filePath of files) {
+      allErrors.push(...validateFile(filePath, icons));
+    }
+  }
+
+  console.log('');
+
+  if (allErrors.length > 0) {
+    console.log(`${colors.red}Found ${allErrors.length} error(s):${colors.reset}\n`);
+    for (const error of allErrors) {
+      const relPath = path.relative(rootDir, error.filePath);
+      console.log(`  ${colors.yellow}${relPath}:${error.line}${colors.reset}`);
+      console.log(`    ${error.message}\n`);
+    }
+    console.log('─'.repeat(60));
+    console.log(`${colors.red}✗ Icon validation failed with ${allErrors.length} error(s)${colors.reset}`);
+    process.exit(1);
+  } else {
+    console.log('─'.repeat(60));
+    console.log(`${colors.green}✓ All icon references resolve!${colors.reset}`);
+    process.exit(0);
+  }
+}
+
+validate();


### PR DESCRIPTION
## Checklist before requesting a review

- [ ] I have formatted the subject to include the issue number
  as `[#123] Verb in past tense with a period at the end.` — no issue raised for this; happy to
  create one and rename
- [x] I have provided information in the `Changed` section about WHY something was
  done if this was a bespoke implementation.
- [x] I have performed a self-review of my code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have run new and existing relevant tests locally with my changes,
  and they have passed.
- [ ] I have provided screenshots, where applicable. — not applicable, build-time check only

## Changed

1. **Added `tools/scripts/validate-icons.js`**, which checks that every icon referenced by name
   actually exists in `assets/icons`, and wired it into `npm run validate` alongside the
   existing theme-variable and component-enum checks. It therefore also runs from
   `npm run lint`, CI, and the pre-push hook.

   **The problem.** `icon.twig` inlines its SVG like this:

   ```twig
   {%- set source = source(assets_dir ~ '/icons/' ~ symbol ~ '.svg', true) -%}
   {%- if source is not empty -%}
   ```

   The `true` is Drupal's `ignore_missing`, so an unresolvable name yields an empty string, and
   the `is not empty` guard then renders **nothing at all** — no error, no warning, no element
   in the output.

   The practical consequence is that a mistyped icon name is invisible until a human looks at
   the rendered page. A test suite can pass in full while every icon on the page is blank. I hit
   exactly this while rendering these components outside Drupal: `icon: 'right-arrow'` silently
   produced nothing, because the actual names are `right-arrow-1` and `right-arrow-2`.

   **Why not just remove `ignore_missing`.** That would make Twig throw, which turns a mistyped
   icon into a fatal error on a live page. Failing a production render is worse than a missing
   icon. The mistake is better caught where it is made — at build time — which is what this
   does.

2. **Scope of the check.** It scans `.twig` and `.js` files under both packages' `components`
   directories for icon names written as literals (`icon: 'name'`, `symbol: "name"`), and
   reports any that do not resolve, with file and line.

   Deliberately excluded, to avoid false positives:
   - non-literal values (`symbol: icon`), which cannot be checked statically;
   - empty values (`icon: ''`), which is how templates opt out of rendering an icon;
   - `icon_placement:` / `icon_class:` and similar, via a lookbehind on the property name;
   - `__snapshots__` directories.

### Verification

- The library currently passes, so this is a guard against future typos rather than a fix for an
  existing one — worth being explicit about, since a validator that passes on day one can be
  mistaken for one that does nothing.
- To confirm it is not vacuous, I changed `symbol: 'right-arrow-2'` to `symbol: 'right-arrow'`
  in `event-card.twig` and confirmed the reported failure, then reverted:

  ```
  packages/sdc/components/02-molecules/event-card/event-card.twig:176
      symbol: 'right-arrow' does not match any icon in assets/icons

  ✗ Icon validation failed with 1 error(s)
  ```

- `npm run lint` and `npm run validate` pass; full test suite passes (386 tests).

### Note

This covers icon names written as literals in the library. It cannot cover a name supplied at
runtime from a content field, where the silent-blank behaviour still applies — that would need
either a warning path in the icon component or validation at the point the field is saved.
Worth considering separately if that turns out to bite anyone.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added automated validation to detect invalid icon and symbol references in component templates and scripts.
  * Validation reports the affected file and line when an unknown reference is found.

* **Chores**
  * Included icon validation in the standard project validation workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->