### PR TITLE
Pinned the auto-author-assign action to a commit SHA.

### DIFF
--- a/.github/workflows/pr-auto-assign-author.yml
+++ b/.github/workflows/pr-auto-assign-author.yml
@@ -13,4 +13,7 @@ jobs:
   assign-author:
     runs-on: ubuntu-latest
     steps:
-      - uses: toshimaru/auto-author-assign@v3.0.1
+      # Pinned by commit SHA rather than tag: this workflow runs on
+      # pull_request_target, so the action executes with a write-scoped token on
+      # pull requests from forks. A tag can be moved to point at other code.
+      - uses: toshimaru/auto-author-assign@4d585cc37690897bd9015942ed6e766aa7cdb97f # v3.0.1


### PR DESCRIPTION
## Checklist before requesting a review

- [ ] I have formatted the subject to include the issue number
  as `[#123] Verb in past tense with a period at the end.` — **no tracking issue exists.** Opening one would trigger the Jira sync workflow that #1003 is currently fixing.
- [x] I have provided information in the `Changed` section about WHY something was
  done if this was a bespoke implementation.
- [x] I have performed a self-review of my code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works. — **no test harness exists for workflow files** in this repo.
- [x] I have run new and existing relevant tests locally with my changes,
  and they have passed. — full pre-push suite passed; the workflow YAML was parse-checked.
- [ ] I have provided screenshots, where applicable. — not applicable, CI-only change.

## Changed

1. **Pinned `toshimaru/auto-author-assign` to commit SHA `4d585cc` instead of the `v3.0.1` tag.**

This came out of a security review of #1003 against the [Wiz write-up of the Snowflake GitHub Actions injection](https://www.wiz.io/blog/red-agent-snowflake-copilot-cicd-bug). The Jira workflow itself came back clean, but the sweep across the other workflows surfaced this one.

`pr-auto-assign-author.yml` runs on `pull_request_target` with `permissions: pull-requests: write`. That combination means the action executes with a write-scoped token on pull requests opened from forks. A git tag is a mutable pointer — whoever controls the upstream repository, or anyone who compromises it, can move `v3.0.1` to point at different code, and that code would then run against this repository with a write token on the next fork PR.

A commit SHA is immutable, so the pin removes that path. The tag name is kept in a trailing comment so the version stays readable and Dependabot can still propose updates.

Verified `refs/tags/v3.0.1` resolves to `4d585cc37690897bd9015942ed6e766aa7cdb97f` via the GitHub API before pinning.

The workflow is not otherwise injectable — it performs no checkout and interpolates no untrusted event data.

### Follow-up, not in this PR

The same sweep found roughly 20 other unpinned actions across six workflows (`actions/checkout@v6`, `codecov/codecov-action@v5`, `shivammathur/setup-php@v2` and others). Those are lower risk, since none of them combine `pull_request_target` with a write-scoped token the way this one does. Pinning them repo-wide is worth doing as its own change, alongside a Dependabot configuration to keep the pins current.

## Screenshots

Not applicable.
