### PR TITLE
[#1005] Fixed the Jira workflow writing to a root-owned pandoc output file.

### DIFF
--- a/.github/workflows/post-opened-issue-to-jira.yml
+++ b/.github/workflows/post-opened-issue-to-jira.yml
@@ -47,19 +47,22 @@ jobs:
           payload="${RUNNER_TEMP}/payload.json"
           response="${RUNNER_TEMP}/response.json"
 
-          printf '\n----\nGitHub issue: %s\n' "$ISSUE_URL" >> "$body_file"
-
+          # The footer is appended inside jq rather than written to $body_file:
+          # pandoc runs as root in its container, so the file it produces is
+          # root-owned and this step, running as `runner`, cannot write to it.
+          #
           # Jira caps the summary at 255 characters; GitHub issue titles can be longer.
           jq -n \
             --arg project "$JIRA_PROJECT_KEY" \
             --arg summary "UI Kit (GitHub): $ISSUE_TITLE" \
+            --arg url "$ISSUE_URL" \
             --rawfile description "$body_file" \
             '{
               fields: {
                 project: {key: $project},
                 issuetype: {name: "Story"},
                 summary: $summary[0:255],
-                description: $description,
+                description: ($description + "\n----\nGitHub issue: " + $url),
                 components: [{name: "UIKit"}]
               }
             }' > "$payload"


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have formatted the subject to include the issue number
  as `[#123] Verb in past tense with a period at the end.` — see #1005, the issue whose run surfaced this.
- [x] I have provided information in the `Changed` section about WHY something was
  done if this was a bespoke implementation.
- [x] I have performed a self-review of my code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works. — **no test harness exists for workflow files** in this repo. The reproduction described below was run locally instead.
- [x] I have run new and existing relevant tests locally with my changes,
  and they have passed.
- [ ] I have provided screenshots, where applicable. — not applicable, CI-only change.

## Changed

1. **Build the `GitHub issue:` footer inside `jq` instead of appending it to pandoc's output file.**

### The failure

The first real run after #1005 was opened failed at [run 32094644496](https://github.com/civictheme/uikit/actions/runs/32094644496/job/95583502702):

```
/home/runner/work/_temp/.../sh: line 7:
  /home/runner/work/_temp/_github_workflow/issue.jira: Permission denied
```

`pandoc/core` is a container action, so it runs as root and the `issue.jira` it writes is root-owned. The `Create Jira issue` step runs as the `runner` user, so this line could never succeed:

```bash
printf '\n----\nGitHub issue: %s\n' "$ISSUE_URL" >> "$body_file"
```

This is a regression introduced in #1003. The code it replaced only ever *read* that file (`cat "$body_file" >> "$GITHUB_ENV"`), and reading a root-owned file is fine — appending to one is not. The permissions difference is invisible in the diff, which is why it got through review.

### The fix

Stop writing to the file. The footer is concatenated in `jq`, which already receives the body via `--rawfile`:

```jq
description: ($description + "\n----\nGitHub issue: " + $url),
```

The URL is passed with `--arg url`, so it stays JSON-safe by construction and nothing writes to the container-owned file at any point.

### Verification

Reproduced locally by extracting the step's `run:` script from the YAML and executing it against a mock Jira with the body file `chmod 444` to stand in for root ownership:

- the merged version fails with the same `line 7 … Permission denied`
- this version exits 0 and Jira receives the description with the footer intact

Re-ran the hostile-input checks afterwards, since the description is now built differently: a body containing `$(id)`, backticks, `{code}` fences and a bare `EOF` line, plus a title carrying shell metacharacters, still produces well-formed JSON, executes nothing, is carried through verbatim as inert data, and leaves the source file unmodified.

## Screenshots

Not applicable.
