### PR TITLE
[#1001] Fixed Link Below on List not being contained. Updated story.

### DIFF
--- a/packages/sdc/components/03-organisms/list/__snapshots__/list.test.js.snap
+++ b/packages/sdc/components/03-organisms/list/__snapshots__/list.test.js.snap
@@ -251,7 +251,7 @@ exports[`List Component renders with all attributes provided 1`] = `
                         
                   
       <div
-        class="ct-list__link-below ct-flex-justify-content-center"
+        class="ct-list__link-below ct-flex-justify-content-center container"
       >
         
           

--- a/packages/sdc/components/03-organisms/list/list.twig
+++ b/packages/sdc/components/03-organisms/list/list.twig
@@ -213,7 +213,7 @@
 
     {% block list_below_block %}
       {% if link_below %}
-        <div class="ct-list__link-below ct-flex-justify-content-center">
+        <div class="ct-list__link-below ct-flex-justify-content-center container">
           {% include 'civictheme:button' with {
             theme: theme,
             type: 'secondary',

--- a/packages/sdc/components/04-templates/page/page.stories.data.js
+++ b/packages/sdc/components/04-templates/page/page.stories.data.js
@@ -159,7 +159,25 @@ export const PageFullWidthData = {
         Accordion(accordionData),
         Accordion({ ...accordionData, with_background: false }),
         List({ ...listData, with_background: true, vertical_spacing: 'both' }),
-        List({ ...listData, with_background: false, vertical_spacing: 'both' }),
+        List({
+          ...listData,
+          with_background: false,
+          vertical_spacing: 'both',
+          link_above: {
+            text: 'Example link above call to action',
+            url: 'http://www.example.com',
+            title: 'Example link above call to action',
+            is_new_window: false,
+            is_external: false,
+          },
+          link_below: {
+            text: 'Example link below call to action',
+            url: 'http://www.example.com',
+            title: 'Example link below call to action',
+            is_new_window: false,
+            is_external: false,
+          },
+        }),
       ].join(''),
     };
   },

--- a/packages/sdc/components/04-templates/page/page.stories.data.js
+++ b/packages/sdc/components/04-templates/page/page.stories.data.js
@@ -165,14 +165,14 @@ export const PageFullWidthData = {
           vertical_spacing: 'both',
           link_above: {
             text: 'Example link above call to action',
-            url: 'http://www.example.com',
+            url: '/example',
             title: 'Example link above call to action',
             is_new_window: false,
             is_external: false,
           },
           link_below: {
             text: 'Example link below call to action',
-            url: 'http://www.example.com',
+            url: '/example',
             title: 'Example link below call to action',
             is_new_window: false,
             is_external: false,

--- a/packages/twig/components/03-organisms/list/__snapshots__/list.test.js.snap
+++ b/packages/twig/components/03-organisms/list/__snapshots__/list.test.js.snap
@@ -251,7 +251,7 @@ exports[`List Component renders with all attributes provided 1`] = `
                         
                   
       <div
-        class="ct-list__link-below ct-flex-justify-content-center"
+        class="ct-list__link-below ct-flex-justify-content-center container"
       >
         
           

--- a/packages/twig/components/03-organisms/list/list.twig
+++ b/packages/twig/components/03-organisms/list/list.twig
@@ -213,7 +213,7 @@
 
     {% block list_below_block %}
       {% if link_below %}
-        <div class="ct-list__link-below ct-flex-justify-content-center">
+        <div class="ct-list__link-below ct-flex-justify-content-center container">
           {% include '@atoms/button/button.twig' with {
             theme: theme,
             type: 'secondary',

--- a/packages/twig/components/04-templates/page/page.stories.data.js
+++ b/packages/twig/components/04-templates/page/page.stories.data.js
@@ -159,7 +159,25 @@ export const PageFullWidthData = {
         Accordion(accordionData),
         Accordion({ ...accordionData, with_background: false }),
         List({ ...listData, with_background: true, vertical_spacing: 'both' }),
-        List({ ...listData, with_background: false, vertical_spacing: 'both' }),
+        List({
+          ...listData,
+          with_background: false,
+          vertical_spacing: 'both',
+          link_above: {
+            text: 'Example link above call to action',
+            url: 'http://www.example.com',
+            title: 'Example link above call to action',
+            is_new_window: false,
+            is_external: false,
+          },
+          link_below: {
+            text: 'Example link below call to action',
+            url: 'http://www.example.com',
+            title: 'Example link below call to action',
+            is_new_window: false,
+            is_external: false,
+          },
+        }),
       ].join(''),
     };
   },

--- a/packages/twig/components/04-templates/page/page.stories.data.js
+++ b/packages/twig/components/04-templates/page/page.stories.data.js
@@ -165,14 +165,14 @@ export const PageFullWidthData = {
           vertical_spacing: 'both',
           link_above: {
             text: 'Example link above call to action',
-            url: 'http://www.example.com',
+            url: '/example',
             title: 'Example link above call to action',
             is_new_window: false,
             is_external: false,
           },
           link_below: {
             text: 'Example link below call to action',
-            url: 'http://www.example.com',
+            url: '/example',
             title: 'Example link below call to action',
             is_new_window: false,
             is_external: false,


### PR DESCRIPTION
https://github.com/civictheme/uikit/issues/1001

## Checklist before requesting a review

- [x] I have formatted the subject to include the issue number
  as `[#123] Verb in past tense with a period at the end.`
- [x] I have provided information in the `Changed` section about WHY something was
  done if this was a bespoke implementation.
- [x] I have performed a self-review of my code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have run new and existing relevant tests locally with my changes,
  and they have passed.
- [x] I have provided screenshots, where applicable.

## Changed

1. Added 'contained' class to link_below.
2. Checked link_above, but not an issue as it sits within a row.
3. Updated Page Full Width Data story to include example link above and link below to view this fix.

## Screenshots
<img width="760" height="891" alt="uikit-container-on-link-below" src="https://github.com/user-attachments/assets/ea1b92ab-fcc2-4cd7-8623-e4283cd20fe6" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved list layouts by applying consistent container styling to links displayed below lists.

* **Documentation**
  * Expanded full-width page examples to demonstrate lists with call-to-action links above and below.
  * Examples now cover link text, destinations, titles, external links, and opening links in a new window.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->